### PR TITLE
Update configure and add Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: c
+matrix:
+  include:
+    - os: osx
+      env: TARGET_MACHINE=a6osx
+    - os: linux
+      env: TARGET_MACHINE=i3le
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+            - g++-multilib
+            - lib32ncurses5-dev
+            - libx32ncurses5-dev
+            - uuid-dev:i386
+      before_script:
+        - sudo sysctl net.ipv6.conf.all.disable_ipv6=0
+    - os: linux
+      env: TARGET_MACHINE=a6le
+      before_script:
+        - sudo sysctl net.ipv6.conf.all.disable_ipv6=0
+dist: xenial
+script:
+  - .travis/build.sh
+after_failure:
+  - cat src/*.mo src/swish/*.mo

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e -o pipefail
+CSV=csv9.5.2
+echo 'travis_fold:start:ChezScheme'
+echo Installing Chez Scheme...
+echo Downloading $CSV
+curl -Ls https://github.com/cisco/ChezScheme/releases/download/v9.5.2/csv9.5.2.tar.gz | tar -xzf -
+echo Building $CSV
+(cd $CSV; ./configure -m=$TARGET_MACHINE; make)
+echo 'travis_fold:end:ChezScheme'
+CSROOT=$PWD/$CSV/$TARGET_MACHINE
+export SCHEMEHEAPDIRS=$CSROOT/boot/$TARGET_MACHINE
+echo 'travis_fold:start:Swish'
+echo Building Swish...
+./configure --scheme=$CSROOT/bin/$TARGET_MACHINE/scheme
+make
+echo 'travis_fold:end:Swish'
+echo Testing Swish...
+make test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/becls/swish.svg?branch=master)](https://travis-ci.org/becls/swish)
+
 # Swish Concurrency Engine
 
 The Swish Concurrency Engine is a framework used to write

--- a/configure
+++ b/configure
@@ -504,3 +504,8 @@ add ""
 add "include Mf-config"
 add "include Mf-${BASE_MACHINE_TYPE}"
 add "include Mf-base"
+
+git submodule update --init
+if [ ! -d libuv/build/gyp ]; then
+    git clone --depth 1 https://github.com/chromium/gyp.git libuv/build/gyp
+fi

--- a/src/swish/Mf-base
+++ b/src/swish/Mf-base
@@ -42,10 +42,6 @@ chezscheme.tmp-revision:
 io-constants.ss: io-constants${EXESUFFIX}
 	./$< > $@
 
-../../libuv/include:
-	git submodule update --init ../../libuv
-	git clone https://github.com/chromium/gyp.git ../../libuv/build/gyp
-
 compile.ss: ${SwishLibs}
 
 ../../${BUILD}/bin/swish.boot: boot.ss compile.ss ../../${BUILD}/bin/swish.library


### PR DESCRIPTION
Update the configure script to initialize and update the libuv submodule and to install the gyp code if not already present.

Add Travis-CI scripts for a6osx, i3le and a6le.