### PR TITLE
Provide file-descriptor I/O

### DIFF
--- a/doc/swish/db.tex
+++ b/doc/swish/db.tex
@@ -452,6 +452,33 @@ By default, \var{symbol->sql} is the identity function.
 
 \end{itemize}
 
+\defineentry{database?}
+\begin{procedure}
+  \code{(database? \var{x})}
+\end{procedure}
+\returns{} a boolean
+
+The \code{database?} procedure determines whether or not the datum
+\var{x} is a database record instance.
+
+\defineentry{database-create-time}
+\begin{procedure}
+  \code{(database-create-time \var{db})}
+\end{procedure}
+\returns{} a clock time in milliseconds
+
+The \code{database-create-time} procedure returns the clock time from
+\code{erlang:now} when database record instance \var{db} was created.
+
+\defineentry{database-filename}
+\begin{procedure}
+  \code{(database-filename \var{db})}
+\end{procedure}
+\returns{} a string
+
+The \code{database-filename} procedure returns the filename of
+database record instance \var{db}.
+
 \defineentry{database-count}
 \begin{procedure}
   \code{(database-count)}
@@ -470,6 +497,43 @@ databases.
 The \code{print-databases} procedure prints information about all open
 databases to textual output port \var{op}, which defaults to the
 current output port.
+
+\defineentry{statement?}
+\begin{procedure}
+  \code{(statement? \var{x})}
+\end{procedure}
+\returns{} a boolean
+
+The \code{statement?} procedure determines whether or not the datum
+\var{x} is a statement record instance.
+
+\defineentry{statement-create-time}
+\begin{procedure}
+  \code{(statement-create-time \var{stmt})}
+\end{procedure}
+\returns{} a clock time in milliseconds
+
+The \code{statement-create-time} procedure returns the clock time from
+\code{erlang:now} when statement record instance \var{stmt} was
+created.
+
+\defineentry{statement-database}
+\begin{procedure}
+  \code{(statement-database \var{stmt})}
+\end{procedure}
+\returns{} a string
+
+The \code{statement-database} procedure returns the database record
+instance of the statement record instance \var{stmt}.
+
+\defineentry{statement-sql}
+\begin{procedure}
+  \code{(statement-sql \var{stmt})}
+\end{procedure}
+\returns{} a string
+
+The \code{statement-sql} procedure returns the SQL string of the
+statement record instance \var{stmt}.
 
 \defineentry{statement-count}
 \begin{procedure}

--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -1348,6 +1348,17 @@ The \code{listener-address} procedure returns the \code{address} of
 the given TCP \var{listener}\index{TCP listener}.
 
 % ----------------------------------------------------------------------------
+\defineentry{listener-create-time}
+\begin{procedure}
+  \code{(listener-create-time \var{listener})}
+\end{procedure}
+\returns{} a clock time in milliseconds
+
+The \code{listener-create-time} procedure returns the clock time from
+\code{erlang:now} when the given TCP \var{listener}\index{TCP
+  listener} was created.
+
+% ----------------------------------------------------------------------------
 \defineentry{listener-port-number}
 \begin{procedure}
   \code{(listener-port-number \var{listener})}
@@ -1581,6 +1592,36 @@ The \code{osi-port-count} procedure returns the number of open
 osi-ports.
 
 % ----------------------------------------------------------------------------
+\defineentry{osi-port-create-time}
+\begin{procedure}
+  \code{(osi-port-create-time \var{p})}
+\end{procedure}
+\returns{} a clock time in milliseconds
+
+The \code{osi-port-create-time} procedure returns the clock time from
+\code{erlang:now} when the osi-port \var{p} was created.
+
+% ----------------------------------------------------------------------------
+\defineentry{osi-port-name}
+\begin{procedure}
+  \code{(osi-port-name \var{p})}
+\end{procedure}
+\returns{} a string
+
+The \code{osi-port-name} procedure returns the name of osi-port
+\var{p}.
+
+% ----------------------------------------------------------------------------
+\defineentry{osi-port?}
+\begin{procedure}
+  \code{(osi-port? \var{x})}
+\end{procedure}
+\returns{} a boolean
+
+The \code{osi-port?} procedure determines whether or not the datum
+\var{x} is an osi-port.
+
+% ----------------------------------------------------------------------------
 \defineentry{path-combine}
 \begin{procedure}
   \code{(path-combine \var{path$_1$} \var{path$_2$} \etc{})}
@@ -1600,6 +1641,17 @@ needed.
 
 The \code{path-watcher-count} procedure returns the number of open
 path watchers\index{path watcher}.
+
+% ----------------------------------------------------------------------------
+\defineentry{path-watcher-create-time}
+\begin{procedure}
+  \code{(path-watcher-create-time \var{watcher})}
+\end{procedure}
+\returns{} a clock time in milliseconds
+
+The \code{path-watcher-create-time} procedure returns the clock time
+from \code{erlang:now} when the given path \var{watcher}\index{path
+  watcher} was created.
 
 % ----------------------------------------------------------------------------
 \defineentry{path-watcher-path}

--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -1395,6 +1395,27 @@ for the file \var{path} using \var{mode}, which defaults to
 \code{\#o777}. It returns \var{path}.
 
 % ----------------------------------------------------------------------------
+\defineentry{make-osi-input-port}
+\begin{procedure}
+  \code{(make-osi-input-port \var{p})}
+\end{procedure}
+\returns{} a binary input port
+
+The \code{make-osi-input-port} procedure returns a custom binary input
+port that reads from osi-port \var{p}. It does not track position.
+
+% ----------------------------------------------------------------------------
+\defineentry{make-osi-output-port}
+\begin{procedure}
+  \code{(make-osi-output-port \var{p})}
+\end{procedure}
+\returns{} a binary output port
+
+The \code{make-osi-output-port} procedure returns a custom binary
+output port that writes to osi-port \var{p}. It does not track
+position.
+
+% ----------------------------------------------------------------------------
 \defineentry{make-utf8-transcoder}
 \begin{procedure}
   \code{(make-utf8-transcoder)}
@@ -1404,6 +1425,18 @@ for the file \var{path} using \var{mode}, which defaults to
 The \code{make-utf8-transcoder} procedure creates a UTF-8 transcoder
 with end-of-line style \code{none} and error-handling mode
 \code{replace}.
+
+% ----------------------------------------------------------------------------
+\defineentry{open-fd-port}
+\begin{procedure}
+  \code{(open-fd-port \var{name} \var{fd} \var{close?})}
+\end{procedure}
+\returns{} an osi-port
+
+The \code{open-fd-port} procedure creates an osi-port with the given
+\var{name} by calling \code{osi\_open\_fd} with \var{fd} and
+\var{close?}. The osi-port is registered with the osi-port
+guardian\index{osi-port guardian}.
 
 % ----------------------------------------------------------------------------
 \defineentry{open-file}

--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -1413,7 +1413,9 @@ for the file \var{path} using \var{mode}, which defaults to
 \returns{} a binary input port
 
 The \code{make-osi-input-port} procedure returns a custom binary input
-port that reads from osi-port \var{p}. It does not track position.
+port that reads from osi-port \var{p}. It does not track
+position. Closing the input port closes the underlying osi-port
+\var{p}.
 
 % ----------------------------------------------------------------------------
 \defineentry{make-osi-output-port}
@@ -1424,7 +1426,8 @@ port that reads from osi-port \var{p}. It does not track position.
 
 The \code{make-osi-output-port} procedure returns a custom binary
 output port that writes to osi-port \var{p}. It does not track
-position.
+position. Closing the output port closes the underlying osi-port
+\var{p}.
 
 % ----------------------------------------------------------------------------
 \defineentry{make-utf8-transcoder}
@@ -1447,7 +1450,10 @@ with end-of-line style \code{none} and error-handling mode
 The \code{open-fd-port} procedure creates an osi-port with the given
 \var{name} by calling \code{osi\_open\_fd} with \var{fd} and
 \var{close?}. The osi-port is registered with the osi-port
-guardian\index{osi-port guardian}.
+guardian\index{osi-port guardian}. When the osi-port is closed, the
+underlying file descriptor \var{fd} is closed if and only if
+\var{close?} is not \code{\#f}. When $0 \le \var{fd} \le 2$,
+\var{close?} must be \code{\#f} for the standard I/O file descriptor.
 
 % ----------------------------------------------------------------------------
 \defineentry{open-file}
@@ -1580,6 +1586,16 @@ The \code{open-file-to-write} procedure calls\\
 
 The \code{open-utf8-bytevector} procedure calls
 \code{(binary->utf8 (open-bytevector-input-port \var{bv}))}.
+
+% ----------------------------------------------------------------------------
+\defineentry{osi-port-closed?}
+\begin{procedure}
+  \code{(osi-port-closed? \var{p})}
+\end{procedure}
+\returns{} a boolean
+
+The \code{osi-port-closed?} procedure determines whether or not the
+osi-port \var{p} is closed.
 
 % ----------------------------------------------------------------------------
 \defineentry{osi-port-count}

--- a/doc/swish/osi.tex
+++ b/doc/swish/osi.tex
@@ -421,6 +421,16 @@ otherwise.
 
 \subsection {File System Functions}
 
+\defineentry{osi\_open\_fd}
+\begin{function}
+  ptr \code{osi\_open\_fd}(int \var{fd}, int \var{close});
+\end{function}
+
+The \code{osi\_open\_fd} function returns a port handle for the file
+descriptor \var{fd} when successful and an error pair otherwise. When
+the port is closed, the file descriptor \var{fd} is closed if and only
+if \var{close} is non-zero.
+
 \defineentry{osi\_open\_file}
 \begin{function}
   ptr \code{osi\_open\_file}(const char* \var{path}, int \var{flags}, int \var{mode}, ptr \var{callback});
@@ -508,15 +518,6 @@ issued and an error pair otherwise. When the realpath operation
 finishes, it enqueues the callback list \code{(\var{callback}
   \var{result})}, where \var{result} is the string path when
 successful and a negative error code otherwise.
-
-\defineentry{osi\_get\_stdin}
-\begin{function}
-  uptr \code{osi\_get\_stdin}(void);
-\end{function}
-
-The \code{osi\_get\_stdin} function returns a handle to a static port
-that reads from the standard input of the current process. This port
-cannot be closed.
 
 \defineentry{osi\_get\_temp\_directory}
 \begin{function}

--- a/doc/swish/osi.tex
+++ b/doc/swish/osi.tex
@@ -429,7 +429,9 @@ otherwise.
 The \code{osi\_open\_fd} function returns a port handle for the file
 descriptor \var{fd} when successful and an error pair otherwise. When
 the port is closed, the file descriptor \var{fd} is closed if and only
-if \var{close} is non-zero.
+if \var{close} is non-zero. It is an error to set \var{close} to a
+non-zero value on a standard I/O file descriptor ($0 \le \var{fd} \le
+2$).
 
 \defineentry{osi\_open\_file}
 \begin{function}

--- a/src/swish/db.ss
+++ b/src/swish/db.ss
@@ -29,6 +29,9 @@
    SQLITE_STATUS_MEMORY_USED
    columns
    database-count
+   database-create-time
+   database-filename
+   database?
    db:filename
    db:log
    db:start&link
@@ -54,6 +57,10 @@
    sqlite:sql
    sqlite:step
    statement-count
+   statement-create-time
+   statement-database
+   statement-sql
+   statement?
    transaction
    with-db
    )

--- a/src/swish/errors.ss
+++ b/src/swish/errors.ss
@@ -75,6 +75,7 @@
       [#(listen-tcp-failed ,address ,port-number ,who ,errno) (format "Error ~d from ~a when listening on TCP port ~d: ~a." errno who port-number (errno->english errno))]
       [#(name-already-registered ,pid) (format "Name is already registered to ~s." pid)]
       [#(osi-error ,name ,who ,errno) (format "Error ~d from ~a during ~a: ~a." errno who name (errno->english errno))]
+      [#(osi-port-closed ,who ,p) (format "Error from ~a: ~a is closed." who (osi-port-name p))]
       [#(process-already-registered ,name) (format "Process is already registered as ~a." name)]
       [#(start-specs #(duplicate-child-name ,name)) (format "Duplicate child name in start-specs: ~s." name)]
       [#(start-specs #(invalid-child-spec ,x)) (format "Invalid child-spec in start-specs: ~s." x)]

--- a/src/swish/io.ss
+++ b/src/swish/io.ss
@@ -41,6 +41,7 @@
    list-directory
    listen-tcp
    listener-address
+   listener-create-time
    listener-port-number
    listener?
    make-directory
@@ -57,8 +58,12 @@
    open-file-to-write
    open-utf8-bytevector
    osi-port-count
+   osi-port-create-time
+   osi-port-name
+   osi-port?
    path-combine
    path-watcher-count
+   path-watcher-create-time
    path-watcher-path
    path-watcher?
    print-osi-ports

--- a/src/swish/osi.c
+++ b/src/swish/osi.c
@@ -1005,7 +1005,7 @@ ptr osi_list_uv_handles(void) {
 }
 
 ptr osi_open_fd(int fd, int close) {
-  if (fd < 0)
+  if ((fd < 0) || (close && (fd <= 2)))
     return osi_make_error_pair("osi_open_fd", UV_EINVAL);
   fs_port_t* port = malloc_container(fs_port_t);
   if (!port)

--- a/src/swish/osi.h
+++ b/src/swish/osi.h
@@ -66,11 +66,11 @@ EXPORT ptr osi_spawn(const char* path, ptr args, ptr callback);
 EXPORT ptr osi_kill(int pid, int signum);
 
 // File System
+EXPORT ptr osi_open_fd(int fd, int close);
 EXPORT ptr osi_open_file(const char* path, int flags, int mode, ptr callback);
 EXPORT ptr osi_get_executable_path(void);
 EXPORT ptr osi_get_file_size(uptr port, ptr callback);
 EXPORT ptr osi_get_real_path(const char* path, ptr callback);
-EXPORT uptr osi_get_stdin(void);
 EXPORT ptr osi_get_temp_directory(void);
 EXPORT ptr osi_chmod(const char* path, int mode, ptr callback);
 EXPORT ptr osi_make_directory(const char* path, int mode, ptr callback);

--- a/src/swish/osi.ss
+++ b/src/swish/osi.ss
@@ -64,7 +64,6 @@
    osi_get_statement_columns*
    osi_get_statement_expanded_sql
    osi_get_statement_expanded_sql*
-   osi_get_stdin
    osi_get_tcp_listener_port
    osi_get_tcp_listener_port*
    osi_get_temp_directory
@@ -85,6 +84,8 @@
    osi_make_uuid*
    osi_open_database
    osi_open_database*
+   osi_open_fd
+   osi_open_fd*
    osi_open_file
    osi_open_file*
    osi_prepare_statement
@@ -162,11 +163,11 @@
   (define-osi osi_kill (pid int) (signum int))
 
   ;; File System
+  (define-osi osi_open_fd (fd int) (close? boolean))
   (define-osi osi_open_file (path string) (flags int) (mode int) (callback ptr))
   (define-osi osi_get_executable_path)
   (define-osi osi_get_file_size (port uptr) (callback ptr))
   (define-osi osi_get_real_path (path string) (callback ptr))
-  (fdefine osi_get_stdin uptr)
   (define-osi osi_get_temp_directory)
   (define-osi osi_chmod (path string) (mode int) (callback ptr))
   (define-osi osi_make_directory (path string) (mode int) (callback ptr))

--- a/src/swish/run.c
+++ b/src/swish/run.c
@@ -54,7 +54,6 @@ static void swish_init(void) {
   add_foreign(osi_get_stat);
   add_foreign(osi_get_statement_columns);
   add_foreign(osi_get_statement_expanded_sql);
-  add_foreign(osi_get_stdin);
   add_foreign(osi_get_tcp_listener_port);
   add_foreign(osi_get_temp_directory);
   add_foreign(osi_get_time);
@@ -68,6 +67,7 @@ static void swish_init(void) {
   add_foreign(osi_make_directory);
   add_foreign(osi_make_uuid);
   add_foreign(osi_open_database);
+  add_foreign(osi_open_fd);
   add_foreign(osi_open_file);
   add_foreign(osi_prepare_statement);
   add_foreign(osi_read_port);


### PR DESCRIPTION
This pull request adds open-fd-port for performing asynchronous I/O to file descriptors 0 (stdin), 1 (stdout), 2 (stderr), and higher. It also exports some record-related procedures from the base system.