### PR TITLE
Dynamic paths for Chez's include/lib dirs

### DIFF
--- a/src/swish/Makefile
+++ b/src/swish/Makefile
@@ -17,6 +17,9 @@ else
 $(error Operating system $(OS) is not supported.)
 endif
 
+MACHINE_TYPE := $(shell echo '(machine-type)' | scheme -q)
+CHEZ_VERSION := $(shell scheme --version 2>&1)
+
 io-constants.ss: io-constants$(EXESUFFIX)
 	./$< > $@
 

--- a/src/swish/Mf-a6le
+++ b/src/swish/Mf-a6le
@@ -1,4 +1,4 @@
-SchemeInclude=/usr/lib/csv9.5/a6le
+SchemeInclude=/usr/lib/csv${CHEZ_VERSION}/${MACHINE_TYPE}/
 UvInclude=../../libuv/include
 UvLib=../../libuv/out/Release/obj.target
 ifneq (,$(shell gcc --help=warning | grep implicit-fallthrough))

--- a/src/swish/Mf-a6nt
+++ b/src/swish/Mf-a6nt
@@ -1,5 +1,6 @@
-SchemeInclude=C:/Program Files/Chez Scheme 9.5/boot/a6nt
-SchemeLib=C:/Program Files/Chez Scheme 9.5/bin/a6nt/csv95.lib
+SchemeDir=C:/Program Files/Chez Scheme ${CHEZ_VERSION}
+SchemeInclude=${SchemeDir}/boot/${MACHINE_TYPE}
+SchemeLib=${SchemeDir}/bin/${MACHINE_TYPE}/csv$(subst .,,${CHEZ_VERSION}).lib
 UvInclude=../../libuv/include
 UvLib=../../libuv/Release/lib/libuv.lib
 C=../vs64 cl /nologo /Ox /MD /W3

--- a/src/swish/Mf-a6osx
+++ b/src/swish/Mf-a6osx
@@ -1,4 +1,4 @@
-SchemeInclude=/usr/local/lib/csv9.5/a6osx
+SchemeInclude=/usr/local/lib/csv${CHEZ_VERSION}/${MACHINE_TYPE}/
 UvInclude=../../libuv/include
 UvLib=../../libuv/build/Release
 C = gcc -m64 -fPIC -Wall -Wextra -Werror -O2

--- a/src/swish/Mf-arm32le
+++ b/src/swish/Mf-arm32le
@@ -1,4 +1,4 @@
-SchemeInclude=/usr/lib/csv9.5/arm32le
+SchemeInclude=/usr/lib/csv${CHEZ_VERSION}/${MACHINE_TYPE}/
 UvInclude=../../libuv/include
 UvLib=../../libuv/out/Release/obj.target
 C = gcc -fPIC -Wall -Wextra -Werror -O2

--- a/src/swish/Mf-i3le
+++ b/src/swish/Mf-i3le
@@ -1,4 +1,4 @@
-SchemeInclude=/usr/lib/csv9.5/i3le
+SchemeInclude=/usr/lib/csv${CHEZ_VERSION}/${MACHINE_TYPE}/
 UvInclude=../../libuv/include
 UvLib=../../libuv/out/Release/obj.target
 ifneq (,$(shell gcc --help=warning | grep implicit-fallthrough))

--- a/src/swish/Mf-i3nt
+++ b/src/swish/Mf-i3nt
@@ -1,10 +1,11 @@
 ifdef ProgramFiles(x86)
-SchemeInclude=C:/Program Files (x86)/Chez Scheme 9.5/boot/i3nt
-SchemeLib=C:/Program Files (x86)/Chez Scheme 9.5/bin/i3nt/csv95.lib
+SchemeDir=C:/Program Files (x86)/Chez Scheme ${CHEZ_VERSION}
 else
-SchemeInclude=C:/Program Files/Chez Scheme 9.5/boot/i3nt
-SchemeLib=C:/Program Files/Chez Scheme 9.5/bin/i3nt/csv95.lib
+SchemeDir=C:/Program Files/Chez Scheme ${CHEZ_VERSION}
 endif
+SchemeInclude=${SchemeDir}/boot/${MACHINE_TYPE}
+SchemeLib=${SchemeDir}/bin/${MACHINE_TYPE}/csv$(subst .,,${CHEZ_VERSION}).lib
+
 UvInclude=../../libuv/include
 UvLib=../../libuv/Release/lib/libuv.lib
 C=../vs32 cl /nologo /Ox /MD /W3

--- a/src/swish/Mf-i3osx
+++ b/src/swish/Mf-i3osx
@@ -1,4 +1,4 @@
-SchemeInclude=/usr/local/lib/csv9.5/i3osx
+SchemeInclude=/usr/local/lib/csv${CHEZ_VERSION}/${MACHINE_TYPE}/
 UvInclude=../../libuv/include
 UvLib=../../libuv/build/Release
 C = gcc -m32 -fPIC -Wall -Wextra -Werror -O2


### PR DESCRIPTION
Here are changes to the makefiles that remove the hardcoded paths. I've been able to test this with ta6le, partially with ta6nt (no VS installed), and with arm32le (albeit on an aarch64 machine).