### PR TITLE
JSON objects now use symbols for keys

### DIFF
--- a/doc/swish/http.tex
+++ b/doc/swish/http.tex
@@ -466,7 +466,7 @@ Scheme types:
   \var{string} & \var{string} \\
   \var{number} & \var{number} \\
   \var{array} & \var{list} \\
-  \var{object} & hashtable mapping case-sensitive strings to values \\
+  \var{object} & symbol hashtable mapping symbols to values \\
 
   \hline
 \end{tabular}
@@ -480,8 +480,9 @@ JavaScript implementation can interpret the data.
 \end{syntax}
 
 The \code{json:extend-object} construct adds the \var{key} /
-\var{value} pairs to the hashtable \var{ht} using
-\code{hashtable-set!}. The resulting expression returns \var{ht}.
+\var{value} pairs to the symbol hashtable \var{ht} using
+\code{symbol-hashtable-set!}. Each \var{key} is a literal
+identifier. The resulting expression returns \var{ht}.
 
 \defineentry{json:make-object}
 \begin{syntax}
@@ -489,7 +490,7 @@ The \code{json:extend-object} construct adds the \var{key} /
 \end{syntax}
 
 The \code{json:make-object} construct expands into a call to
-\code{json:extend-object} with a new hashtable.
+\code{json:extend-object} with a new symbol hashtable.
 
 \defineentry{json:delete!}
 \begin{procedure}
@@ -497,15 +498,15 @@ The \code{json:make-object} construct expands into a call to
 \end{procedure}
 \returns{} unspecified
 
-The \code{json:delete!} procedure expects \var{path} to be a string or
-a non-empty list of strings.
-If \var{path} is a string, then \code{json:delete!} is equivalent
-to \code{hashtable-delete!}.
+The \code{json:delete!} procedure expects \var{path} to be a symbol or
+a non-empty list of symbols.
+If \var{path} is a symbol, then \code{json:delete!} is equivalent
+to \code{symbol-hashtable-delete!}.
 Otherwise, \code{json:delete!} follows \var{path} as it descends into
 the nested hashtable \var{ht}, treating each element as a key into
 the hashtable reached by traversing the preceding elements.
 When \code{json:delete!} reaches the final key in \var{path},
-it calls \code{hashtable-delete!} to remove the association for
+it calls \code{symbol-hashtable-delete!} to remove the association for
 that key in the hashtable reached at that point.
 If any key along the way does not map to a hashtable,
 \code{json:delete!} has no effect.
@@ -517,15 +518,15 @@ If any key along the way does not map to a hashtable,
 \returns{} the value found by traversing \var{path} in \var{ht},
 \var{default} if none
 
-The \code{json:ref} procedure expects \var{path} to be a string or
-a non-empty list of strings.
-If \var{path} is a string, then \code{json:ref} is equivalent
-to \code{hashtable-ref}.
+The \code{json:ref} procedure expects \var{path} to be a symbol or
+a non-empty list of symbols.
+If \var{path} is a symbol, then \code{json:ref} is equivalent
+to \code{symbol-hashtable-ref}.
 Otherwise, \code{json:ref} follows \var{path} as it descends into
 the nested hashtable \var{ht}, treating each element as a key into
 the hashtable reached by traversing the preceding elements.
 When \code{json:ref} reaches the final key in \var{path},
-it calls \code{hashtable-ref} to retrieve the value of that key
+it calls \code{symbol-hashtable-ref} to retrieve the value of that key
 in the hashtable reached at that point.
 If any key along the way does not map to a hashtable,
 or if the final hashtable does not contain the final key,
@@ -537,15 +538,15 @@ or if the final hashtable does not contain the final key,
 \end{procedure}
 \returns{} unspecified
 
-The \code{json:update!} procedure expects \var{path} to be a string or
-a non-empty list of strings.
-If \var{path} is a string, then \code{json:update!} is equivalent
-to \code{hashtable-update!}.
+The \code{json:update!} procedure expects \var{path} to be a symbol or
+a non-empty list of symbols.
+If \var{path} is a symbol, then \code{json:update!} is equivalent
+to \code{symbol-hashtable-update!}.
 Otherwise, \code{json:update!} follows \var{path} as it descends into
 the nested hashtable \var{ht}, treating each element as a key into
 the hashtable reached by traversing the preceding elements.
 When \code{json:update!} reaches the final key in \var{path},
-it calls \code{hashtable-update!} to update that key in the
+it calls \code{symbol-hashtable-update!} to update that key in the
 hashtable reached at that point.
 If any key along the way does not map to a hashtable,
 \code{json:update!} installs an empty hashtable at that key
@@ -582,8 +583,9 @@ The following exceptions may be raised:
 
 The \code{json:write} procedure writes the object \var{x} to the
 textual output port \var{op} in JSON format. JSON objects are sorted
-by key using \code{string<?} to provide stable output. Scheme fixnums,
-bignums, and finite flonums may be used as numbers.
+by key using \code{string<?} on the string values of the symbols to
+provide stable output. Scheme fixnums, bignums, and finite flonums may
+be used as numbers.
 
 When \var{indent} is a non-negative fixnum, the output is more
 readable by a human. List items and key/value pairs are indented on
@@ -614,13 +616,13 @@ is raised.
 Given a textual output port \var{op}, an \var{indent} level, and a
 writer procedure \var{wr}, the \code{json:write-object} construct
 writes a JSON object with the given \var{key} / \var{value} pairs to
-\var{op}, sorted by key using \code{string<?}.  Each \var{key} must be
-a distinct string literal.  The \var{wr} procedure takes \var{op}, an
-object \var{x}, and an \var{indent} level just like the \var{wr}
-procedure that is passed to \code{json:write}'s \var{custom-write}
-procedure.
+\var{op}, sorted by key using \code{string<?} on the string values of
+the symbols.  Each \var{key} must be a distinct symbol.  The \var{wr}
+procedure takes \var{op}, an object \var{x}, and an \var{indent} level
+just like the \var{wr} procedure that is passed to \code{json:write}'s
+\var{custom-write} procedure.
 
-The following are equivalent, provided the keys are string literals.
+The following are equivalent, provided the keys are symbols.
 
 \antipar\begin{alltt}
 (begin (json:write \var{op} (json:make-object [\var{key} \var{value}] \etc) \var{indent}) \#t)

--- a/doc/swish/http.tex
+++ b/doc/swish/http.tex
@@ -481,8 +481,9 @@ JavaScript implementation can interpret the data.
 
 The \code{json:extend-object} construct adds the \var{key} /
 \var{value} pairs to the symbol hashtable \var{ht} using
-\code{symbol-hashtable-set!}. Each \var{key} is a literal
-identifier. The resulting expression returns \var{ht}.
+\code{symbol-hashtable-set!}. Each \var{key} is a literal identifier
+or an unquoted expression \code{,\var{e}} that evaluates to a
+symbol. The resulting expression returns \var{ht}.
 
 \defineentry{json:make-object}
 \begin{syntax}

--- a/src/swish/app.ms
+++ b/src/swish/app.ms
@@ -207,7 +207,7 @@
       ;; reject non-hashtable
       [#(EXIT #(bad-arg app:config rubbish)) (catch (app:config 'rubbish))]
       [,unspecified (void)]
-      [,obj (json:make-object ["foo" "bar"] ["baz" '(1 2 3)])]
+      [,obj (json:make-object [foo "bar"] [baz '(1 2 3)])]
       ;; hashtable okay
       [,@unspecified (app:config obj)]
       [,obj (app:config)]
@@ -215,14 +215,14 @@
       [#f (let ([me self])
             (spawn (lambda () (send me (app:config))))
             (receive [,cfg (eq? cfg (app:config))]))]
-      [(1 2 3) (json:ref (app:config) "baz" #f)]
+      [(1 2 3) (json:ref (app:config) 'baz #f)]
       ;; #f okay
       [,@unspecified (app:config #f)]
-      [#f (json:ref (app:config) "foo" #f)]
+      [#f (json:ref (app:config) 'foo #f)]
       ;; we're unaffected by process-parameter change
       [#f (begin
             (spawn (lambda () (app:config obj)))
-            (json:ref (app:config) "foo" #f))]
+            (json:ref (app:config) 'foo #f))]
       ;; check config path when no app:path set
       [,expected (path-combine (base-dir) ".config")]
       [,@expected (parameterize ([app:path #f])
@@ -239,9 +239,9 @@
          app:config-filename)]
       ;; read config from file
       [,data (json:make-object
-              ["powder" "keg"]
-              ["floss" (json:make-object ["sauce" "moss"])]
-              ["glass" '(3 4 5)])]
+              [powder "keg"]
+              [floss (json:make-object [sauce "moss"])]
+              [glass '(3 4 5)])]
       [,expected (json:object->string data)]
       [,@expected
        (with-fake-config `("flim" "flam" ,(fix-exe "blott"))
@@ -266,16 +266,16 @@
       ["got default"
        (with-fake-config `("Applications" ,(fix-exe "zap"))
          (lambda (op)
-           (json:write op (json:make-object ["flip" "pers"])))
+           (json:write op (json:make-object [flip "pers"])))
          (lambda ()
            ;; confirm config written
            (match-let*
-            (["pers" (json:ref (app:config) "flip" #f)])
+            (["pers" (json:ref (app:config) 'flip #f)])
             'ok)
            ;; now delete and force reload
            (assert (delete-file (app:config-filename)))
            (app:config #f)
-           (json:ref (app:config) "flip" "got default")))]
+           (json:ref (app:config) 'flip "got default")))]
       ;; found directory instead of file at app:config-filename
       ;; as happens if we start a swish repl in ${HOME}
       ["nope"
@@ -284,7 +284,7 @@
            (make-directory (app:config-filename))
            (app:config #f)
            (assert (directory? (app:config-filename)))
-           (json:ref (app:config) "grail" "nope")))]
+           (json:ref (app:config) 'grail "nope")))]
       )
      'ok)))
 

--- a/src/swish/cli.ms
+++ b/src/swish/cli.ms
@@ -26,7 +26,13 @@
  (swish testing)
  )
 
-(alias make-ht json:make-object)
+(define-syntax make-ht
+  (syntax-rules ()
+    [(_ (key val) ...)
+     (let ([ht (make-hashtable string-hash string=?)])
+       (hashtable-set! ht key val)
+       ...
+       ht)]))
 
 (define (dump x)
   (cond

--- a/src/swish/foreign.ms
+++ b/src/swish/foreign.ms
@@ -248,7 +248,7 @@
                          (printf "key: ~a = ~a\n" key (hashtable-ref dict key "NOT FOUND")))
                        (printf "handler called\n")
                        (printf "path = ~a\n" path)
-                       (show "file")
+                       (show 'file)
                        (load-shared-object path)))]
                  [else (match mode)]))
             (define after-rso (foreign-entry? "square"))

--- a/src/swish/foreign.ss
+++ b/src/swish/foreign.ss
@@ -32,13 +32,13 @@
    (swish json))
 
   (define (so-path so-name . more)
-    `("swish" "shared-object" ,so-name ,(symbol->string (machine-type))
-      ,@more))
+    `(swish shared-object ,(string->symbol so-name) ,(machine-type)
+       ,@more))
 
   (define (provide-shared-object so-name filename)
     (unless (string? so-name) (bad-arg 'provide-shared-object so-name))
     (unless (string? filename) (bad-arg 'provide-shared-object filename))
-    (json:update! (app:config) (so-path so-name "file") values filename))
+    (json:update! (app:config) (so-path so-name 'file) values filename))
 
   (define require-shared-object
     (case-lambda
@@ -50,7 +50,7 @@
       (unless (string? so-name) (bad-arg 'require-shared-object so-name))
       (unless (procedure? handler) (bad-arg 'require-shared-object handler))
       (let* ([dict (json:ref (app:config) (so-path so-name) #f)]
-             [file (and (hashtable? dict) (hashtable-ref dict "file" #f))])
+             [file (and (hashtable? dict) (hashtable-ref dict 'file #f))])
         (unless (string? file)
           (raise `#(unknown-shared-object ,so-name)))
         (match (catch (handler (resolve file) so-name dict))

--- a/src/swish/json.ms
+++ b/src/swish/json.ms
@@ -108,7 +108,7 @@
     #((1 "foo") "[1,\"foo\"]")
 
     #(,(json:make-object [foo '(123)]) "{\"foo\":[123]}")
-    #(,(json:make-object [foo (json:make-object [bar #t])])
+    #(,(json:make-object [,'foo (json:make-object [bar #t])])
       "{\"foo\":{\"bar\":true}}")
 
     #((-123 "foo" ,(json:make-object [bar '()]) #\nul)

--- a/src/swish/json.ms
+++ b/src/swish/json.ms
@@ -29,12 +29,15 @@
  (swish testing)
  )
 
+(define (symbol<? x y)
+  (string<? (symbol->string x) (symbol->string y)))
+
 (define (dump x)
   (cond
-   [(hashtable? x)
+   [(symbol-hashtable? x)
     (vector-map
-     (lambda (k) (cons k (dump (hashtable-ref x k #f))))
-     (vector-sort string<? (hashtable-keys x)))]
+     (lambda (k) (cons k (dump (symbol-hashtable-ref x k #f))))
+     (vector-sort symbol<? (hashtable-keys x)))]
    [(pair? x) (map dump x)]
    [else x]))
 
@@ -97,18 +100,18 @@
          (get-output-string op)))
     #("\x1D11E;\x1d11f;\x1d120;" "\"\\uD834\\uDD1E\x1D11F;\\ud834\\udd20\"")
     #(,(json:make-object) "{}")
-    #(,(json:make-object ["foo" "bar"]) "{\"foo\":\"bar\"}")
-    #(,(json:make-object ["foo" "bar"] ["baz" 123])
+    #(,(json:make-object [foo "bar"]) "{\"foo\":\"bar\"}")
+    #(,(json:make-object [foo "bar"] [baz 123])
       "{\"foo\":\"bar\",\"baz\":123}")
     #(() "[]")
     #((()) "[[]]")
     #((1 "foo") "[1,\"foo\"]")
 
-    #(,(json:make-object ["foo" '(123)]) "{\"foo\":[123]}")
-    #(,(json:make-object ["foo" (json:make-object ["bar" #t])])
+    #(,(json:make-object [foo '(123)]) "{\"foo\":[123]}")
+    #(,(json:make-object [foo (json:make-object [bar #t])])
       "{\"foo\":{\"bar\":true}}")
 
-    #((-123 "foo" ,(json:make-object ["bar" '()]) #\nul)
+    #((-123 "foo" ,(json:make-object [bar '()]) #\nul)
       "[-123,\"foo\",{\"bar\":[]},null]")
     ))
 
@@ -155,16 +158,16 @@
        (let ()
          (json:write op
            (json:make-object
-            ["bar" "rel"]
-            ["foo" "tstep"]
-            ["ace" "rbic"]))
+            [bar "rel"]
+            [foo "tstep"]
+            [ace "rbic"]))
          (get))]
       [,@by-write
        (let ()
          (json:write-object op #f json:write
-           ["bar" "rel"]
-           ["foo" "tstep"]
-           ["ace" "rbic"])
+           [bar "rel"]
+           [foo "tstep"]
+           [ace "rbic"])
          (get))]
       [,custom-write
        (lambda (op v indent wr)
@@ -174,9 +177,9 @@
       ["{\"abc\":[\"four\",\"five\",\"six\"],\"def\":[7,8,9],\"ghi\":3}"
        (begin
          (json:write-object op #f json:write
-           ["ghi" 3]
-           ["abc" '#(4 5 6) custom-write]
-           ["def" '(7 8 9) custom-write])
+           [ghi 3]
+           [abc '#(4 5 6) custom-write]
+           [def '(7 8 9) custom-write])
          (get))])
      'ok)))
 
@@ -187,9 +190,9 @@
        (begin
          (json:write op
            (json:make-object
-            ["ghi" 3]
-            ["abc" '#(4 5 6)]
-            ["def" '(7 8 9)])
+            [ghi 3]
+            [abc '#(4 5 6)]
+            [def '(7 8 9)])
            0
            (lambda (op x indent wr)
              (cond
@@ -202,9 +205,9 @@
        (begin
          (json:write op
            (json:make-object
-            ["ghi" 3]
-            ["abc" '#(4 5 6)]
-            ["def" '(7 8 9)])
+            [ghi 3]
+            [abc '#(4 5 6)]
+            [def '(7 8 9)])
            0
            (lambda (op x indent wr)
              (cond
@@ -219,14 +222,14 @@
        (begin
          (json:write op
            (json:make-object
-            ["list" (list 1 2 'flubber)])
+            [list (list 1 2 'flubber)])
            0
            (lambda (op x indent wr)
              (match x
                [flubber
                 (json:write-object op indent wr
-                  ["tiki" "torch"]
-                  ["wiki" "hello" goodbye])
+                  [tiki "torch"]
+                  [wiki "hello" goodbye])
                 #t]
                [,_ #f])))
          (get))])
@@ -236,38 +239,37 @@
   (define-tuple <obj> a b c)
   (define dne (box #t))
   (define (must-ref ht key)
-    (let ([hit (hashtable-ref ht key dne)])
+    (let ([hit (symbol-hashtable-ref ht key dne)])
       (if (eq? hit dne)
           (errorf 'must-ref "did not find ~s" key)
           hit)))
   (define (custom-inflate x)
-    (match (hashtable-ref x "_type_" #f)
+    (match (symbol-hashtable-ref x '_type_ #f)
       ["<obj>"
        (<obj> make
-         [a (must-ref x "a")]
-         [b (must-ref x "b")]
-         [c (must-ref x "c")])]
+         [a (must-ref x 'a)]
+         [b (must-ref x 'b)]
+         [c (must-ref x 'c)])]
       ["symbol"
-       (string->symbol (must-ref x "name"))]
+       (string->symbol (must-ref x 'name))]
       [,_ x]))
   (define (custom-write op x indent wr)
     (match x
       [`(<obj> ,a ,b ,c)
        (json:write-object op #f wr
-         ["_type_" "<obj>"]
-         ["a" a]
-         ["b" b]
-         ["c" c])]
+         [_type_ "<obj>"]
+         [a a]
+         [b b]
+         [c c])]
       [,x
        (guard (symbol? x))
        (json:write-object op #f wr
-         ["_type_" "symbol"]
-         ["name" (symbol->string x)])]
+         [_type_ "symbol"]
+         [name (symbol->string x)])]
       [,_ #f]))
   (define (hashtable->alist ht)
-    (let-values ([(keys vals) (hashtable-entries ht)])
-      (sort (lambda (a b) (string<? (car a) (car b)))
-        (map cons (vector->list keys) (vector->list vals)))))
+    (sort (lambda (a b) (symbol<? (car a) (car b)))
+      (vector->list (hashtable-cells ht))))
   (define (compare x y)
     (cond
      [(eqv? x y) 'ok]
@@ -279,8 +281,8 @@
      [(vector? x)
       (and (vector? y)
            (compare (vector->list x) (vector->list y)))]
-     [(hashtable? x)
-      (and (hashtable? y)
+     [(symbol-hashtable? x)
+      (and (symbol-hashtable? y)
            (compare (hashtable->alist x) (hashtable->alist y)))]
      [else #f]))
   (define (nop-custom-inflate x) x)
@@ -298,13 +300,13 @@
           [c (list
               (<obj> make [a 1] [b 2] [c 3])
               (json:make-object
-               ["able" (<obj> make [a 4] [b 5] [c 6])]
-               ["baker" '("one" "two")]
-               ["charlie" "delta"])
+               [able (<obj> make [a 4] [b 5] [c 6])]
+               [baker '("one" "two")]
+               [charlie "delta"])
               (<obj> make
                 [a 'typical]
                 [b 'fore]
-                [c (json:make-object ["take" "cake"])]))])]
+                [c (json:make-object [take "cake"])]))])]
     [,string (json:object->string x #f custom-write)]
     [ok (compare x (json:string->object string custom-inflate))]
     [,bv (json:object->bytevector x #f custom-write)]
@@ -352,109 +354,125 @@
    'ok)
   (match-let*
    ([#(EXIT #(bad-arg json:ref 7)) (catch (json:ref 7 "abc" "def"))]
-    [#(EXIT #(bad-arg json:ref (ument)))
-     (catch (json:ref (json:make-object) '(ument) #f))]
+    [#(EXIT #(bad-arg json:ref ("ument")))
+     (catch (json:ref (json:make-object) '("ument") #f))]
     [#(EXIT #(bad-arg json:ref ()))
      (catch (json:ref (json:make-object) '() #f))]
-    [#(EXIT #(bad-arg json:ref ("tarry" not)))
-     (let ([obj (json:make-object ["tarry" (json:make-object)])])
-       (catch (json:ref obj '("tarry" not) #f)))]
+    [#(EXIT #(bad-arg json:ref (tarry "not")))
+     (let ([obj (json:make-object [tarry (json:make-object)])])
+       (catch (json:ref obj '(tarry "not") #f)))]
     [#(EXIT #(bad-arg json:ref #\z))
      (catch (json:ref (json:make-object) #\z "def"))]
-    [#(EXIT #(bad-arg json:update! 7)) (catch (json:update! 7 "abc" values 2))]
-    [#(EXIT #(bad-arg json:update! (ument)))
-     (catch (json:update! (json:make-object) '(ument) values #f))]
-    [#(EXIT #(bad-arg json:update! ("tarry" not)))
-     (let ([obj (json:make-object ["tarry" (json:make-object)])])
-       (catch (json:update! obj '("tarry" not) values 123)))]
+    [#(EXIT #(bad-arg json:update! 7)) (catch (json:update! 7 'abc values 2))]
+    [#(EXIT #(bad-arg json:update! ("ument")))
+     (catch (json:update! (json:make-object) '("ument") values #f))]
+    [#(EXIT #(bad-arg json:update! (tarry "not")))
+     (let ([obj (json:make-object [tarry (json:make-object)])])
+       (catch (json:update! obj '(tarry "not") values 123)))]
     [#(EXIT #(bad-arg json:update! ()))
      (catch (json:update! (json:make-object) '() values 2))]
-    [#(EXIT #(bad-arg json:update! bogus))
-     (catch (json:update! (json:make-object) 'bogus values 2))]
+    [#(EXIT #(bad-arg json:update! "bogus"))
+     (catch (json:update! (json:make-object) "bogus" values 2))]
     [#(EXIT #(bad-arg json:update! #\a))
      (catch (json:update! (json:make-object) #\a values 2))]
     [#(EXIT #(bad-arg json:update! #\z))
      (catch (json:update! (json:make-object) values #\z 2))]
-    [#(EXIT #(bad-arg json:delete! 7)) (catch (json:delete! 7 "abc"))]
-    [#(EXIT #(bad-arg json:delete! (ument)))
-     (catch (json:delete! (json:make-object) '(ument)))]
+    [#(EXIT #(bad-arg json:delete! 7)) (catch (json:delete! 7 'abc))]
+    [#(EXIT #(bad-arg json:delete! ("ument")))
+     (catch (json:delete! (json:make-object) '("ument")))]
     [#(EXIT #(bad-arg json:delete! ()))
      (catch (json:delete! (json:make-object) '()))]
-    [#(EXIT #(bad-arg json:delete! ("tarry" not)))
-     (let ([obj (json:make-object ["tarry" (json:make-object)])])
-       (catch (json:delete! obj '("tarry" not))))]
+    [#(EXIT #(bad-arg json:delete! (tarry "not")))
+     (let ([obj (json:make-object [tarry (json:make-object)])])
+       (catch (json:delete! obj '(tarry "not"))))]
     [#(EXIT #(bad-arg json:delete! #\z))
      (catch (json:delete! (json:make-object) #\z))])
    'ok))
 
 (mat stable-ordering ()
-  (define (fake-hash x) 3)
-  (let* ([obj1 (json:extend-object (make-hashtable fake-hash string=?)
-                 ["a" 1]
-                 ["b" 2])]
-         [str1 (json:object->string obj1)]
-         [obj2 (json:extend-object (make-hashtable fake-hash string=?)
-                 ["b" 2]
-                 ["a" 1])]
-         [str2 (json:object->string obj2)])
-    (assert (equal? str1 str2))))
+  (define (find-collision s1 bound)
+    (define (gen)
+      (let* ([len (+ 1 (random 5))]
+	     [s (make-string len)])
+	(do ([i 0 (fx+ i 1)]) ((fx= i len) (string->symbol s))
+	  (string-set! s i
+	    (integer->char (fx+ (char->integer #\a) (random 26)))))))
+    (define target (symbol-hash s1))
+    (let search ([i 0])
+      (and (fx< i bound)
+	   (let ([s2 (gen)])
+	     (if (= (symbol-hash s2) target)
+	         `(,s1 ,s2)
+	         (search (fx+ i 1)))))))
+  (match-let*
+   ([,hash (symbol-hash 'foo)]
+    [,@hash (symbol-hash 'byu)] ;; use find-collision if this fails
+    [,obj1 (json:make-object
+	    [foo 1]
+	    [byu 2])]
+    [,str1 (json:object->string obj1)]
+    [,obj2 (json:make-object
+	    [byu 2]
+	    [foo 1])]
+    [,@str1 (json:object->string obj2)])
+   'ok))
 
 (mat manipulate ()
   (match-let*
    ([,obj (json:make-object)]
-    [1 (json:ref obj "not-found" 1)]
-    [2 (json:ref obj '("not-found") 2)]
-    [3 (json:ref obj '("not-found" "either") 3)]
-    [,_ (json:update! obj "count" values 0)]
-    [0 (json:ref obj "count" 'wrong)]
-    [,_ (json:update! obj "count" add1 9000)]
-    [1 (json:ref obj "count" 'wrong)]
-    [,_ (json:update! obj '("count") list 'wrong)]
-    [(1) (json:ref obj "count" 'wrong)]
-    [,_ (json:update! obj "new" vector "init")]
-    [#("init") (json:ref obj "new" 'wrong)]
-    [,_ (json:update! obj '("new" "world") string-upcase "order")]
-    [#t (hashtable? (json:ref obj "new" 'wrong))]
-    ["ORDER" (json:ref obj '("new" "world") 'wrong)]
-    [other (json:ref obj '("New" "World") 'other)]
-    [,_ (json:update! obj '("new")
-          (lambda (ht) (assert (hashtable? ht)) 123)
+    [1 (json:ref obj 'not-found 1)]
+    [2 (json:ref obj '(not-found) 2)]
+    [3 (json:ref obj '(not-found "either") 3)]
+    [,_ (json:update! obj 'count values 0)]
+    [0 (json:ref obj 'count 'wrong)]
+    [,_ (json:update! obj 'count add1 9000)]
+    [1 (json:ref obj 'count 'wrong)]
+    [,_ (json:update! obj '(count) list 'wrong)]
+    [(1) (json:ref obj 'count 'wrong)]
+    [,_ (json:update! obj 'new vector "init")]
+    [#("init") (json:ref obj 'new 'wrong)]
+    [,_ (json:update! obj '(new world) string-upcase "order")]
+    [#t (hashtable? (json:ref obj 'new 'wrong))]
+    ["ORDER" (json:ref obj '(new world) 'wrong)]
+    [other (json:ref obj '(New World) 'other)]
+    [,_ (json:update! obj '(new)
+          (lambda (ht) (assert (symbol-hashtable? ht)) 123)
           'wrong)]
-    [123 (json:ref obj "new" 'wrong)]
-    [,_ (json:update! obj '("new" "deeper" "path" "a" "b" "c") values 'quarry)]
-    [quarry (json:ref obj '("new" "deeper" "path" "a" "b" "c") 'wrong)]
-    [,_ (json:update! obj '("new" "deeper" "path" "a" "b" "D") values "abcd")]
-    ["abcd" (json:ref obj '("new" "deeper" "path" "a" "b" "D") 'wrong)]
-    [,_ (json:update! obj '("new" "deeper" "path" "a" "B" "D") values "1234")]
-    ["1234" (json:ref obj '("new" "deeper" "path" "a" "B" "D") 'wrong)]
-    [,_ (json:update! obj '("new" "deeper" "path" "A" "B" "D") values "okay")]
-    [,_ (json:delete! obj "not-found")]
-    [,_ (json:delete! obj '("new" "deeper" "mystery"))]
-    ["okay" (json:ref obj '("new" "deeper" "path" "A" "B" "D") 'wrong)]
-    [quarry (json:ref obj '("new" "deeper" "path" "a" "b" "c") 'wrong)]
-    ["abcd" (json:ref obj '("new" "deeper" "path" "a" "b" "D") 'wrong)]
-    [,_ (json:delete! obj '("new" "deeper" "path" "a" "b" "D"))]
-    [gone (json:ref obj '("new" "deeper" "path" "a" "b" "D") 'gone)]
-    [,_ (json:update! obj '("new") hashtable? 7)]
-    [#t (json:ref obj '("new") 'wrong)]
-    [gone (json:ref obj '("new" "deeper" "path" "a" "b" "D") 'gone)]
-    [,_ (json:update! obj '("new") hashtable?
+    [123 (json:ref obj 'new 'wrong)]
+    [,_ (json:update! obj '(new deeper path a b c) values 'quarry)]
+    [quarry (json:ref obj '(new deeper path a b c) 'wrong)]
+    [,_ (json:update! obj '(new deeper path a b D) values "abcd")]
+    ["abcd" (json:ref obj '(new deeper path a b D) 'wrong)]
+    [,_ (json:update! obj '(new deeper path a B D) values "1234")]
+    ["1234" (json:ref obj '(new deeper path a B D) 'wrong)]
+    [,_ (json:update! obj '(new deeper path A B D) values "okay")]
+    [,_ (json:delete! obj 'not-found)]
+    [,_ (json:delete! obj '(new deeper mystery))]
+    ["okay" (json:ref obj '(new deeper path A B D) 'wrong)]
+    [quarry (json:ref obj '(new deeper path a b c) 'wrong)]
+    ["abcd" (json:ref obj '(new deeper path a b D) 'wrong)]
+    [,_ (json:delete! obj '(new deeper path a b D))]
+    [gone (json:ref obj '(new deeper path a b D) 'gone)]
+    [,_ (json:update! obj '(new) hashtable? 7)]
+    [#t (json:ref obj '(new) 'wrong)]
+    [gone (json:ref obj '(new deeper path a b D) 'gone)]
+    [,_ (json:update! obj '(new) hashtable?
           (make-hashtable string-hash string=?))]
-    [#f (json:ref obj '("new") 'wrong)]
-    [,_ (json:update! obj "count" car 'wrong)]
-    [#(("count" . 1) ("new" . #f)) (dump obj)]
-    [,_ (json:delete! obj '("count" "blessings"))]
-    [#(("count" . 1) ("new" . #f)) (dump obj)]
-    [,_ (json:delete! obj "not-found")]
-    [#(("count" . 1) ("new" . #f)) (dump obj)]
-    [,_ (json:delete! obj "count")]
-    [#(("new" . #f)) (dump obj)]
-    [,_ (json:delete! obj '("new"))]
+    [#f (json:ref obj '(new) 'wrong)]
+    [,_ (json:update! obj 'count car 'wrong)]
+    [#((count . 1) (new . #f)) (dump obj)]
+    [,_ (json:delete! obj '(count blessings))]
+    [#((count . 1) (new . #f)) (dump obj)]
+    [,_ (json:delete! obj 'not-found)]
+    [#((count . 1) (new . #f)) (dump obj)]
+    [,_ (json:delete! obj 'count)]
+    [#((new . #f)) (dump obj)]
+    [,_ (json:delete! obj '(new))]
     [#() (dump obj)]
-    [,_ (json:delete! obj '("new"))]
+    [,_ (json:delete! obj '(new))]
     [#() (dump obj)])
    'ok)
   ;; - behavior of json:update! is unspecified if given invalid path
-  ;;   such as ("foo" . bar)
+  ;;   such as (foo . bar)
   ;;   in particular, we'll smash everything along that path
    )

--- a/src/swish/json.ms
+++ b/src/swish/json.ms
@@ -331,6 +331,8 @@
     [#(EXIT #(unexpected-input #\1 1)) (catch (json:string->object "{1}"))]
     [#(EXIT #(unexpected-input #\: 6))
      (catch (json:string->object "{\"a\":1:}"))]
+    [#(EXIT #(unexpected-input #\} 7))
+     (catch (json:string->object "{\"a\":1,}"))]
     [#(EXIT #(unexpected-input #\} 1)) (catch (json:string->object "[}"))]
     [#(EXIT unexpected-eof) (catch (json:string->object "-"))]
     [#(EXIT unexpected-eof) (catch (json:string->object "1."))]
@@ -338,6 +340,7 @@
     [#(EXIT unexpected-eof) (catch (json:string->object "1e+"))]
     [#(EXIT #(unexpected-input #\. 3)) (catch (json:string->object "1.2.3"))]
     [#(EXIT #(unexpected-input #\, 1)) (catch (json:string->object "[,"))]
+    [#(EXIT #(unexpected-input #\] 3)) (catch (json:string->object "[1,]"))]
     [#(EXIT #(unexpected-input #\2 3)) (catch (json:string->object "[1 2]"))]
     [#(EXIT #(unexpected-input #\. 3)) (catch (json:string->object "\"\\u.\""))]
     [#(EXIT #(unexpected-input #\g 2)) (catch (json:string->object "\"\\g\""))]

--- a/src/swish/json.ss
+++ b/src/swish/json.ss
@@ -269,34 +269,34 @@
            [(eqv? c #\[)
             (let lp ([acc '()])
               (let ([c (next-non-ws ip)])
-                (case c
-                  [(#\]) '()]
-                  [else
-                   (unread-char c ip)
-                   (let ([acc (cons (rd ip) acc)])
-                     (let ([c (next-non-ws ip)])
-                       (case c
-                         [(#\,) (lp acc)]
-                         [(#\]) (reverse acc)]
-                         [else (unexpected-input c ip)])))])))]
+                (cond
+                 [(and (eqv? c #\]) (null? acc)) '()]
+                 [else
+                  (unread-char c ip)
+                  (let* ([acc (cons (rd ip) acc)]
+                         [c (next-non-ws ip)])
+                    (case c
+                      [(#\,) (lp acc)]
+                      [(#\]) (reverse acc)]
+                      [else (unexpected-input c ip)]))])))]
            [(eqv? c #\{)
             (custom-inflate
              (let lp ([obj (json:make-object)])
                (let ([c (next-non-ws ip)])
-                 (case c
-                   [(#\")
-                    (let ([key (read-string ip)])
-                      (let ([c (next-non-ws ip)])
-                        (unless (eqv? c #\:)
-                          (unexpected-input c ip)))
-                      (hashtable-set! obj key (rd ip)))
-                    (let ([c (next-non-ws ip)])
-                      (case c
-                        [(#\,) (lp obj)]
-                        [(#\}) obj]
-                        [else (unexpected-input c ip)]))]
-                   [(#\}) obj]
-                   [else (unexpected-input c ip)]))))]
+                 (cond
+                  [(eqv? c #\")
+                   (let* ([key (read-string ip)]
+                          [c (next-non-ws ip)])
+                     (unless (eqv? c #\:)
+                       (unexpected-input c ip))
+                     (hashtable-set! obj key (rd ip)))
+                   (let ([c (next-non-ws ip)])
+                     (case c
+                       [(#\,) (lp obj)]
+                       [(#\}) obj]
+                       [else (unexpected-input c ip)]))]
+                  [(and (eqv? c #\}) (eqv? (hashtable-size obj) 0)) obj]
+                  [else (unexpected-input c ip)]))))]
            [(eqv? c #\-) (- (read-unsigned ip))]
            [else (unread-char c ip) (read-unsigned ip)])))
       (let ([x (seek-non-ws ip)])

--- a/src/swish/json.ss
+++ b/src/swish/json.ss
@@ -45,11 +45,15 @@
   (define-syntax json:extend-object
     (syntax-rules ()
       [(_ $ht (key val) ...)
-       (for-all identifier? #'(key ...))
        (let ([ht $ht])
-         (symbol-hashtable-set! ht 'key val)
+         (symbol-hashtable-set! ht (parse-key key) val)
          ...
          ht)]))
+
+  (define-syntax parse-key
+    (syntax-rules (unquote)
+      [(_ id) (identifier? #'id) (quote id)]
+      [(_ (unquote e)) e]))
 
   (define-syntax json:make-object
     (syntax-rules ()

--- a/web/swish/query.ss
+++ b/web/swish/query.ss
@@ -43,10 +43,10 @@
 (define (meta op)
   (json:write op
     (json:make-object
-     ["instance" (log-db:get-instance-id)]
-     ["computer-name" (osi_get_hostname)]
-     ["software-version" software-version]
-     ["software-product-name" software-product-name]))
+     [instance (log-db:get-instance-id)]
+     [computer-name (osi_get_hostname)]
+     [software-version software-version]
+     [software-product-name software-product-name]))
   'ok)
 
 (define (doit op)
@@ -91,4 +91,4 @@
       [ok (get)]
       [#(EXIT ,reason)
        (json:object->bytevector
-        (json:make-object ["error" (exit-reason->english reason)]))])))
+        (json:make-object [error (exit-reason->english reason)]))])))


### PR DESCRIPTION
@owaddell, this will let you see what I had in mind. The json:make-object form now takes literal keys, which is more restrictive than before, but it seemed to affect only one piece of code. See what you think!