### PR TITLE
Reduce source information

### DIFF
--- a/src/swish/Mf-base
+++ b/src/swish/Mf-base
@@ -59,6 +59,8 @@ compile.ss: ${SwishLibs}
 	'(library-directories (quote (("." . "../${BUILD}/lib"))))' \
 	'(library-extensions (quote ((".ss" . ".wpo"))))' \
 	'(generate-wpo-files #t)' \
+	'(generate-inspector-information #f)' \
+	'(generate-procedure-source-information #t)' \
 	'(import (swish imports))' \
 	'(printf "compiling swish.library~%")' \
 	'(compile-whole-library "../'${BUILD}'/lib/swish/imports.wpo" "../${BUILD}/bin/swish.library")' \
@@ -68,6 +70,8 @@ compile.ss: ${SwishLibs}
 	@echo \
 	'(library-directories (quote (("." . "../${BUILD}/lib"))))' \
 	'(generate-wpo-files #t)' \
+	'(generate-inspector-information #f)' \
+	'(generate-procedure-source-information #t)' \
 	'(import (swish $(<:.ss=)))' \
 	| ../../${BUILD}/bin/swish${EXESUFFIX} -q -- compile.ss
 

--- a/src/swish/swish-build
+++ b/src/swish/swish-build
@@ -346,6 +346,8 @@
     ;; ".so" extension so that compile-library can build both the ".so" file
     ;; and its ".wpo" by-product without conflict.
     (generate-wpo-files #t)
+    (generate-inspector-information #f)
+    (generate-procedure-source-information #t)
     (compile-imported-libraries #t)
     (compile-file-message #f)
     (compile-library-handler


### PR DESCRIPTION
Reduce the source information by setting `(generate-inspector-information #f)` and `(generate-procedure-source-information #t)`.