### PR TITLE
fix submodule check and some errors reported by valgrind

### DIFF
--- a/src/swish/Mf-base
+++ b/src/swish/Mf-base
@@ -1,12 +1,14 @@
-.PHONY: all build-dirs clean platform-clean ready reminders
+.PHONY: all build-dirs clean platform-clean ready reminders submodules
 
-SETUP := Makefile build-dirs git.revision chezscheme.revision
+SETUP := Makefile submodules build-dirs git.revision chezscheme.revision
 CORE := ../../${BUILD}/bin/swish${EXESUFFIX} ../../${BUILD}/bin/swish.boot ../../${BUILD}/bin/swish.library
 AUXLIB := ../../${BUILD}/lib/swish/mat.so ../../${BUILD}/lib/swish/profile.so ../../${BUILD}/lib/swish/testing.so
 
 ready:: | ${SETUP}
 ready:: io-constants.ss ${SwishLibs}
-	@if git submodule status --recursive | grep -q '^[^ ]'; then \
+
+submodules:
+	@if cd ../.. && git submodule status --recursive | grep -q '^[^ ]'; then \
 	  echo "Please update git submodules (or stage submodule change)."; \
 	  exit 1; \
 	fi

--- a/src/swish/osi.c
+++ b/src/swish/osi.c
@@ -804,8 +804,7 @@ ptr osi_spawn(const char* path, ptr args, ptr callback) {
     uv_close(&(in_port->h.handle), close_stream_cb);
     uv_close(&(out_port->h.handle), close_stream_cb);
     uv_close(&(err_port->h.handle), close_stream_cb);
-    Sunlock_object(callback);
-    free(p);
+    uv_close((uv_handle_t*)p, close_handle_data_cb);
     return osi_make_error_pair("uv_spawn", rc);
   }
   ptr r = Smake_vector(4, 0);


### PR DESCRIPTION
This pull request fixes the make rule that checks for out-of-date git submodules. We get different results depending on whether we run it from the top level of the repository or from the src/swish directory. The latter seems to always report that we're up-to-date.

This also tries to address some errors reported by valgrind:
1. libuv isn't populating the `st_flags` and `st_gen` fields, except on the mac
2. it looks like we're supposed to call `uv_close` on the `uv_process_t` instead of freeing it directly.

To see the valgrind issues, try:
```
$ git checkout master
$ ./configure && make
$ valgrind ./build/release/bin/swish
> (spawn-os-process "this-does-not-exist" '() self)
```