### PR TITLE
Minor changes to support Alpine linux

### DIFF
--- a/doc/run-latex
+++ b/doc/run-latex
@@ -1,11 +1,11 @@
-#!/bin/bash -e
+#!/bin/sh -e
 if [ -t 1 ]
 then
   MODE=spinner
 else
   MODE=silent
 fi
-if [ "$1" == "-q" ]; then
+if [ "$1" = "-q" ]; then
   MODE=silent
   shift
 fi
@@ -17,28 +17,33 @@ then
   exit 1
 fi
 
-function silent
+silent()
 {
   "$@" > /dev/null
 }
 
 # pdflatex and friends are very chatty and they create log files anyway.
 # We don't want folks to miss warnings, so replace the noise with a spinner.
-function spinner
+spinner()
 {
+  set +e
+  PIPE=$(mktemp -u)
+  mkfifo $PIPE
   # By default, awk gives us the unbuffered I/O we want for a spinner.
-  "$@" | awk 'BEGIN { n=0; s="|/-\\"; } { printf "%c\r", substr(s,n+1,1); n=(n+1)%4; }'
-  RESULT=${PIPESTATUS[0]}
-  echo -ne " \r"
+  awk 'BEGIN { n=0; s="|/-\\"; } { printf "%c\r", substr(s,n+1,1); n=(n+1)%4; }' < $PIPE &
+  "$@" > $PIPE
+  RESULT=$?
+  rm $PIPE
+  set -e
   return $RESULT
 }
 
-function runpdflatex
+runpdflatex()
 {
   ${MODE} pdflatex -halt-on-error -file-line-error -interaction nonstopmode "$1"
 }
 
-function runbibtex
+runbibtex()
 {
   # bibtex exits w/a nonzero value if there are no citations.
   # In order to allow this, we temporarily set +e to capture the result,
@@ -59,12 +64,12 @@ function runbibtex
   return $RESULT
 }
 
-function alert
+alert()
 {
   echo "$@" 1>&2
 }
 
-function update_indices
+update_indices()
 {
   if fgrep -asq "$1.idx" "$1.log"
   then
@@ -77,7 +82,7 @@ function update_indices
   fi
 }
 
-function display_warnings
+display_warnings()
 {
   if fgrep -a Warning "$1.log" | fgrep -v "Font Warning" | fgrep -v hyphenat
   then
@@ -87,7 +92,7 @@ function display_warnings
   fi
 }
 
-function display_errors
+display_errors()
 {
   egrep -aA 1 '^(\..*:..*:..*|l\.|.*LaTeX Error)' "$1.log"
 }

--- a/src/dump-profile
+++ b/src/dump-profile
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/sh
 echo "(go)" | scheme -q load.ss dump-profile.ss

--- a/src/go
+++ b/src/go
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 make -C swish
 if [ -z ${SCHEME+x} ]; then SCHEME=scheme; fi
 "${SCHEME}" --eedisable repl.ss "$@"

--- a/src/run-mat
+++ b/src/run-mat
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 launch="scheme --eedisable -q repl.ss $1.ms"
 
 find . -name *.mo -delete

--- a/src/run-mats
+++ b/src/run-mats
@@ -1,12 +1,12 @@
-#!/bin/bash -e
-if [[ "$PROFILE_MATS" == "no" ]]; then
+#!/bin/sh -e
+if [ "$PROFILE_MATS" = "no" ]; then
   launch="scheme --eedisable -q repl.ss run-mats.ss"
 else
   rm -f ../data/server.profile
   launch="scheme --eedisable -q replp.ss run-mats.ss"
 fi
 
-if [[ "$OUTDIR" != "" ]]; then
+if [ "$OUTDIR" != "" ]; then
     outdir=$OUTDIR
 else
     outdir=.
@@ -25,6 +25,6 @@ $launch <<EOF
 (console-summary "$outdir")
 EOF
 
-if [[ "$PROFILE_MATS" != "no" ]]; then
+if [ "$PROFILE_MATS" != "no" ]; then
   ./dump-profile
 fi

--- a/src/run-suite
+++ b/src/run-suite
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 launch="scheme --eedisable -q repl.ss run-mats.ss"
 
 find . -name *.mo -delete

--- a/src/run-suitep
+++ b/src/run-suitep
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 launch="scheme --eedisable -q replp.ss run-mats.ss"
 
 find . -name *.mo -delete

--- a/src/swish/osi.c
+++ b/src/swish/osi.c
@@ -633,7 +633,7 @@ size_t osi_get_bytes_used(void) {
   malloc_zone_pressure_relief(NULL, 0);
   struct mstats ms = mstats();
   return ms.bytes_used;
-#elif defined(__linux__)
+#elif defined(__GLIBC__)
   struct mallinfo hinfo = mallinfo();
   return hinfo.hblkhd + hinfo.uordblks;
 #elif defined(_WIN32)
@@ -643,6 +643,8 @@ size_t osi_get_bytes_used(void) {
     if (_USEDENTRY == hinfo._useflag)
       used += hinfo._size;
   return used;
+#else
+  return 0;
 #endif
 }
 

--- a/src/swish/run-mats
+++ b/src/swish/run-mats
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 #This is only meant to be run as part of the run-mats script in the src folder
 
 # Concurrency


### PR DESCRIPTION
These commits remove the bash and glibc dependencies.

There is no obvious portable linux implementation of `osi_get_bytes_used` so I've modified it to return 0 when compiled without glibc. The only other solution I found is [reading the current memory usage from /proc](https://gist.github.com/kleinpa/077a97302b3ea096991ad8e5505dc0f8) but thats slow, less accurate, and could be easily implemented in scheme. I'm not convinced `osi_get_bytes_used` should be in the osi at all.