### PR TITLE
Add message-digest support

### DIFF
--- a/doc/reference.bib
+++ b/doc/reference.bib
@@ -216,3 +216,10 @@
   publisher = {O'Reilly Media, Inc.},
   year = {2006},
 }
+
+@misc{rfc4648,
+  title = {The {Base16}, {Base32}, and {Base64} Data Encodings},
+  key = {rfc4648},
+  year = {2006},
+  note = {\url{https://tools.ietf.org/html/rfc4648}}
+}

--- a/doc/swish.sty
+++ b/doc/swish.sty
@@ -21,6 +21,7 @@
 % SOFTWARE.
 
 \usepackage{sagian}
+\makedecl{binding}
 \makedecl{constructor}
 \makedecl{event}
 \makedecl{function}

--- a/doc/swish/app.tex
+++ b/doc/swish/app.tex
@@ -672,4 +672,24 @@ then \code{require-shared-object} determines the absolute path by
 treating the file name as a path relative to the parent directory
 containing the application configuration file name returned by \code{app:config-filename}.
 
+\defineentry{define-foreign}
+\begin{syntax}
+  \code{(define-foreign \var{name} (\var{arg-name} \var{arg-type}) ...)}
+\end{syntax}
+\expandsto{} \antipar\codebegin
+(begin
+  (define \var{name}* (foreign-procedure (symbol->string '\var{name}) (\var{arg-type} ...) ptr))
+  (define (\var{name} \var{arg-name} ...)
+    (match (\var{name}* \var{arg-name} ...)
+      [(,who . ,err)
+       (guard (symbol? who))
+       (io-error '\var{name} who err)]
+      [,x x])))
+\codeend
+
+The \code{define-foreign} macro defines two procedures: \code{\var{name}*}
+is a raw foreign procedure that expects the specified argument types and returns
+a \code{ptr} value, while \var{name} is a wrapper that calls \code{\var{name}*}
+and raises an \code{io-error} if it returns an error pair.
+
 \input{swish/testing.tex}

--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -2645,3 +2645,44 @@ This is the procedure returned by \code{(foreign-handle-print\ 'digests)}.
 The \code{digest-count} procedure returns the number of open
 message-digest contexts.
 This is the procedure returned by \code{(foreign-handle-count\ 'digests)}.
+
+% ----------------------------------------------------------------------------
+\subsection{Data-Encoding Utilities}
+
+% ----------------------------------------------------------------------------
+\defineentry{base64-decode-bytevector}
+\defineentry{base64url-decode-bytevector}
+\begin{procedure}
+  \code{(base64-decode-bytevector \var{bv})}\strut\\
+  \code{(base64url-decode-bytevector \var{bv})}\strut
+\end{procedure}
+\returns{} a bytevector
+
+The \code{base64-decode-bytevector} and \code{base64url-decode-bytevector}
+procedures return a new bytevector containing the data decoded from bytevector
+\var{bv}.
+The data in \var{bv} must be in the form described in Section 4 or 5,
+respectively, of IETF RFC 4648~\cite{rfc4648}.
+In keeping with Sections 3.1 and 3.3 of~\cite{rfc4648},
+line feeds and non-alphabetic characters are not permitted
+in \var{bv} and should be removed before calling these procedures.
+
+% ----------------------------------------------------------------------------
+\defineentry{base64-encode-bytevector}
+\defineentry{base64url-encode-bytevector}
+\begin{procedure}
+  \code{(base64-encode-bytevector \var{bv})}\strut\\
+  \code{(base64url-encode-bytevector \var{bv})}\strut
+\end{procedure}
+\returns{} a bytevector
+
+The \code{base64-encode-bytevector} and \code{base64url-encode-bytevector}
+procedures return a new byte\-vector containing the binary data from bytevector
+\var{bv} encoded as printable US-ASCII characters as described in Sections 4
+and 5, respectively, of IETF RFC 4648~\cite{rfc4648}.
+Both procedures encode data using an alphabet including \code{A}-\code{Z},
+\code{a}-\code{z}, and \code{0}-\code{9}.
+For \code{base64-encode-bytevector}, the alphabet also includes \code{+} and \code{/}.
+For \code{base64url-encode-bytevector} it includes \code{-} and \code{\_}.
+In keeping with Section 3.1 of~\cite{rfc4648}, these procedures
+do not introduce line breaks in the output.

--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -2441,3 +2441,207 @@ appending the symbols passed as arguments.
 If \var{regexp} is a literal string, the \code{re} macro expands to the
 result of evaluating \code{(pregexp\ \var{regexp})} at expand time.
 Otherwise it expands into a run-time call to \code{pregexp}.
+
+\subsection {Message Digests}
+
+% ----------------------------------------------------------------------------
+\defineentry{make-digest-provider}
+\begin{procedure}
+  \code{(make-digest-provider \var{name} \var{open} \var{hash!} \var{get-hash} \var{close})}
+\end{procedure}
+\returns{} a digest provider record
+
+The \code{make-digest-provider} procedure takes a symbol \var{name}
+and a set of procedures and returns a new digest provider that can
+be used as the value of \code{current-digest-provider} or as an
+argument to \code{open-digest}.
+
+The \var{open} procedure takes a string \var{alg} and an \var{hmac-key}
+that is either \code{\#f} or a bytevector to use for HMAC keyed hashing.
+If the digest provider does not support the specified message-digest algorithm
+\var{alg} or the \var{hmac-key}, it should return an error pair or one of
+the symbols \code{algorithm} or \code{hmac-key} to indicate which argument
+is invalid.
+Otherwise it should return a message-digest context that can be
+passed to \var{hash!}, \var{get-hash}, and \var{close}.
+
+The \var{hash!} procedure has the same interface as \code{osi\_hash\_data} and
+performs the analogous function for the message-digest context initialized by
+\var{open}. It computes the message digest incrementally on the set of bytes
+specified and updates the message-digest context.
+
+The \var{get-hash} procedure has the same interface as \code{osi\_get\_SHA1} and
+performs the analogous function for the message-digest context initialized by
+\var{open} and updated by \var{hash!}.
+
+The \var{close} procedure frees a message-digest context initialized
+by \var{open}.
+
+% ----------------------------------------------------------------------------
+\defineentry{current-digest-provider}
+\begin{parameter}
+  \code{current-digest-provider}
+\end{parameter}
+\returns{} a digest provider record
+
+The \code{current-digest-provider} parameter specifies the digest provider
+used by \code{bytevector->hex-string} and by \code{open-digest} when the
+digest provider is not explicit.
+
+% ----------------------------------------------------------------------------
+\defineentry{default-digest-provider}
+\begin{binding}
+  \code{default-digest-provider}
+\end{binding}
+\returns{} the default digest provider record
+
+The default value of \code{current-digest-provider} is bound to
+\code{default-digest-provider}.
+The default digest provider supports only the SHA1 message-digest algorithm;
+it does not support HMAC keyed hashing.
+
+% ----------------------------------------------------------------------------
+\defineentry{digest-provider-name}
+\begin{procedure}
+  \code{(digest-provider-name \var{dp})}
+\end{procedure}
+\returns{} the name of the digest provider
+
+The \code{digest-provider-name} procedure returns the symbol
+that was supplied to \code{make-digest-provider} when \var{dp}
+was created.
+
+% ----------------------------------------------------------------------------
+\defineentry{open-digest}
+\begin{procedure}
+  \code{(open-digest \var{alg} \opt{\var{hmac-key} \opt{\var{dp}}})}
+\end{procedure}
+
+The \code{open-digest} procedure takes a string or symbol \var{alg}
+naming a message-digest function supported by the digest provider
+\var{dp}, which defaults to the value of \code{current-digest-provider}.
+If \var{alg} is a symbol, it is converted to an upper-case string
+before proceeding.
+The optional \var{hmac-key} may be \code{\#f} to disable HMAC keyed
+hashing; otherwise it must be a bytevector or a string.
+If \var{hmac-key} is a string, it is converted to a bytevector
+using \code{string->utf8}.
+
+The \code{open-digest} procedure disables interrupts while it calls the \var{open}
+procedure that was registered with \code{make-digest-provider}, passing it the
+algorithm name as a string and the \var{hmac-key} as either \code{\#f} or a
+bytevector.
+If successful, it wraps the message-digest context returned by \var{open}
+in a message-digest record \var{md}, registers \var{md}
+with a foreign-handle guardian using the type name \code{digests},
+and returns \var{md}.
+
+% ----------------------------------------------------------------------------
+\defineentry{hash!}
+\begin{procedure}
+  \code{(hash! \var{md} \var{bv} \opt{\var{start-index} \opt{\var{size}}})}
+\end{procedure}
+\returns{} unspecified
+
+The \code{hash!} procedure disables interrupts while it calls the \var{hash!}
+procedure of the message-digest provider used in the \code{open-digest}
+call that returned \var{md}.
+The \var{hash!} procedure computes the message digest incrementally
+on the set of \var{size} bytes in the bytevector \var{bv} starting at
+the zero-based \var{start-index}.
+If omitted, \var{start-index} defaults to zero and \var{size} defaults
+to the size of \var{bv}.
+The \var{hash!} procedure updates the message-digest context within \var{md}.
+
+% ----------------------------------------------------------------------------
+\defineentry{get-hash}
+\begin{procedure}
+  \code{(get-hash \var{md})}
+\end{procedure}
+\returns{} a bytevector
+
+The \code{get-hash} procedure disables interrupts while it calls the \var{get-hash}
+procedure of the message-digest provider used in the \code{open-digest}
+call that returned \var{md}.
+It returns a bytevector containing the message digest accumulated in \var{md}
+by zero or more calls to \code{hash!}.
+
+% ----------------------------------------------------------------------------
+\defineentry{close-digest}
+\begin{procedure}
+  \code{(close-digest \var{md})}
+\end{procedure}
+\returns{} unspecified
+
+The \code{close-digest} procedure disables interrupts, unregisters \var{md}
+with the foreign-handle guardian, calls the \var{close} procedure of the
+message-digest provider used in the \code{open-digest} call that returned
+\var{md}, then enables interrupts.
+
+% ----------------------------------------------------------------------------
+\defineentry{hash->hex-string}
+\begin{procedure}
+  \code{(hash->hex-string \var{bv})}
+\end{procedure}
+\returns{} a string of lower-case hexadecimal digits
+
+The \code{hash->hex-string} procedure takes a bytevector \var{bv} and returns
+the unsigned bytes in \var{bv} as a string of lower-case hexadecimal digits.
+
+% ----------------------------------------------------------------------------
+\defineentry{hex-string->hash}
+\begin{procedure}
+  \code{(hex-string->hash \var{s})}
+\end{procedure}
+\returns{} a bytevector
+
+The \code{hex-string->hash} procedure takes a string \var{s}
+containing an even number of hexadecimal digits and returns a
+bytevector half that size containing the unsigned bytes
+specified by adjacent pairs of hexadecimal digits.
+
+% ----------------------------------------------------------------------------
+\defineentry{bytevector->hex-string}
+\begin{procedure}
+  \code{(bytevector->hex-string \var{bv} \var{alg} \opt{\var{block-size}})}
+\end{procedure}
+\returns{} a string of lower-case hexadecimal digits
+
+The \code{bytevector->hex-string} procedure takes a bytevector \var{bv} and a
+string or symbol \var{alg} naming a message-digest function supported by the
+\code{current-digest-provider} and returns the message digest of \var{bv}
+using \var{alg} as a string of lower-case hexadecimal digits.
+To keep the event loop responsive, \code{bytevector->hex-string} computes
+the message digest of \var{bv} incrementally in chunks of \var{block-size},
+which defaults to 16384.
+When the size of \var{bv} is not more than \var{block-size}, this is
+functionally equivalent to the following:
+\codebegin
+(let ([md (open-digest \var{alg})])
+  (on-exit (close-digest md)
+    (hash! md \var{bv})
+    (hash->hex-string (get-hash md))))
+\codeend
+
+% ----------------------------------------------------------------------------
+\defineentry{print-digests}
+\begin{procedure}
+  \code{(print-digests \opt{\var{op}})}
+\end{procedure}
+\returns{} unspecified
+
+The \code{print-digests} procedure prints information about all open
+message-digest contexts to textual output port \var{op}, which defaults to the
+current output port.
+This is the procedure returned by \code{(foreign-handle-print\ 'digests)}.
+
+% ----------------------------------------------------------------------------
+\defineentry{digest-count}
+\begin{procedure}
+  \code{(digest-count)}
+\end{procedure}
+\returns{} the number of open message-digest contexts
+
+The \code{digest-count} procedure returns the number of open
+message-digest contexts.
+This is the procedure returned by \code{(foreign-handle-count\ 'digests)}.

--- a/doc/swish/osi.tex
+++ b/doc/swish/osi.tex
@@ -962,3 +962,41 @@ The \code{osi\_get\_sqlite\_status} function uses the
 \code{sqlite3\_status64} function with the given \var{operation} and
 \var{reset} flag to return \code{\#(\var{current} \var{highwater})}
 when successful and an error pair otherwise.
+
+\subsection {Message-Digest Functions}
+
+\defineentry{osi\_open\_SHA1}
+\begin{function}
+  \code{ptr osi\_open\_SHA1();}
+\end{function}
+
+The \code{osi\_open\_SHA1} function returns an error pair
+or a context for computing the SHA1 message digest.
+
+\defineentry{osi\_hash\_data}
+\begin{function}
+  \code{ptr osi\_hash\_data(uptr \var{ctxt}, ptr \var{bv}, size\_t \var{start\_index}, uint32\_t \var{size});}
+\end{function}
+
+The \code{osi\_hash\_data} function computes the SHA1 message digest
+incrementally on the \var{size} bytes at the zero-based \var{start\_index}
+of bytevector \var{bv} updating the context \var{ctxt}.
+It returns \code{\#t} when successful and an error pair otherwise.
+
+\defineentry{osi\_get\_SHA1}
+\begin{function}
+  \code{ptr osi\_get\_SHA1(uptr \var{ctxt});}
+\end{function}
+
+The \code{osi\_get\_SHA1} function takes a \var{ctxt} that was created by
+\code{osi\_open\_SHA1} and updated by calling \code{osi\_hash\_data} on a set
+of buffers and returns as a bytevector the SHA1 message digest of the buffers.
+If unsuccessful, it returns an error pair.
+
+\defineentry{osi\_close\_SHA1}
+\begin{function}
+  \code{ptr osi\_close\_SHA1(uptr \var{ctxt});}
+\end{function}
+
+The \code{osi\_close\_SHA1} function frees a \var{ctxt}
+that was allocated by \code{osi\_open\_SHA1}.

--- a/src/swish/.gitignore
+++ b/src/swish/.gitignore
@@ -15,6 +15,8 @@
 /run.o
 /run.obj
 /sh-config
+/sha1.o
+/sha1.obj
 /shlibtest.dll
 /shlibtest.exp
 /shlibtest.ilk

--- a/src/swish/Mf-a6le
+++ b/src/swish/Mf-a6le
@@ -5,7 +5,7 @@ ifneq (,$(shell "${CC}" --help=warnings 2> /dev/null | grep cast-function-type))
   HUSH:=${HUSH} -Wno-cast-function-type
 endif
 C = ${CC} -m64 -msse2 -fPIC -Wall -Wextra -Werror -O2 ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}
-OsiObj=osi.o sqlite.o sqlite3.o
+OsiObj=osi.o sha1.o sqlite.o sqlite3.o
 SystemLibs=-lm -ldl -lncurses -luuid -lpthread
 SwishLibs := ../../${BUILD}/bin/libosi.so ../../${BUILD}/lib/swish_kernel.o
 
@@ -36,7 +36,7 @@ ${SHLIBTEST}: shlibtest.c
 	$C -shared -o $@ $^ -I"${LIBUV_INCLUDE}" -I"${SCHEME_INCLUDE}" -I"${SWISH_INCLUDE}"
 
 platform-clean:
-	rm -f main.o osi.o run.o sqlite.o
+	rm -f main.o osi.o run.o sha1.o sqlite.o
 
 pristine: clean
 	rm -rf sqlite3.o ../../libuv/out/Release

--- a/src/swish/Mf-a6nt
+++ b/src/swish/Mf-a6nt
@@ -1,6 +1,6 @@
 C=../vs 64 cl /nologo /Ox /MD /W3 /Zi
 LD=../vs 64 link /nologo /nodefaultlib:libcmt /debug:full /libpath:"../../${BUILD}/bin" /libpath:"${SCHEME_LIBPATH}"
-OsiObj=osi.obj run.obj sqlite.obj
+OsiObj=osi.obj run.obj sha1.obj sqlite.obj
 SystemLibs=rpcrt4.lib ole32.lib advapi32.lib User32.lib
 SwishLibs := ../../${BUILD}/bin/libuv.dll ../../${BUILD}/bin/sqlite3.dll ../../${BUILD}/bin/osi.dll
 
@@ -39,6 +39,7 @@ platform-clean:
 	rm -f ../../${BUILD}/bin/libuv.{dll,exp,lib,pdb}
 	rm -f ../../${BUILD}/bin/swish.{exe,exp,ilk,lib,pdb}
 	rm -f io-constants.{exe,ilk,obj,pdb}
+	rm -f sha1.obj
 	rm -f shlibtest.{dll,exp,lib,pdb}
 	rm -f {main,osi,run,sqlite}.obj
 	rm -f vc140.pdb

--- a/src/swish/Mf-a6osx
+++ b/src/swish/Mf-a6osx
@@ -1,5 +1,5 @@
 C = ${CC} -m64 -fPIC -Wall -Wextra -Werror -O2 ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}
-OsiObj=osi.o sqlite.o sqlite3.o
+OsiObj=osi.o sha1.o sqlite.o sqlite3.o
 SystemLibs=-liconv -lm -lncurses
 SwishLibs := ../../${BUILD}/bin/libosi.dylib ../../${BUILD}/lib/swish_kernel.o
 
@@ -30,7 +30,7 @@ ${SHLIBTEST}: shlibtest.c
 	$C -dynamiclib -undefined dynamic_lookup -o $@ $^ -I"${LIBUV_INCLUDE}" -I"${SCHEME_INCLUDE}" -I"${SWISH_INCLUDE}"
 
 platform-clean:
-	rm -f main.o osi.o run.o sqlite.o
+	rm -f main.o osi.o run.o sha1.o sqlite.o
 
 pristine: clean
 	rm -rf sqlite3.o ../../libuv/build/Release

--- a/src/swish/Mf-arm32le
+++ b/src/swish/Mf-arm32le
@@ -1,5 +1,5 @@
 C = ${CC} -std=gnu99 -fPIC -Wall -Wextra -Werror -O2 ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}
-OsiObj=osi.o sqlite.o sqlite3.o
+OsiObj=osi.o sha1.o sqlite.o sqlite3.o
 SystemLibs=-lm -ldl -lncurses -luuid -lpthread
 SwishLibs := ../../${BUILD}/bin/libosi.so ../../${BUILD}/lib/swish_kernel.o
 
@@ -30,7 +30,7 @@ ${SHLIBTEST}: shlibtest.c
 	$C -shared -o $@ $^ -I"${LIBUV_INCLUDE}" -I"${SCHEME_INCLUDE}" -I"${SWISH_INCLUDE}"
 
 platform-clean:
-	rm -f main.o osi.o run.o sqlite.o
+	rm -f main.o osi.o run.o sha1.o sqlite.o
 
 pristine: clean
 	rm -rf sqlite3.o ../../libuv/out/Release

--- a/src/swish/Mf-i3le
+++ b/src/swish/Mf-i3le
@@ -5,7 +5,7 @@ ifneq (,$(shell "${CC}" --help=warnings 2> /dev/null | grep cast-function-type))
   HUSH:=${HUSH} -Wno-cast-function-type
 endif
 C = ${CC} -m32 -fPIC -Wall -Wextra -Werror -O2 ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}
-OsiObj=osi.o sqlite.o sqlite3.o
+OsiObj=osi.o sha1.o sqlite.o sqlite3.o
 SystemLibs=-lm -ldl -lncurses -luuid -lpthread
 SwishLibs := ../../${BUILD}/bin/libosi.so ../../${BUILD}/lib/swish_kernel.o
 
@@ -36,7 +36,7 @@ ${SHLIBTEST}: shlibtest.c
 	$C -shared -o $@ $^ -I"${LIBUV_INCLUDE}" -I"${SCHEME_INCLUDE}" -I"${SWISH_INCLUDE}"
 
 platform-clean:
-	rm -f main.o osi.o run.o sqlite.o
+	rm -f main.o osi.o run.o sha1.o sqlite.o
 
 pristine: clean
 	rm -rf sqlite3.o ../../libuv/out/Release

--- a/src/swish/Mf-i3nt
+++ b/src/swish/Mf-i3nt
@@ -1,6 +1,6 @@
 C=../vs 32 cl /nologo /Ox /MD /W3 /Zi
 LD=../vs 32 link /nologo /nodefaultlib:libcmt /debug:full /libpath:"../../${BUILD}/bin" /libpath:"${SCHEME_LIBPATH}"
-OsiObj=osi.obj run.obj sqlite.obj
+OsiObj=osi.obj run.obj sha1.obj sqlite.obj
 SystemLibs=rpcrt4.lib ole32.lib advapi32.lib User32.lib
 SwishLibs := ../../${BUILD}/bin/libuv.dll ../../${BUILD}/bin/sqlite3.dll ../../${BUILD}/bin/osi.dll
 
@@ -39,6 +39,7 @@ platform-clean:
 	rm -f ../../${BUILD}/bin/libuv.{dll,exp,lib,pdb}
 	rm -f ../../${BUILD}/bin/swish.{exe,exp,ilk,lib,pdb}
 	rm -f io-constants.{exe,ilk,obj,pdb}
+	rm -f sha1.obj
 	rm -f shlibtest.{dll,exp,lib,pdb}
 	rm -f {main,osi,run,sqlite}.obj
 	rm -f vc140.pdb

--- a/src/swish/base64.ms
+++ b/src/swish/base64.ms
@@ -1,0 +1,189 @@
+;; Copyright 2019 Beckman Coulter, Inc.
+;;
+;; Permission is hereby granted, free of charge, to any person
+;; obtaining a copy of this software and associated documentation
+;; files (the "Software"), to deal in the Software without
+;; restriction, including without limitation the rights to use, copy,
+;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;; of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be
+;; included in all copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+(import
+ (scheme)
+ (swish imports)
+ (swish mat)
+ )
+
+(define-syntax test-vectors
+  (syntax-rules ()
+    [(_ [input output] ...)
+     (begin (test-case input output) ...)]))
+
+;; macro so we get better source information from bad-match
+(define-syntax test-case
+  (syntax-rules (BASE64)
+    [(_ (BASE64 input) output)
+     (match-let*
+      ([,in (string->utf8 input)]
+       [,out (string->utf8 output)]
+       [output (utf8->string ($encode in))]
+       [input (utf8->string ($decode out))]
+       [,@out ($encode in)]
+       [,@in ($decode out)])
+      'ok)]
+    [(_ input output)
+     (bytevector? (datum input))
+     (match-let*
+      ([,in input]
+       [,out (string->utf8 output)]
+       [output (utf8->string ($encode input))]
+       [input ($decode out)]
+       [,@out ($encode in)]
+       [,@in ($decode out)])
+      'ok)]))
+
+(define (generate-bv len p)
+  (let-values ([(op get-bv) (open-bytevector-output-port)])
+    (do ([i 0 (+ i 1)]) ((= i len))
+      (put-u8 op (p i)))
+    (get-bv)))
+
+(mat base64 ()
+  (fluid-let-syntax ([$encode (identifier-syntax base64-encode-bytevector)]
+                     [$decode (identifier-syntax base64-decode-bytevector)])
+    (define (round-trip input)
+      (match-let*
+       ([,out ($encode input)]
+        [,@input ($decode out)])
+       'ok))
+    (test-vectors
+     ;; from https://tools.ietf.org/html/rfc4648#section-10
+     [(BASE64 "") ""]
+     [(BASE64 "f") "Zg=="]
+     [(BASE64 "fo") "Zm8="]
+     [(BASE64 "foo") "Zm9v"]
+     [(BASE64 "foob") "Zm9vYg=="]
+     [(BASE64 "fooba") "Zm9vYmE="]
+     [(BASE64 "foobar") "Zm9vYmFy"]
+     ;; testing zeros in the input
+     [#vu8(0) "AA=="]
+     [#vu8(0 0) "AAA="]
+     [#vu8(0 0 0) "AAAA"]
+     [#vu8(0 0 0 0) "AAAAAA=="]
+     [#vu8(0 0 0 0 0) "AAAAAAA="]
+     [#vu8(0 0 0 0 0 0) "AAAAAAAA"]
+     ;; testing high values in the input
+     [#vu8(255) "/w=="]
+     [#vu8(255 255) "//8="]
+     [#vu8(255 255 255) "////"]
+     [#vu8(255 255 255 255) "/////w=="]
+     ;; hit each character in the output encoding
+     [#vu8(#x00 #x10 #x83 #x10 #x51 #x87 #x20 #x92 #x8b #x30 #xd3 #x8f
+            #x41 #x14 #x93 #x51 #x55 #x97 #x61 #x96 #x9b #x71 #xd7 #x9f
+            #x82 #x18 #xa3 #x92 #x59 #xa7 #xa2 #x9a #xab #xb2 #xdb #xaf
+            #xc3 #x1c #xb3 #xd3 #x5d #xb7 #xe3 #x9e #xbb #xf3 #xdf #xbf)
+       "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"])
+    (round-trip (generate-bv 256 values))
+    (parameterize ([random-seed 2609306995])
+      (round-trip (generate-bv 1021 (lambda (i) (random 256))))
+      (round-trip (generate-bv 1022 (lambda (i) (random 256))))
+      (round-trip (generate-bv 1023 (lambda (i) (random 256))))
+      (round-trip (generate-bv 1024 (lambda (i) (random 256)))))))
+
+(mat base64url ()
+  (fluid-let-syntax ([$encode (identifier-syntax base64url-encode-bytevector)]
+                     [$decode (identifier-syntax base64url-decode-bytevector)])
+    (define (round-trip input)
+      (match-let*
+       ([,out ($encode input)]
+        [,@input ($decode out)])
+       'ok))
+    (test-vectors
+     ;; from https://tools.ietf.org/html/rfc4648#section-10
+     [(BASE64 "") ""]
+     [(BASE64 "f") "Zg=="]
+     [(BASE64 "fo") "Zm8="]
+     [(BASE64 "foo") "Zm9v"]
+     [(BASE64 "foob") "Zm9vYg=="]
+     [(BASE64 "fooba") "Zm9vYmE="]
+     [(BASE64 "foobar") "Zm9vYmFy"]
+     ;; testing zeros in the input
+     [#vu8(0) "AA=="]
+     [#vu8(0 0) "AAA="]
+     [#vu8(0 0 0) "AAAA"]
+     [#vu8(0 0 0 0) "AAAAAA=="]
+     [#vu8(0 0 0 0 0) "AAAAAAA="]
+     [#vu8(0 0 0 0 0 0) "AAAAAAAA"]
+     ;; testing high values in the input
+     [#vu8(255) "_w=="]
+     [#vu8(255 255) "__8="]
+     [#vu8(255 255 255) "____"]
+     [#vu8(255 255 255 255) "_____w=="]
+     ;; hit each character in the output encoding
+     [#vu8(#x00 #x10 #x83 #x10 #x51 #x87 #x20 #x92 #x8b #x30 #xd3 #x8f
+            #x41 #x14 #x93 #x51 #x55 #x97 #x61 #x96 #x9b #x71 #xd7 #x9f
+            #x82 #x18 #xa3 #x92 #x59 #xa7 #xa2 #x9a #xab #xb2 #xdb #xaf
+            #xc3 #x1c #xb3 #xd3 #x5d #xb7 #xe3 #x9e #xbb #xf3 #xdf #xbf)
+       "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"])
+    (round-trip (generate-bv 256 values))
+    (parameterize ([random-seed 2609306995])
+      (round-trip (generate-bv 1021 (lambda (i) (random 256))))
+      (round-trip (generate-bv 1022 (lambda (i) (random 256))))
+      (round-trip (generate-bv 1023 (lambda (i) (random 256))))
+      (round-trip (generate-bv 1024 (lambda (i) (random 256)))))))
+
+(mat base64-errors ()
+  (define bip (open-bytevector-input-port (string->utf8 "")))
+  (define-values (bop get-bop) (open-bytevector-output-port))
+  (match-let*
+   ([#(EXIT #(bad-arg base64-encode-bytevector 7)) (catch (base64-encode-bytevector 7))]
+    [#(EXIT #(bad-arg base64url-encode-bytevector 7)) (catch (base64url-encode-bytevector 7))]
+    [#(EXIT #(bad-arg base64-decode-bytevector 7)) (catch (base64-decode-bytevector 7))]
+    [#(EXIT #(bad-arg base64url-decode-bytevector 7)) (catch (base64url-decode-bytevector 7))]
+    [,short (string->utf8 "Zm9vYg=")]
+    [#(EXIT #(bad-arg base64-decode-bytevector ,@short)) (catch (base64-decode-bytevector short))]
+    [#(EXIT #(bad-arg base64url-decode-bytevector ,@short)) (catch (base64url-decode-bytevector short))]
+    [,short (string->utf8 "fun")]
+    [#(EXIT #(bad-arg base64-decode-bytevector ,@short)) (catch (base64-decode-bytevector short))]
+    [#(EXIT #(bad-arg base64url-decode-bytevector ,@short)) (catch (base64url-decode-bytevector short))]
+    [,long (string->utf8 "VG9mdQ===")]
+    [#(EXIT #(bad-arg base64-decode-bytevector ,@long)) (catch (base64-decode-bytevector long))]
+    [#(EXIT #(bad-arg base64url-decode-bytevector ,@long)) (catch (base64url-decode-bytevector long))]
+    [,bad (string->utf8 "====")]
+    [#(EXIT #(bad-arg base64-decode-bytevector ,@bad)) (catch (base64-decode-bytevector bad))]
+    [#(EXIT #(bad-arg base64url-decode-bytevector ,@bad)) (catch (base64url-decode-bytevector bad))]
+    [,bad (string->utf8 "=BAD")]
+    [#(EXIT #(bad-arg base64-decode-bytevector ,@bad)) (catch (base64-decode-bytevector bad))]
+    [#(EXIT #(bad-arg base64url-decode-bytevector ,@bad)) (catch (base64url-decode-bytevector bad))]
+    [,bad (string->utf8 "B=AD")]
+    [#(EXIT #(bad-arg base64-decode-bytevector ,@bad)) (catch (base64-decode-bytevector bad))]
+    [#(EXIT #(bad-arg base64url-decode-bytevector ,@bad)) (catch (base64url-decode-bytevector bad))]
+    [,bad (string->utf8 "BA=D")]
+    [#(EXIT #(bad-arg base64-decode-bytevector ,@bad)) (catch (base64-decode-bytevector bad))]
+    [#(EXIT #(bad-arg base64url-decode-bytevector ,@bad)) (catch (base64url-decode-bytevector bad))]
+    [,bad (string->utf8 "VG9m Q==")]
+    [#(EXIT #(bad-arg base64-decode-bytevector ,@bad)) (catch (base64-decode-bytevector bad))]
+    [#(EXIT #(bad-arg base64url-decode-bytevector ,@bad)) (catch (base64url-decode-bytevector bad))]
+    [,bad (string->utf8 "YnVn====")]
+    [#(EXIT #(bad-arg base64-decode-bytevector ,@bad)) (catch (base64-decode-bytevector bad))]
+    [#(EXIT #(bad-arg base64url-decode-bytevector ,@bad)) (catch (base64url-decode-bytevector bad))]
+    [,bad (string->utf8 "YnVnY===")]
+    [#(EXIT #(bad-arg base64-decode-bytevector ,@bad)) (catch (base64-decode-bytevector bad))]
+    [#(EXIT #(bad-arg base64url-decode-bytevector ,@bad)) (catch (base64url-decode-bytevector bad))]
+    [,bad (string->utf8 "soBAD===")]
+    [#(EXIT #(bad-arg base64-decode-bytevector ,@bad)) (catch (base64-decode-bytevector bad))]
+    [#(EXIT #(bad-arg base64url-decode-bytevector ,@bad)) (catch (base64url-decode-bytevector bad))]
+    )
+   'ok))

--- a/src/swish/base64.ss
+++ b/src/swish/base64.ss
@@ -1,0 +1,202 @@
+#!chezscheme
+;; Copyright 2019 Beckman Coulter, Inc.
+;;
+;; Permission is hereby granted, free of charge, to any person
+;; obtaining a copy of this software and associated documentation
+;; files (the "Software"), to deal in the Software without
+;; restriction, including without limitation the rights to use, copy,
+;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;; of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be
+;; included in all copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+(library (swish base64)
+ (export
+   base64-decode-bytevector
+   base64-encode-bytevector
+   base64url-decode-bytevector
+   base64url-encode-bytevector
+   )
+  (import
+   (scheme)
+   (swish erlang)
+   (swish io))
+
+  ;; see RFC 4648 https://tools.ietf.org/html/rfc4648
+
+  (define pad (char->integer #\=))
+  (define (pad? b) (fx= b pad))
+
+  (define (base64-encoded-size in-size)
+    (let-values ([(d m) (fxdiv-and-mod in-size 3)])
+      (fx* 4 (if (fx= m 0) d (fx+ d 1)))))
+
+  (define (base64-decoded-size in-size)
+    (fx* 3 (fx/ in-size 4)))
+
+  (define-syntax define-encoding
+    (let ()
+      (define (make-encode ranges)
+        (let-values ([(op get-bv) (open-bytevector-output-port)])
+          (define add-range
+            (lambda (s)
+              (match (map char->integer (string->list s))
+                [(,i) (put-u8 op i)]
+                [(,start ,end)
+                 (do ([i start (+ i 1)]) ((> i end))
+                   (put-u8 op i))])))
+          (for-each add-range ranges)
+          (get-bv)))
+      (define (encode->decode bv)
+        (let ([end (bytevector-length bv)]
+              [out (make-bytevector 256 -1)])
+          (do ([i 0 (fx1+ i)]) ((fx= i end))
+            (bytevector-u8-set! out (bytevector-u8-ref bv i) i))
+          out))
+      (lambda (x)
+        (syntax-case x ()
+          [(_ encode decode str ...)
+           (andmap string? (datum (str ...)))
+           (let ([encode-bv (make-encode (datum (str ...)))])
+             #`(begin
+                 (define encode '#,encode-bv)
+                 (define decode '#,(encode->decode encode-bv))))]))))
+
+  (define-encoding base64-encoding base64-decoding "AZ" "az" "09" "+" "/")
+  (define-encoding base64url-encoding base64url-decoding "AZ" "az" "09" "-" "_")
+
+  ;; dump encoding tables in the orientation used in RFC 4648
+  #;
+  (define (dump x)
+    (do ([r 0 (+ r 1)]) ((> r 16))
+      (do ([c 0 (+ c 17)]) ((> c 51))
+        (let ([i (+ r c)])
+          (when (< i (bytevector-length x))
+            (printf "~v@a ~a" (if (= c 0) 10 14) i (integer->char (bytevector-u8-ref x i))))))
+      (newline)))
+
+  (define (base64-decode-bytevector bv)
+    (arg-check 'base64-decode-bytevector [bv bytevector?])
+    (base64-decode bv base64-decoding 'base64-decode-bytevector))
+
+  (define (base64url-decode-bytevector bv)
+    (arg-check 'base64url-decode-bytevector [bv bytevector?])
+    (base64-decode bv base64url-decoding 'base64url-decode-bytevector))
+
+  ;; RFC 4648 recommends rejecting bad inputs
+  (define (base64-decode bv decoding who)
+    (define input-size (#3%bytevector-length bv))
+    (unless (fxzero? (fxremainder input-size 4))
+      (bad-arg who bv))
+    (if (fx= input-size 0)
+        '#vu8()
+        (let ([end (fx- input-size 4)]
+              [out (make-bytevector (base64-decoded-size input-size))])
+          (define (get i offset) (#3%bytevector-s8-ref bv (fx+ i offset)))
+          (define (check bits) (if (fx>= bits 0) bits (bad-arg who bv)))
+          (define (shift bits offset) (#3%fxsll bits (- 24 (* 6 (+ offset 1)))))
+          (define (extract-bytes i) (values (get i 0) (get i 1) (get i 2) (get i 3)))
+          (define (->bits byte) (#3%bytevector-s8-ref decoding byte))
+          (define (pad-or-bits byte) (if (fx= byte pad) 0 (->bits byte)))
+          (define (check-get-bits byte) (check (->bits byte)))
+          (define (combine check-get-bits a b c d)
+            (#3%fxlogor
+             (shift (check (->bits a)) 0)
+             (shift (check-get-bits b) 1)
+             (shift (check-get-bits c) 2)
+             (shift (check-get-bits d) 3)))
+          (define (finish i j)
+            (let-values ([(a b c d) (extract-bytes i)])
+              (#3%bytevector-u24-set! out j (combine pad-or-bits a b c d) 'big)
+              (cond
+               [(pad? b) (bad-arg who bv)] ;; already checked a
+               [(pad? c)
+                (unless (pad? d) (bad-arg who bv))
+                (#3%bytevector-truncate! out (fx+ j 1))]
+               [(pad? d)
+                (#3%bytevector-truncate! out (fx+ j 2))])))
+          (do ([i 0 (fx+ i 4)] [j 0 (fx+ j 3)]) ((fx= i end) (finish i j))
+            (let-values ([(a b c d) (extract-bytes i)])
+              (#3%bytevector-u24-set! out j (combine check-get-bits a b c d) 'big)))
+          out)))
+
+  (define (base64-encode-bytevector bv)
+    (arg-check 'base64-encode-bytevector [bv bytevector?])
+    (base64-encode bv base64-encoding))
+
+  (define (base64url-encode-bytevector bv)
+    (arg-check 'base64url-encode-bytevector [bv bytevector?])
+    (base64-encode bv base64url-encoding))
+
+  (define (base64-encode bv encoding)
+    (define input-size (#3%bytevector-length bv))
+    (if (fx= input-size 0)
+        '#vu8()
+        (let ([out (make-bytevector (base64-encoded-size input-size))])
+          (define (write-encoded base in)
+            (let ([bits (#3%bytevector-u24-ref bv in 'big)])
+              (meta-cond
+               [(< (integer-length (most-positive-fixnum)) 32)
+                (#3%bytevector-u16-set! out base
+                  (#3%fxlogor
+                   (#3%fxsll (translate bits 3/4) 8)
+                   (#3%fxsll (translate bits 2/4) 0))
+                  'big)
+                (#3%bytevector-u16-set! out (fx+ base 2)
+                  (#3%fxlogor
+                   (#3%fxsll (translate bits 1/4) 8)
+                   (#3%fxsll (translate bits 0/4) 0))
+                  'big)]
+               [else
+                (#3%bytevector-u32-set! out base
+                  (#3%fxlogor
+                   (#3%fxsll (translate bits 3/4) 24)
+                   (#3%fxsll (translate bits 2/4) 16)
+                   (#3%fxsll (translate bits 1/4) 8)
+                   (#3%fxsll (translate bits 0/4) 0))
+                  'big)])))
+          (define (write-padded base bits n)
+            (set base 0 bits 3/4)
+            (set base 1 bits 2/4)
+            (if (= n 1)
+                (set base 2 bits 1/4)
+                (#3%bytevector-u8-set! out (#3%fx+ base 2) pad))
+            (#3%bytevector-u8-set! out (#3%fx+ base 3) pad))
+          (define (set base offset bits shift)
+            (#3%bytevector-u8-set! out (#3%fx+ base offset)
+              (translate bits shift)))
+          (define (translate bits shift)
+            (#3%bytevector-u8-ref encoding
+              (#3%fxlogand (#3%fxsra bits (* 24 shift)) #x3F)))
+          (define (get-bits i)
+            (#3%fxlogor
+             (get i 16)
+             (get (#3%fx+ i 1) 8)
+             (get (#3%fx+ i 2) 0)))
+          (define (get i shift)
+            (if (#3%fx>= i input-size)
+                0
+                (#3%fxsll (#3%bytevector-u8-ref bv i) shift)))
+          (let loop ([in 0] [base 0])
+            (let ([next (#3%fx+ in 3)])
+              (cond
+               [(#3%fx< next input-size)
+                (write-encoded base in)
+                (loop next (#3%fx+ base 4))]
+               [(#3%fx= next input-size)
+                (write-encoded base in)]
+               [else
+                (write-padded base (get-bits in) (- next input-size))])))
+          out)))
+
+)

--- a/src/swish/digest.ms
+++ b/src/swish/digest.ms
@@ -1,0 +1,385 @@
+;; Copyright 2019 Beckman Coulter, Inc.
+;;
+;; Permission is hereby granted, free of charge, to any person
+;; obtaining a copy of this software and associated documentation
+;; files (the "Software"), to deal in the Software without
+;; restriction, including without limitation the rights to use, copy,
+;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;; of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be
+;; included in all copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+(import
+ (scheme)
+ (swish digest)
+ (swish imports)
+ (swish mat)
+ (swish testing)
+ )
+
+(define-syntax foreach
+  (syntax-rules ()
+    [(_ ([v ls] ...) e0 e1 ...)
+     (for-each (lambda (v ...) e0 e1 ...) ls ...)]))
+
+(define digest-algorithms
+  (if (eq? default-digest-provider (current-digest-provider))
+      '(sha1)
+      '(md5 sha1 sha256 sha384 sha512)))
+
+(define sample
+  (case-lambda
+   [() (string->utf8 "The quick brown fox jumps over the lazy dog.")]
+   [(digest)
+    (hex-string->hash
+     (match digest
+       [md5 "e4d909c290d0fb1ca068ffaddf22cbd0"]
+       [sha1 "408d94384216f890ff7a0c3528e8bed1e0b01621"]
+       [sha256 "ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c"]
+       [sha384 "ed892481d8272ca6df370bf706e4d7bc1b5739fa2177aae6c50e946678718fc67a7af2819a021c2fc34e91bdb63409d7"]
+       [sha512 "91ea1245f20d46ae9a037a989f54f1f790f0a47607eeb8a14d12890cea77a1bbc6c7ed9cf205e67b7f2b8fd4c7dfd3a7a8617e45f3c463d481c7e586c39ac1ed"]))]
+   [(digest hmac-key)
+    (hex-string->hash
+     (match hmac-key
+       ["asparagus"
+        (match digest
+          [md5 "726999b3be39d760e89dc6cec47ea7c6"]
+          [sha1 "ba1b3fd9e0d1ae3f1c90bb1d26e8d19784f5ed13"]
+          [sha256 "ece8d02d8bca1f93bdef2a584b4ecd8f01d61f3f77458fbd998a81520a65d048"]
+          [sha384 "b794dc7999b3bd804a2441acb1d8915856532ad6c297dd34475b2ad170556284b8f098eb56da462f98dc43fae8ce436c"]
+          [sha512 "9587cd2fcabb2405fb3055e53bdc507bc313310c2647486e1392a5e4c6ee0fb2fed19452249b52fab1e3920e03e5c99a2177feea248761b3f6a2b886de608447"])]
+       ["tetrahedron"
+        (match digest
+          [md5 "31653c0d334dae8e362336e3a52d8906"]
+          [sha1 "2da0332017db8de2abd14dc2cd56aec3bba57cbd"]
+          [sha256 "b80f269097184bbee705f4c8fc6f0239356d9818b637d838b1d870b67d959308"]
+          [sha384 "5f0e27e31e8be58c6e15d8d596f0f1a4122e4a24325592f3856d3e34893257dca04730eebc8da1312dd30012ba7e4f5b"]
+          [sha512 "e4995a245974d92e697ac43646eb73fbfb1f2d48544e57c75e4c76c93695c8d501b4d563eb3e6c7a10bc755c869978c69c14250ad6c929cc5705d284773cab7e"])]))]))
+
+(define expected-provider-name (digest-provider-name (current-digest-provider)))
+(define verbose (make-parameter #f))
+
+(define (by-chunk hasher data chunk-size)
+  (let ([len (bytevector-length data)])
+    (do ([i 0 (+ i chunk-size)]) ((>= i len))
+      (let ([size (min chunk-size (- len i))])
+        (when (verbose)
+          (printf " (hash! hasher data i=~s size=~s)\n" i size))
+        (hash! hasher data i size)))
+    (get-hash hasher)))
+
+(define (exercise alg key data expected)
+  (match-let*
+   ([,hasher (open-digest alg key)]
+    [,@expected-provider-name (digest-provider-name hasher)]
+    [,_ (hash! hasher data)]
+    [,@expected (get-hash hasher)]
+    [ok (do ([i 1 (+ i 1)]) ((= i (bytevector-length data)) 'ok)
+          (match (by-chunk hasher data i)
+            [,@expected 'ok]))]
+    [,hasher (open-digest alg key (current-digest-provider))]
+    [,_ (hash! hasher data)]
+    [,@expected (get-hash hasher)])
+   'ok))
+
+(mat digest ()
+  (define (get-hex digest)
+    (match-let* ([,@expected-provider-name (digest-provider-name digest)])
+      (hash->hex-string (get-hash digest))))
+  (foreach ([alg digest-algorithms])
+    (match-let*
+     ([,input (sample)]
+      [,expected (sample alg)]
+      [ok (exercise alg #f input expected)]
+      [ok (if (symbol? alg)
+              (exercise (string-upcase (symbol->string alg)) #f input expected)
+              'ok)])
+     'ok))
+  (match-let*
+   ([,empty-bv (make-bytevector 0)]
+    [,hash-empty-bv
+     (lambda (alg)
+       (let ([digest (open-digest alg)])
+         (hash! digest empty-bv)
+         (get-hex digest)))]
+    ["da39a3ee5e6b4b0d3255bfef95601890afd80709"
+     (get-hex (open-digest 'sha1))]
+    ["da39a3ee5e6b4b0d3255bfef95601890afd80709"
+     (hash-empty-bv 'sha1)])
+   (unless (eq? default-digest-provider (current-digest-provider))
+     (match-let*
+      (["d41d8cd98f00b204e9800998ecf8427e"
+        (get-hex (open-digest 'md5))]
+       ["d41d8cd98f00b204e9800998ecf8427e"
+        (hash-empty-bv 'md5)]
+       ["e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        (get-hex (open-digest 'sha256))]
+       ["e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        (hash-empty-bv 'sha256)]
+       ["38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
+        (get-hex (open-digest 'sha384))]
+       ["38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
+        (hash-empty-bv 'sha384)]
+       ["cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        (get-hex (open-digest 'sha512))]
+       ["cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        (hash-empty-bv 'sha512)])
+      'ok))
+   'ok))
+
+(unless (eq? default-digest-provider (current-digest-provider))
+  (mat hmac-digest ()
+    (foreach ([hmac-key '("asparagus" "tetrahedron")])
+      (foreach ([alg digest-algorithms])
+        (match-let*
+         ([,input (sample)]
+          [,expected (sample alg hmac-key)]
+          [,hmac-key (string->utf8 hmac-key)]
+          [ok (exercise alg hmac-key input expected)]
+          [ok (if (symbol? alg)
+                  (exercise (string-upcase (symbol->string alg)) hmac-key input expected)
+                  'ok)])
+         'ok)))))
+
+(mat hex-string ()
+  (define max-size (expt 2 12))
+  (define random-bytevector
+    (with-interrupts-disabled
+     (parameterize ([random-seed 4294967295])
+       (let ([bv (make-bytevector max-size)])
+         (do ([i 0 (fx+ i 1)]) ((fx= i max-size))
+           (bytevector-u8-set! bv i (random 256)))
+         bv))))
+  (do ([i 0 (+ i 7)]) ((> i max-size))
+    (match-let*
+     ([,input (make-bytevector i)]
+      [,_ (bytevector-copy! random-bytevector (- max-size i 1) input 0 i)]
+      [,hex-string (hash->hex-string input)]
+      [#t (or (equal? input (hex-string->hash hex-string)) hex-string)]
+      [,hex-string (string-upcase hex-string)]
+      [#t (or (equal? input (hex-string->hash hex-string)) hex-string)])
+     'ok))
+  (match-let*
+   ([,empty-bv #vu8(#xda #x39 #xa3 #xee #x5e #x6b #x4b #xd #x32 #x55 #xbf
+                     #xef #x95 #x60 #x18 #x90 #xaf #xd8 #x7 #x9)]
+    ["da39a3ee5e6b4b0d3255bfef95601890afd80709" (hash->hex-string empty-bv)]
+    [,@empty-bv (hex-string->hash "da39a3ee5e6b4b0d3255bfef95601890aFD80709")])
+   'ok))
+
+(mat bytevector->hex-string ()
+  (match-let*
+   ([,bv (string->utf8 "This is only a test.")]
+    ["aa5ec50ae51153ae2932a23ecd006dee613403c2"
+     (bytevector->hex-string bv 'sha1)]
+    ["aa5ec50ae51153ae2932a23ecd006dee613403c2"
+     (bytevector->hex-string bv 'sha1 1)]
+    ["aa5ec50ae51153ae2932a23ecd006dee613403c2"
+     (bytevector->hex-string bv 'sha1 8)])
+   (unless (eq? default-digest-provider (current-digest-provider))
+     (match-let*
+      (["3d57d0d7d5817e272a533c8ef6e3be9d"
+        (bytevector->hex-string bv 'md5)]
+       ["3d57d0d7d5817e272a533c8ef6e3be9d"
+        (bytevector->hex-string bv 'md5 1)]
+       ["3d57d0d7d5817e272a533c8ef6e3be9d"
+        (bytevector->hex-string bv 'md5 5)]
+       ["9973a0d1729566f34377e90cea4a40c0c1106d55baf2a3e0127ddcad4015962d"
+        (bytevector->hex-string bv 'sha256)]
+       ["9973a0d1729566f34377e90cea4a40c0c1106d55baf2a3e0127ddcad4015962d"
+        (bytevector->hex-string bv 'sha256 3)]
+       ["04133564638c82a3ed481f565c1a70e95699a9221a44e3f9bcdc4bdd927f22e79365311fd345623c4c55c3dfa9948b33"
+        (bytevector->hex-string bv 'sha384)]
+       ["04133564638c82a3ed481f565c1a70e95699a9221a44e3f9bcdc4bdd927f22e79365311fd345623c4c55c3dfa9948b33"
+        (bytevector->hex-string bv 'sha384 2)]
+       ["07164354d2facc5518205e345e0d276a5477fb6a665e70b98f3b1b4836e17d59aa0ad1113d3a330f67cf81e13ee0105c69e50e3b09ea5bc6f85840bc9e6c3ca2"
+        (bytevector->hex-string bv 'sha512)]
+       ["07164354d2facc5518205e345e0d276a5477fb6a665e70b98f3b1b4836e17d59aa0ad1113d3a330f67cf81e13ee0105c69e50e3b09ea5bc6f85840bc9e6c3ca2"
+        (bytevector->hex-string bv 'sha512 7)])
+      'ok))
+   'ok))
+
+(mat errors ()
+  (define bip (open-bytevector-input-port (string->utf8 "")))
+  (define-values (bop get-bop) (open-bytevector-output-port))
+  (define-syntax fails-with
+    (syntax-rules ()
+      [(_ expr string)
+       (match-let*
+        ([#(EXIT ,reason) (catch expr)]
+         [string (swish-exit-reason->english reason)])
+        'ok)]))
+  (match-let*
+   ([,@expected-provider-name (digest-provider-name (open-digest 'sha1))]
+    [#(EXIT #(bad-arg get-hash browns)) (catch (get-hash 'browns))]
+    [#(EXIT #(bad-arg hash! -5)) (catch (hash! (open-digest 'sha1) (string->utf8 "foo") -5 3))]
+    [#(EXIT #(bad-arg hash! 0)) (catch (hash! (open-digest 'sha1) (string->utf8 "foo") 1 0))]
+    [#(EXIT #(bad-arg hash! 123)) (catch (hash! (open-digest 'sha1) 123))]
+    [#(EXIT #(bad-arg hash! 123)) (catch (hash! 123 (string->utf8 "foo")))]
+    [#(EXIT #(bad-arg hash->hex-string #f)) (catch (hash->hex-string #f))]
+    [#(EXIT #(bad-arg hash->hex-string "tag")) (catch (hash->hex-string "tag"))]
+    [#(EXIT #(bad-arg hex-string->hash "tag")) (catch (hex-string->hash "tag"))]
+    [#(EXIT ,alg-reason) (catch (open-digest "!exist"))]
+    [ok (match alg-reason
+          [#(bad-arg open-digest "!exist") 'ok]
+          [#(io-error ,_ ,_ ,_)
+           (guard (not (eq? default-digest-provider (current-digest-provider))))
+           'ok])]
+    [#(EXIT ,@alg-reason) (catch (open-digest "!exist" "foo"))]
+    [#(EXIT #(bad-arg open-digest parakeet)) (catch (open-digest 'sha1 'parakeet))]
+    [#(EXIT #(bad-arg close-digest ion)) (catch (close-digest 'ion))]
+    [#(EXIT #(bad-arg bytevector->hex-string not-bv)) (catch (bytevector->hex-string 'not-bv 'sha1))]
+    [#(EXIT ,bv-alg-reason) (catch (bytevector->hex-string #vu8(1) 'not-alg))]
+    [ok (match bv-alg-reason
+          [#(bad-arg bytevector->hex-string not-alg) 'ok]
+          [#(io-error ,_ ,_ ,_)
+           (guard (not (eq? default-digest-provider (current-digest-provider))))
+           'ok])]
+    [#(EXIT #(bad-arg bytevector->hex-string 0)) (catch (bytevector->hex-string #vu8(1 2 3) 'sha1 0))]
+    [#(EXIT #(bad-arg bytevector->hex-string -1)) (catch (bytevector->hex-string #vu8(1 2 3) 'sha1 -1))]
+    [#(EXIT ,reason) (catch (hash! (open-digest 'sha1) #vu8(1 2 3 4 5) 3 7))]
+    [,all-ok (map (lambda (x) 'ok) digest-algorithms)]
+    [,d* (map open-digest digest-algorithms)]
+    [ok (begin (for-each close-digest d*) (for-each close-digest d*) 'ok)]
+    [,@all-ok
+     (map
+      (lambda (digest)
+        (fails-with (hash! digest (sample))
+          "Exception in hash!: cannot write to closed digest."))
+      d*)]
+    [,@all-ok
+     (map
+      (lambda (digest)
+        (fails-with (get-hash digest)
+          "Exception in get-hash: cannot read from closed digest."))
+      d*)]
+    [#(EXIT #(bad-arg open-digest tofu)) (catch (open-digest 'sha1 #f 'tofu))]
+    [#(EXIT #(bad-arg make-digest-provider "foo"))
+     (catch (make-digest-provider "foo" car cdr cons list))]
+    [#(EXIT #(bad-arg make-digest-provider "bar"))
+     (catch (make-digest-provider 'foo "bar" cdr cons list))]
+    [#(EXIT #(bad-arg make-digest-provider "bar"))
+     (catch (make-digest-provider 'foo car "bar" cons list))]
+    [#(EXIT #(bad-arg make-digest-provider "bar"))
+     (catch (make-digest-provider 'foo car cdr "bar" list))]
+    [#(EXIT #(bad-arg make-digest-provider "bar"))
+     (catch (make-digest-provider 'foo car cdr cons "bar"))]
+    [#(EXIT #(bad-arg open-digest 123))
+     (catch (open-digest 123))]
+    [#(EXIT #(bad-arg open-digest not-string-or-bytevector))
+     (catch (open-digest 'sha1 'not-string-or-bytevector))]
+    [#(EXIT #(bad-arg open-digest "not supported by default provider"))
+     (catch (open-digest 'sha1 "not supported by default provider"
+              default-digest-provider))]
+    [#(EXIT #(bad-arg current-digest-provider xyz))
+     (catch (current-digest-provider 'xyz))]
+    [#(EXIT #(bad-arg hex-string->hash cursed))
+     (catch (hex-string->hash 'cursed))]
+    [#(EXIT #(bad-arg hex-string->hash "cursed"))
+     (catch (hex-string->hash "cursed"))]
+    [#(EXIT #(io-error open-digest "fake_foreign_entry" 123))
+     (catch
+      (open-digest 'anything #f
+        (make-digest-provider 'bad-provider
+          (lambda (algorithm hmac-key)
+            ;; always return an error pair
+            '("fake_foreign_entry" . 123))
+          values
+          values
+          values)))]
+    )
+   (unless (eq? default-digest-provider (current-digest-provider))
+     (match-let*
+      ([,h* (map (lambda (alg) (open-digest alg "amethyst")) digest-algorithms)]
+       [ok (begin (for-each close-digest h*) (for-each close-digest h*) 'ok)]
+       [,@all-ok
+        (map
+         (lambda (digest)
+           (fails-with (hash! digest (sample))
+             "Exception in hash!: cannot write to closed digest."))
+         h*)]
+       [,@all-ok
+        (map
+         (lambda (digest)
+           (fails-with (get-hash digest)
+             "Exception in get-hash: cannot read from closed digest."))
+         h*)])
+      'ok))
+   'ok))
+
+(mat sha1 ()
+  (define-foreign osi_open_SHA1)
+  (define-foreign osi_hash_data (digest uptr) (bv ptr) (start_index size_t) (size unsigned-32))
+  (define-foreign osi_get_SHA1 (digest uptr))
+  (define osi_close_SHA1* (foreign-procedure "osi_close_SHA1" (uptr) void))
+  (define ctxt
+    (match (osi_open_SHA1)
+      [,ctxt (guard (not (pair? ctxt))) ctxt]))
+  (on-exit (osi_close_SHA1* ctxt)
+    (match-let*
+     ([(osi_hash_data . ,@UV_EINVAL) (osi_hash_data* ctxt "not a bytevector" 0 0)]
+      [(osi_hash_data . ,@UV_EINVAL) (osi_hash_data* ctxt #vu8(1 2 3) 3 1)]
+      [(osi_hash_data . ,@UV_EINVAL) (osi_hash_data* ctxt #vu8(1 2 3) 1 3)])
+     'ok)
+    (let ([bv (string->utf8 "The quick brown fox jumps over the lazy dog.")])
+      (define (build n)
+        (call-with-bytevector-output-port
+         (lambda (op)
+           (do ([i 0 (+ i 1)]) ((fx= i n))
+             (put-bytevector op bv)))))
+      (define (repeat n)
+        (do ([n n (- n 1)]
+             [buffer (build n)]
+             [start-index 0 (+ start-index size)]
+             [size (bytevector-length bv)])
+            ((eqv? n 0) (hash->hex-string (osi_get_SHA1 ctxt)))
+          (osi_hash_data ctxt buffer start-index size)))
+      (define (concat n) (bytevector->hex-string (build n) 'sha1))
+      (assert (string=? "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+                (repeat 0) (concat 0)))
+      (assert (string=? "408d94384216f890ff7a0c3528e8bed1e0b01621"
+                (repeat 1) (concat 1)))
+      (assert (string=? "8f5f36a551598bfe05ddc29320af6a7199c83bea"
+                (repeat 2) (concat 2)))
+      (assert (string=? "245ec449184e3121811c7a1506364c2e7f450a69"
+                (repeat 10) (concat 10)))
+      (assert (string=? "305aab2f9e6e5fac89f8c0cb40d89337be9ed4f0"
+                (repeat 13) (concat 13)))
+      (assert (string=? "3673e790a691891b34a41ba0f277ac25e0675abb"
+                (repeat 16) (concat 16))))))
+
+(mat digest-management ()
+  (define (get-print-digests)
+    (let ([os (open-output-string)])
+      (print-digests os)
+      (get-output-string os)))
+  (match-let*
+   ([,_ (gc)]
+    [0 (digest-count)]
+    [,n 12]
+    [,ds (map open-digest (make-list n 'sha1))]
+    [,@n (digest-count)]
+    [,pat
+     (format "(?:  [0-9]+: ~a SHA1 opened [0-9]+\n){~a}"
+       (digest-provider-name (current-digest-provider))
+       n)]
+    [(,str)
+     (guard (string? str))
+     (pregexp-match pat (get-print-digests))]
+    [,_ (gc)]
+    [0 (digest-count)]
+    ["" (get-print-digests)]
+    ["#<digest-provider swish>" (format "~s" default-digest-provider)]
+    ["#<SHA1 digest>" (format "~s" (open-digest 'sha1))]
+    )
+   'ok))

--- a/src/swish/digest.ss
+++ b/src/swish/digest.ss
@@ -1,0 +1,272 @@
+;; Copyright 2019 Beckman Coulter, Inc.
+;;
+;; Permission is hereby granted, free of charge, to any person
+;; obtaining a copy of this software and associated documentation
+;; files (the "Software"), to deal in the Software without
+;; restriction, including without limitation the rights to use, copy,
+;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;; of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be
+;; included in all copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+#!chezscheme
+(library (swish digest)
+  (export
+   bytevector->hex-string
+   close-digest
+   current-digest-provider
+   default-digest-provider
+   digest-count
+   digest-provider-name
+   get-hash
+   hash!
+   hash->hex-string
+   hex-string->hash
+   make-digest-provider
+   open-digest
+   print-digests
+   )
+  (import
+   (scheme)
+   (swish erlang)
+   (swish foreign)
+   (swish io)
+   (swish meta)
+   )
+
+  (define-record-type (digest-provider $make-digest-provider digest-provider?)
+    (nongenerative)
+    (fields
+     (immutable name)
+     (immutable open)
+     (immutable hash!)
+     (immutable get)
+     (immutable close)))
+
+  (define (make-digest-provider name open hash! get close)
+    (arg-check 'make-digest-provider
+      [name symbol?]
+      [open procedure?]
+      [hash! procedure?]
+      [get procedure?]
+      [close procedure?])
+    ($make-digest-provider name open hash! get close))
+
+  (define-record-type digest (parent digest-provider)
+    (nongenerative)
+    (fields
+     (mutable ctx)
+     (immutable algorithm)
+     (immutable create-time)))
+
+  (define-foreign osi_open_SHA1)
+  (define-foreign osi_hash_data (digest uptr) (bv ptr) (start_index size_t) (size unsigned-32))
+  (define-foreign osi_get_SHA1 (digest uptr))
+  (define osi_close_SHA1* (foreign-procedure "osi_close_SHA1" (uptr) void))
+  (define (osi_open_digest algorithm hmac-key)
+    (cond
+     [(not (equal? algorithm "SHA1")) 'algorithm]
+     [hmac-key 'hmac-key]
+     [else (osi_open_SHA1)]))
+
+  (define default-digest-provider
+    (make-digest-provider 'swish
+      osi_open_digest
+      osi_hash_data
+      osi_get_SHA1
+      osi_close_SHA1*))
+
+  (define current-digest-provider
+    (make-process-parameter
+     default-digest-provider
+     (lambda (x)
+       (unless (digest-provider? x)
+         (bad-arg 'current-digest-provider x))
+       x)))
+
+  (define digests
+    (make-foreign-handle-guardian 'digests
+      digest-ctx
+      digest-ctx-set!
+      digest-create-time
+      (lambda (d) ($close-digest d))
+      (lambda (op d ctx)
+        (fprintf op "  ~d: ~a ~a opened ~d\n" ctx
+          (digest-provider-name d)
+          (digest-algorithm d)
+          (digest-create-time d)))))
+
+  (define digest-count (foreign-handle-count 'digests))
+  (define print-digests (foreign-handle-print 'digests))
+
+  (define (open-digest* who algorithm hmac-key provider)
+    (let* ([digest-name
+            (cond
+             [(string? algorithm) algorithm]
+             [(symbol? algorithm) (string-upcase (symbol->string algorithm))]
+             [else (bad-arg who algorithm)])]
+           [maybe-hmac
+            (cond
+             [(or (not hmac-key) (bytevector? hmac-key)) hmac-key]
+             [(string? hmac-key) (string->utf8 hmac-key)]
+             [else (bad-arg who hmac-key)])])
+      (with-interrupts-disabled
+       (match ((digest-provider-open provider) digest-name maybe-hmac)
+         [,ctx
+          (guard (integer? ctx))
+          (@make-digest provider ctx digest-name)]
+         [algorithm (bad-arg who algorithm)]
+         [hmac-key (bad-arg who hmac-key)]
+         [(,whence . ,err) (io-error who whence err)]))))
+
+  (define (@make-digest provider ctx algorithm)
+    (let ([d (make-digest
+              (digest-provider-name provider)
+              (digest-provider-open provider)
+              (digest-provider-hash! provider)
+              (digest-provider-get provider)
+              (digest-provider-close provider)
+              ctx
+              algorithm
+              (erlang:now))])
+      (digests d ctx)))
+
+  (define ($close-digest digest)
+    (with-interrupts-disabled
+     (let ([ctx (digest-ctx digest)])
+       (when ctx
+         (digests digest #f)
+         ((digest-provider-close digest) ctx)
+         (void)))))
+
+  (define (close-digest digest)
+    (arg-check 'close-digest [digest digest?])
+    ($close-digest digest))
+
+  (define (closed-digest-error who what digest)
+    (errorf who "cannot ~a closed ~a" what
+      (record-type-name (record-rtd digest))))
+
+  (define open-digest
+    (case-lambda
+     [(algorithm)
+      (open-digest algorithm #f)]
+     [(algorithm hmac-key)
+      (open-digest* 'open-digest algorithm hmac-key (current-digest-provider))]
+     [(algorithm hmac-key provider)
+      (unless (digest-provider? provider)
+        (bad-arg 'open-digest provider))
+      (open-digest* 'open-digest algorithm hmac-key provider)]))
+
+  (define (help-hash! digest data start-index size)
+    (arg-check 'hash! [digest digest?])
+    (with-interrupts-disabled
+     (let ([ctx (digest-ctx digest)])
+       (if ctx
+           ((digest-provider-hash! digest) ctx data start-index size)
+           (closed-digest-error 'hash! "write to" digest))
+       (void))))
+
+  (define (fixnum>= lower-bound)
+    (lambda (n)
+      (and (fixnum? n) (fx>= n lower-bound))))
+
+  (define hash!
+    (case-lambda
+     [(digest data)
+      (arg-check 'hash! [data bytevector?])
+      (help-hash! digest data 0 (bytevector-length data))]
+     [(digest data start-index size)
+      (arg-check 'hash!
+        [data bytevector?]
+        [start-index (fixnum>= 0)]
+        [size (fixnum>= 1)])
+      (help-hash! digest data start-index size)]))
+
+  (define (get-hash digest)
+    (arg-check 'get-hash [digest digest?])
+    (with-interrupts-disabled
+     (let ([ctx (digest-ctx digest)])
+       (if ctx
+           ((digest-provider-get digest) ctx)
+           (closed-digest-error 'get-hash "read from" digest)))))
+
+  (define (hash->hex-string bv)
+    (define digits "0123456789abcdef")
+    (arg-check 'hash->hex-string [bv bytevector?])
+    (let* ([len (#3%bytevector-length bv)]
+           [s (make-string (fx* 2 len))])
+      (do ([i 0 (#3%fx+ i 1)]) ((#3%fx= i len))
+        (let ([j (#3%fx* i 2)]
+              [b (#3%bytevector-u8-ref bv i)])
+          (let-values ([(hi lo) (values (#3%fxsrl b 4) (#3%fxlogand b #xF))])
+            (#3%string-set! s j (#3%string-ref digits hi))
+            (#3%string-set! s (#3%fx+ j 1) (#3%string-ref digits lo)))))
+      s))
+
+  (define-syntax char-value
+    (syntax-rules (else)
+      [(_ ignore [else e0 e1 ...]) (begin e0 e1 ...)]
+      [(_ expr [(lo n hi) val] more ...)
+       (let* ([c expr] [x (#3%char->integer c)])
+         (if (#3%fx<= (char->integer lo) x (char->integer hi))
+             (let ([n (#3%fx- x (char->integer lo))]) val)
+             (char-value c more ...)))]))
+
+  (define (hex-string->hash s)
+    (define (bad-input) (bad-arg 'hex-string->hash s))
+    (arg-check 'hex-string->hash [s string?])
+    (let ([len (string-length s)])
+      (unless (even? len) (bad-input))
+      (let ([bv (make-bytevector (fx/ len 2))])
+        (define (hex-val s i)
+          (char-value (#3%string-ref s i)
+            [(#\0 n #\9) n]
+            [(#\a n #\f) (fx+ 10 n)]
+            [(#\A n #\F) (fx+ 10 n)]
+            [else (bad-input)]))
+        (do ([i 0 (#3%fx+ i 2)]) ((#3%fx= i len))
+          (#3%bytevector-u8-set! bv (#3%fxsrl i 1)
+            (#3%fxlogor (#3%fxsll (hex-val s i) 4) (hex-val s (#3%fx+ i 1)))))
+        bv)))
+
+  (define default-block-size (expt 2 14)) ;; under .5ms on 2012 laptop
+  (define bytevector->hex-string
+    (case-lambda
+     [(bv algorithm) (bytevector->hex-string bv algorithm default-block-size)]
+     [(bv algorithm block-size)
+      (arg-check 'bytevector->hex-string
+        [bv bytevector?]
+        [block-size (lambda (x) (and (fixnum? x) (fx> x 0)))])
+      (let ([md (open-digest* 'bytevector->hex-string algorithm #f
+                 (current-digest-provider))])
+        (on-exit (close-digest md)
+          (let ([len (bytevector-length bv)])
+            (do ([i 0 (#3%fx+ i block-size)]) ((#3%fx>= i len))
+              (hash! md bv i (#3%fxmin block-size (#3%fx- len i)))))
+          (hash->hex-string (get-hash md))))]))
+
+  (record-writer (record-type-descriptor digest-provider)
+    (lambda (r p wr)
+      (display-string "#<digest-provider" p)
+      (let ([name (digest-provider-name r)])
+        (when name
+          (write-char #\space p)
+          (wr name p)))
+      (write-char #\> p)))
+
+  (record-writer (record-type-descriptor digest)
+    (lambda (r p wr)
+      (fprintf p "#<~a digest>" (digest-algorithm r))))
+  )

--- a/src/swish/imports.ss
+++ b/src/swish/imports.ss
@@ -29,6 +29,7 @@
     (swish app-core)
     (swish app-io)
     (swish application)
+    (swish base64)
     (swish cli)
     (swish db)
     (swish digest)

--- a/src/swish/imports.ss
+++ b/src/swish/imports.ss
@@ -31,6 +31,7 @@
     (swish application)
     (swish cli)
     (swish db)
+    (swish digest)
     (swish erlang)
     (swish errors)
     (swish event-mgr)

--- a/src/swish/osi.h
+++ b/src/swish/osi.h
@@ -32,6 +32,7 @@
 #include <malloc.h>
 #endif
 #include <string.h>
+#include "sha.h"
 #include "sqlite3.h"
 
 typedef struct {
@@ -88,6 +89,12 @@ EXPORT ptr osi_listen_tcp(const char* address, uint16_t port, ptr callback);
 EXPORT void osi_close_tcp_listener(uptr listener);
 EXPORT ptr osi_get_tcp_listener_port(uptr listener);
 EXPORT ptr osi_get_ip_address(uptr port);
+
+// Message Digest
+EXPORT ptr osi_open_SHA1();
+EXPORT ptr osi_hash_data(SHA1Context* ctxt, ptr bv, size_t start_index, uint32_t size);
+EXPORT ptr osi_get_SHA1(SHA1Context* ctxt);
+EXPORT void osi_close_SHA1(SHA1Context* ctxt);
 
 // SQLite
 EXPORT ptr osi_open_database(const char* filename, int flags, ptr callback);

--- a/src/swish/run.c
+++ b/src/swish/run.c
@@ -32,6 +32,7 @@ static void swish_init(void) {
   add_foreign(osi_bind_statement);
   add_foreign(osi_chmod);
   add_foreign(osi_clear_statement_bindings);
+  add_foreign(osi_close_SHA1);
   add_foreign(osi_close_database);
   add_foreign(osi_close_path_watcher);
   add_foreign(osi_close_port);
@@ -39,6 +40,7 @@ static void swish_init(void) {
   add_foreign(osi_connect_tcp);
   add_foreign(osi_exit);
   add_foreign(osi_finalize_statement);
+  add_foreign(osi_get_SHA1);
   add_foreign(osi_get_argv);
   add_foreign(osi_get_bytes_used);
   add_foreign(osi_get_callbacks);
@@ -57,6 +59,7 @@ static void swish_init(void) {
   add_foreign(osi_get_tcp_listener_port);
   add_foreign(osi_get_temp_directory);
   add_foreign(osi_get_time);
+  add_foreign(osi_hash_data);
   add_foreign(osi_init);
   add_foreign(osi_interrupt_database);
   add_foreign(osi_is_quantum_over);
@@ -66,6 +69,7 @@ static void swish_init(void) {
   add_foreign(osi_listen_tcp);
   add_foreign(osi_make_directory);
   add_foreign(osi_make_uuid);
+  add_foreign(osi_open_SHA1);
   add_foreign(osi_open_database);
   add_foreign(osi_open_fd);
   add_foreign(osi_open_file);

--- a/src/swish/sha-private.h
+++ b/src/swish/sha-private.h
@@ -1,0 +1,28 @@
+/************************ sha-private.h ************************/
+/***************** See RFC 6234 for details. *******************/
+#ifndef _SHA_PRIVATE__H
+#define _SHA_PRIVATE__H
+/*
+ * These definitions are defined in FIPS 180-3, section 4.1.
+ * Ch() and Maj() are defined identically in sections 4.1.1,
+ * 4.1.2, and 4.1.3.
+ *
+ * The definitions used in FIPS 180-3 are as follows:
+ */
+
+#ifndef USE_MODIFIED_MACROS
+#define SHA_Ch(x,y,z)        (((x) & (y)) ^ ((~(x)) & (z)))
+#define SHA_Maj(x,y,z)       (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
+#else /* USE_MODIFIED_MACROS */
+/*
+ * The following definitions are equivalent and potentially faster.
+ */
+
+#define SHA_Ch(x, y, z)      (((x) & ((y) ^ (z))) ^ (z))
+#define SHA_Maj(x, y, z)     (((x) & ((y) | (z))) | ((y) & (z)))
+
+#endif /* USE_MODIFIED_MACROS */
+
+#define SHA_Parity(x, y, z)  ((x) ^ (y) ^ (z))
+
+#endif /* _SHA_PRIVATE__H */

--- a/src/swish/sha.h
+++ b/src/swish/sha.h
@@ -1,0 +1,355 @@
+/**************************** sha.h ****************************/
+/***************** See RFC 6234 for details. *******************/
+/*
+   Copyright (c) 2011 IETF Trust and the persons identified as
+   authors of the code.  All rights reserved.
+
+   Redistribution and use in source and binary forms, with or
+   without modification, are permitted provided that the following
+   conditions are met:
+
+   - Redistributions of source code must retain the above
+     copyright notice, this list of conditions and
+     the following disclaimer.
+
+   - Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   - Neither the name of Internet Society, IETF or IETF Trust, nor
+     the names of specific contributors, may be used to endorse or
+     promote products derived from this software without specific
+     prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+   NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+   OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+   EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#ifndef _SHA_H_
+#define _SHA_H_
+
+/*
+ *  Description:
+ *      This file implements the Secure Hash Algorithms
+ *      as defined in the U.S. National Institute of Standards
+ *      and Technology Federal Information Processing Standards
+ *      Publication (FIPS PUB) 180-3 published in October 2008
+ *      and formerly defined in its predecessors, FIPS PUB 180-1
+ *      and FIP PUB 180-2.
+ *
+ *      A combined document showing all algorithms is available at
+ *              http://csrc.nist.gov/publications/fips/
+ *                     fips180-3/fips180-3_final.pdf
+ *
+ *      The five hashes are defined in these sizes:
+ *              SHA-1           20 byte / 160 bit
+ *              SHA-224         28 byte / 224 bit
+ *              SHA-256         32 byte / 256 bit
+ *              SHA-384         48 byte / 384 bit
+ *              SHA-512         64 byte / 512 bit
+ *
+ *  Compilation Note:
+ *    These files may be compiled with two options:
+ *        USE_32BIT_ONLY - use 32-bit arithmetic only, for systems
+ *                         without 64-bit integers
+ *
+ *        USE_MODIFIED_MACROS - use alternate form of the SHA_Ch()
+ *                         and SHA_Maj() macros that are equivalent
+ *                         and potentially faster on many systems
+ *
+ */
+
+#include <stdint.h>
+/*
+ * If you do not have the ISO standard stdint.h header file, then you
+ * must typedef the following:
+ *    name              meaning
+ *  uint64_t         unsigned 64-bit integer
+ *  uint32_t         unsigned 32-bit integer
+ *  uint8_t          unsigned 8-bit integer (i.e., unsigned char)
+ *  int_least16_t    integer of >= 16 bits
+ *
+ * See stdint-example.h
+ */
+
+#ifndef _SHA_enum_
+#define _SHA_enum_
+/*
+ *  All SHA functions return one of these values.
+ */
+enum {
+    shaSuccess = 0,
+    shaNull,            /* Null pointer parameter */
+    shaInputTooLong,    /* input data too long */
+    shaStateError,      /* called Input after FinalBits or Result */
+    shaBadParam         /* passed a bad parameter */
+};
+#endif /* _SHA_enum_ */
+
+/*
+ *  These constants hold size information for each of the SHA
+ *  hashing operations
+ */
+enum {
+    SHA1_Message_Block_Size = 64, SHA224_Message_Block_Size = 64,
+    SHA256_Message_Block_Size = 64, SHA384_Message_Block_Size = 128,
+    SHA512_Message_Block_Size = 128,
+    USHA_Max_Message_Block_Size = SHA512_Message_Block_Size,
+    SHA1HashSize = 20, SHA224HashSize = 28, SHA256HashSize = 32,
+    SHA384HashSize = 48, SHA512HashSize = 64,
+    USHAMaxHashSize = SHA512HashSize,
+
+    SHA1HashSizeBits = 160, SHA224HashSizeBits = 224,
+    SHA256HashSizeBits = 256, SHA384HashSizeBits = 384,
+    SHA512HashSizeBits = 512, USHAMaxHashSizeBits = SHA512HashSizeBits
+};
+
+/*
+ *  These constants are used in the USHA (Unified SHA) functions.
+ */
+typedef enum SHAversion {
+    SHA1, SHA224, SHA256, SHA384, SHA512
+} SHAversion;
+
+/*
+ *  This structure will hold context information for the SHA-1
+ *  hashing operation.
+ */
+typedef struct SHA1Context {
+    uint32_t Intermediate_Hash[SHA1HashSize/4]; /* Message Digest */
+
+    uint32_t Length_High;               /* Message length in bits */
+    uint32_t Length_Low;                /* Message length in bits */
+
+    int_least16_t Message_Block_Index;  /* Message_Block array index */
+                                        /* 512-bit message blocks */
+    uint8_t Message_Block[SHA1_Message_Block_Size];
+
+    int Computed;                   /* Is the hash computed? */
+    int Corrupted;                  /* Cumulative corruption code */
+} SHA1Context;
+
+/*
+ *  This structure will hold context information for the SHA-256
+ *  hashing operation.
+ */
+typedef struct SHA256Context {
+    uint32_t Intermediate_Hash[SHA256HashSize/4]; /* Message Digest */
+
+    uint32_t Length_High;               /* Message length in bits */
+    uint32_t Length_Low;                /* Message length in bits */
+
+    int_least16_t Message_Block_Index;  /* Message_Block array index */
+                                        /* 512-bit message blocks */
+    uint8_t Message_Block[SHA256_Message_Block_Size];
+    int Computed;                   /* Is the hash computed? */
+    int Corrupted;                  /* Cumulative corruption code */
+} SHA256Context;
+
+/*
+ *  This structure will hold context information for the SHA-512
+ *  hashing operation.
+ */
+typedef struct SHA512Context {
+#ifdef USE_32BIT_ONLY
+    uint32_t Intermediate_Hash[SHA512HashSize/4]; /* Message Digest  */
+    uint32_t Length[4];                 /* Message length in bits */
+#else /* !USE_32BIT_ONLY */
+    uint64_t Intermediate_Hash[SHA512HashSize/8]; /* Message Digest */
+    uint64_t Length_High, Length_Low;   /* Message length in bits */
+#endif /* USE_32BIT_ONLY */
+
+    int_least16_t Message_Block_Index;  /* Message_Block array index */
+                                        /* 1024-bit message blocks */
+    uint8_t Message_Block[SHA512_Message_Block_Size];
+
+    int Computed;                   /* Is the hash computed?*/
+    int Corrupted;                  /* Cumulative corruption code */
+} SHA512Context;
+
+/*
+ *  This structure will hold context information for the SHA-224
+ *  hashing operation.  It uses the SHA-256 structure for computation.
+ */
+typedef struct SHA256Context SHA224Context;
+
+/*
+ *  This structure will hold context information for the SHA-384
+ *  hashing operation.  It uses the SHA-512 structure for computation.
+ */
+typedef struct SHA512Context SHA384Context;
+
+/*
+ *  This structure holds context information for all SHA
+ *  hashing operations.
+ */
+typedef struct USHAContext {
+    int whichSha;               /* which SHA is being used */
+    union {
+      SHA1Context sha1Context;
+      SHA224Context sha224Context; SHA256Context sha256Context;
+      SHA384Context sha384Context; SHA512Context sha512Context;
+    } ctx;
+} USHAContext;
+
+/*
+ *  This structure will hold context information for the HMAC
+ *  keyed-hashing operation.
+ */
+typedef struct HMACContext {
+    int whichSha;               /* which SHA is being used */
+    int hashSize;               /* hash size of SHA being used */
+    int blockSize;              /* block size of SHA being used */
+    USHAContext shaContext;     /* SHA context */
+    unsigned char k_opad[USHA_Max_Message_Block_Size];
+                        /* outer padding - key XORd with opad */
+    int Computed;               /* Is the MAC computed? */
+    int Corrupted;              /* Cumulative corruption code */
+
+} HMACContext;
+
+/*
+ *  This structure will hold context information for the HKDF
+ *  extract-and-expand Key Derivation Functions.
+ */
+typedef struct HKDFContext {
+    int whichSha;               /* which SHA is being used */
+    HMACContext hmacContext;
+    int hashSize;               /* hash size of SHA being used */
+    unsigned char prk[USHAMaxHashSize];
+                        /* pseudo-random key - output of hkdfInput */
+    int Computed;               /* Is the key material computed? */
+    int Corrupted;              /* Cumulative corruption code */
+} HKDFContext;
+
+/*
+ *  Function Prototypes
+ */
+
+/* SHA-1 */
+extern int SHA1Reset(SHA1Context *);
+extern int SHA1Input(SHA1Context *, const uint8_t *bytes,
+                     unsigned int bytecount);
+extern int SHA1FinalBits(SHA1Context *, uint8_t bits,
+                         unsigned int bit_count);
+extern int SHA1Result(SHA1Context *,
+                      uint8_t Message_Digest[SHA1HashSize]);
+
+/* SHA-224 */
+extern int SHA224Reset(SHA224Context *);
+extern int SHA224Input(SHA224Context *, const uint8_t *bytes,
+                       unsigned int bytecount);
+extern int SHA224FinalBits(SHA224Context *, uint8_t bits,
+                           unsigned int bit_count);
+extern int SHA224Result(SHA224Context *,
+                        uint8_t Message_Digest[SHA224HashSize]);
+
+/* SHA-256 */
+extern int SHA256Reset(SHA256Context *);
+extern int SHA256Input(SHA256Context *, const uint8_t *bytes,
+                       unsigned int bytecount);
+extern int SHA256FinalBits(SHA256Context *, uint8_t bits,
+                           unsigned int bit_count);
+extern int SHA256Result(SHA256Context *,
+                        uint8_t Message_Digest[SHA256HashSize]);
+
+/* SHA-384 */
+extern int SHA384Reset(SHA384Context *);
+extern int SHA384Input(SHA384Context *, const uint8_t *bytes,
+                       unsigned int bytecount);
+extern int SHA384FinalBits(SHA384Context *, uint8_t bits,
+                           unsigned int bit_count);
+extern int SHA384Result(SHA384Context *,
+                        uint8_t Message_Digest[SHA384HashSize]);
+
+/* SHA-512 */
+extern int SHA512Reset(SHA512Context *);
+extern int SHA512Input(SHA512Context *, const uint8_t *bytes,
+                       unsigned int bytecount);
+extern int SHA512FinalBits(SHA512Context *, uint8_t bits,
+                           unsigned int bit_count);
+extern int SHA512Result(SHA512Context *,
+                        uint8_t Message_Digest[SHA512HashSize]);
+
+/* Unified SHA functions, chosen by whichSha */
+extern int USHAReset(USHAContext *context, SHAversion whichSha);
+extern int USHAInput(USHAContext *context,
+                     const uint8_t *bytes, unsigned int bytecount);
+extern int USHAFinalBits(USHAContext *context,
+                         uint8_t bits, unsigned int bit_count);
+extern int USHAResult(USHAContext *context,
+                      uint8_t Message_Digest[USHAMaxHashSize]);
+extern int USHABlockSize(enum SHAversion whichSha);
+extern int USHAHashSize(enum SHAversion whichSha);
+extern int USHAHashSizeBits(enum SHAversion whichSha);
+extern const char *USHAHashName(enum SHAversion whichSha);
+
+/*
+ * HMAC Keyed-Hashing for Message Authentication, RFC 2104,
+ * for all SHAs.
+ * This interface allows a fixed-length text input to be used.
+ */
+extern int hmac(SHAversion whichSha, /* which SHA algorithm to use */
+    const unsigned char *text,     /* pointer to data stream */
+    int text_len,                  /* length of data stream */
+    const unsigned char *key,      /* pointer to authentication key */
+    int key_len,                   /* length of authentication key */
+    uint8_t digest[USHAMaxHashSize]); /* caller digest to fill in */
+
+/*
+ * HMAC Keyed-Hashing for Message Authentication, RFC 2104,
+ * for all SHAs.
+ * This interface allows any length of text input to be used.
+ */
+extern int hmacReset(HMACContext *context, enum SHAversion whichSha,
+                     const unsigned char *key, int key_len);
+extern int hmacInput(HMACContext *context, const unsigned char *text,
+                     int text_len);
+extern int hmacFinalBits(HMACContext *context, uint8_t bits,
+                         unsigned int bit_count);
+extern int hmacResult(HMACContext *context,
+                      uint8_t digest[USHAMaxHashSize]);
+
+/*
+ * HKDF HMAC-based Extract-and-Expand Key Derivation Function,
+ * RFC 5869, for all SHAs.
+ */
+extern int hkdf(SHAversion whichSha, const unsigned char *salt,
+                int salt_len, const unsigned char *ikm, int ikm_len,
+                const unsigned char *info, int info_len,
+                uint8_t okm[ ], int okm_len);
+extern int hkdfExtract(SHAversion whichSha, const unsigned char *salt,
+                       int salt_len, const unsigned char *ikm,
+                       int ikm_len, uint8_t prk[USHAMaxHashSize]);
+extern int hkdfExpand(SHAversion whichSha, const uint8_t prk[ ],
+                      int prk_len, const unsigned char *info,
+                      int info_len, uint8_t okm[ ], int okm_len);
+
+/*
+ * HKDF HMAC-based Extract-and-Expand Key Derivation Function,
+ * RFC 5869, for all SHAs.
+ * This interface allows any length of text input to be used.
+ */
+extern int hkdfReset(HKDFContext *context, enum SHAversion whichSha,
+                     const unsigned char *salt, int salt_len);
+
+extern int hkdfInput(HKDFContext *context, const unsigned char *ikm,
+                     int ikm_len);
+extern int hkdfFinalBits(HKDFContext *context, uint8_t ikm_bits,
+                         unsigned int ikm_bit_count);
+extern int hkdfResult(HKDFContext *context,
+                      uint8_t prk[USHAMaxHashSize],
+                      const unsigned char *info, int info_len,
+                      uint8_t okm[USHAMaxHashSize], int okm_len);
+#endif /* _SHA_H_ */

--- a/src/swish/sha1.c
+++ b/src/swish/sha1.c
@@ -1,0 +1,411 @@
+/**************************** sha1.c ***************************/
+/***************** See RFC 6234 for details. *******************/
+/* Copyright (c) 2011 IETF Trust and the persons identified as */
+/* authors of the code.  All rights reserved.                  */
+/* See sha.h for terms of use and redistribution.              */
+
+/*
+ *  Description:
+ *      This file implements the Secure Hash Algorithm SHA-1
+ *      as defined in the U.S. National Institute of Standards
+ *      and Technology Federal Information Processing Standards
+ *      Publication (FIPS PUB) 180-3 published in October 2008
+ *      and formerly defined in its predecessors, FIPS PUB 180-1
+ *      and FIP PUB 180-2.
+ *
+ *      A combined document showing all algorithms is available at
+ *              http://csrc.nist.gov/publications/fips/
+ *                     fips180-3/fips180-3_final.pdf
+ *
+ *      The SHA-1 algorithm produces a 160-bit message digest for a
+ *      given data stream that can serve as a means of providing a
+ *      "fingerprint" for a message.
+ *
+ *  Portability Issues:
+ *      SHA-1 is defined in terms of 32-bit "words".  This code
+ *      uses <stdint.h> (included via "sha.h") to define 32- and
+ *      8-bit unsigned integer types.  If your C compiler does
+ *      not support 32-bit unsigned integers, this code is not
+ *      appropriate.
+ *
+ *  Caveats:
+ *      SHA-1 is designed to work with messages less than 2^64 bits
+ *      long.  This implementation uses SHA1Input() to hash the bits
+ *      that are a multiple of the size of an 8-bit octet, and then
+ *      optionally uses SHA1FinalBits() to hash the final few bits of
+ *      the input.
+ */
+
+#include "sha.h"
+#include "sha-private.h"
+
+/*
+ *  Define the SHA1 circular left shift macro
+ */
+#define SHA1_ROTL(bits,word) \
+                (((word) << (bits)) | ((word) >> (32-(bits))))
+
+/*
+ * Add "length" to the length.
+ * Set Corrupted when overflow has occurred.
+ */
+static uint32_t addTemp;
+#define SHA1AddLength(context, length)                     \
+    (addTemp = (context)->Length_Low,                      \
+     (context)->Corrupted =                                \
+        (((context)->Length_Low += (length)) < addTemp) && \
+        (++(context)->Length_High == 0) ? shaInputTooLong  \
+                                        : (context)->Corrupted )
+
+/* Local Function Prototypes */
+static void SHA1ProcessMessageBlock(SHA1Context *context);
+static void SHA1Finalize(SHA1Context *context, uint8_t Pad_Byte);
+static void SHA1PadMessage(SHA1Context *context, uint8_t Pad_Byte);
+
+/*
+ *  SHA1Reset
+ *
+ *  Description:
+ *      This function will initialize the SHA1Context in preparation
+ *      for computing a new SHA1 message digest.
+ *
+ *  Parameters:
+ *      context: [in/out]
+ *          The context to reset.
+ *
+ *  Returns:
+ *      sha Error Code.
+ *
+ */
+int SHA1Reset(SHA1Context *context)
+{
+  if (!context) return shaNull;
+
+  context->Length_High = context->Length_Low = 0;
+  context->Message_Block_Index = 0;
+
+  /* Initial Hash Values: FIPS 180-3 section 5.3.1 */
+  context->Intermediate_Hash[0]   = 0x67452301;
+  context->Intermediate_Hash[1]   = 0xEFCDAB89;
+  context->Intermediate_Hash[2]   = 0x98BADCFE;
+  context->Intermediate_Hash[3]   = 0x10325476;
+  context->Intermediate_Hash[4]   = 0xC3D2E1F0;
+
+  context->Computed   = 0;
+  context->Corrupted  = shaSuccess;
+
+  return shaSuccess;
+}
+
+/*
+ *  SHA1Input
+ *
+ *  Description:
+ *      This function accepts an array of octets as the next portion
+ *      of the message.
+ *
+ *  Parameters:
+ *      context: [in/out]
+ *          The SHA context to update.
+ *      message_array[ ]: [in]
+ *          An array of octets representing the next portion of
+ *          the message.
+ *      length: [in]
+ *          The length of the message in message_array.
+ *
+ *  Returns:
+ *      sha Error Code.
+ *
+ */
+int SHA1Input(SHA1Context *context,
+    const uint8_t *message_array, unsigned length)
+{
+  if (!context) return shaNull;
+  if (!length) return shaSuccess;
+  if (!message_array) return shaNull;
+  if (context->Computed) return context->Corrupted = shaStateError;
+  if (context->Corrupted) return context->Corrupted;
+
+  while (length--) {
+    context->Message_Block[context->Message_Block_Index++] =
+      *message_array;
+
+    if ((SHA1AddLength(context, 8) == shaSuccess) &&
+      (context->Message_Block_Index == SHA1_Message_Block_Size))
+      SHA1ProcessMessageBlock(context);
+
+    message_array++;
+  }
+
+  return context->Corrupted;
+}
+
+/*
+ * SHA1FinalBits
+ *
+ * Description:
+ *   This function will add in any final bits of the message.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The SHA context to update.
+ *   message_bits: [in]
+ *     The final bits of the message, in the upper portion of the
+ *     byte.  (Use 0b###00000 instead of 0b00000### to input the
+ *     three bits ###.)
+ *   length: [in]
+ *     The number of bits in message_bits, between 1 and 7.
+ *
+ * Returns:
+ *   sha Error Code.
+ */
+int SHA1FinalBits(SHA1Context *context, uint8_t message_bits,
+    unsigned int length)
+{
+  static uint8_t masks[8] = {
+      /* 0 0b00000000 */ 0x00, /* 1 0b10000000 */ 0x80,
+      /* 2 0b11000000 */ 0xC0, /* 3 0b11100000 */ 0xE0,
+      /* 4 0b11110000 */ 0xF0, /* 5 0b11111000 */ 0xF8,
+      /* 6 0b11111100 */ 0xFC, /* 7 0b11111110 */ 0xFE
+  };
+
+  static uint8_t markbit[8] = {
+      /* 0 0b10000000 */ 0x80, /* 1 0b01000000 */ 0x40,
+      /* 2 0b00100000 */ 0x20, /* 3 0b00010000 */ 0x10,
+      /* 4 0b00001000 */ 0x08, /* 5 0b00000100 */ 0x04,
+      /* 6 0b00000010 */ 0x02, /* 7 0b00000001 */ 0x01
+  };
+
+  if (!context) return shaNull;
+  if (!length) return shaSuccess;
+  if (context->Corrupted) return context->Corrupted;
+  if (context->Computed) return context->Corrupted = shaStateError;
+  if (length >= 8) return context->Corrupted = shaBadParam;
+
+  SHA1AddLength(context, length);
+  SHA1Finalize(context,
+    (uint8_t) ((message_bits & masks[length]) | markbit[length]));
+
+  return context->Corrupted;
+}
+
+/*
+ * SHA1Result
+ *
+ * Description:
+ *   This function will return the 160-bit message digest
+ *   into the Message_Digest array provided by the caller.
+ *   NOTE:
+ *    The first octet of hash is stored in the element with index 0,
+ *      the last octet of hash in the element with index 19.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The context to use to calculate the SHA-1 hash.
+ *   Message_Digest[ ]: [out]
+ *     Where the digest is returned.
+ *
+ * Returns:
+ *   sha Error Code.
+ *
+ */
+int SHA1Result(SHA1Context *context,
+    uint8_t Message_Digest[SHA1HashSize])
+{
+  int i;
+
+  if (!context) return shaNull;
+  if (!Message_Digest) return shaNull;
+  if (context->Corrupted) return context->Corrupted;
+
+  if (!context->Computed)
+    SHA1Finalize(context, 0x80);
+
+  for (i = 0; i < SHA1HashSize; ++i)
+    Message_Digest[i] = (uint8_t) (context->Intermediate_Hash[i>>2]
+                                   >> (8 * ( 3 - ( i & 0x03 ) )));
+
+  return shaSuccess;
+}
+
+/*
+ * SHA1ProcessMessageBlock
+ *
+ * Description:
+ *   This helper function will process the next 512 bits of the
+ *   message stored in the Message_Block array.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The SHA context to update.
+ *
+ * Returns:
+ *   Nothing.
+ *
+ * Comments:
+ *   Many of the variable names in this code, especially the
+ *   single character names, were used because those were the
+ *   names used in the Secure Hash Standard.
+ */
+static void SHA1ProcessMessageBlock(SHA1Context *context)
+{
+  /* Constants defined in FIPS 180-3, section 4.2.1 */
+  const uint32_t K[4] = {
+      0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xCA62C1D6
+  };
+  int        t;               /* Loop counter */
+  uint32_t   temp;            /* Temporary word value */
+  uint32_t   W[80];           /* Word sequence */
+  uint32_t   A, B, C, D, E;   /* Word buffers */
+
+  /*
+   * Initialize the first 16 words in the array W
+   */
+  for (t = 0; t < 16; t++) {
+    W[t]  = ((uint32_t)context->Message_Block[t * 4]) << 24;
+    W[t] |= ((uint32_t)context->Message_Block[t * 4 + 1]) << 16;
+    W[t] |= ((uint32_t)context->Message_Block[t * 4 + 2]) << 8;
+    W[t] |= ((uint32_t)context->Message_Block[t * 4 + 3]);
+  }
+
+  for (t = 16; t < 80; t++)
+    W[t] = SHA1_ROTL(1, W[t-3] ^ W[t-8] ^ W[t-14] ^ W[t-16]);
+
+  A = context->Intermediate_Hash[0];
+  B = context->Intermediate_Hash[1];
+  C = context->Intermediate_Hash[2];
+  D = context->Intermediate_Hash[3];
+  E = context->Intermediate_Hash[4];
+
+  for (t = 0; t < 20; t++) {
+    temp = SHA1_ROTL(5,A) + SHA_Ch(B, C, D) + E + W[t] + K[0];
+    E = D;
+    D = C;
+    C = SHA1_ROTL(30,B);
+    B = A;
+    A = temp;
+  }
+
+  for (t = 20; t < 40; t++) {
+    temp = SHA1_ROTL(5,A) + SHA_Parity(B, C, D) + E + W[t] + K[1];
+    E = D;
+    D = C;
+    C = SHA1_ROTL(30,B);
+    B = A;
+    A = temp;
+  }
+
+  for (t = 40; t < 60; t++) {
+    temp = SHA1_ROTL(5,A) + SHA_Maj(B, C, D) + E + W[t] + K[2];
+    E = D;
+    D = C;
+    C = SHA1_ROTL(30,B);
+    B = A;
+    A = temp;
+  }
+
+  for (t = 60; t < 80; t++) {
+    temp = SHA1_ROTL(5,A) + SHA_Parity(B, C, D) + E + W[t] + K[3];
+    E = D;
+    D = C;
+    C = SHA1_ROTL(30,B);
+    B = A;
+    A = temp;
+  }
+
+  context->Intermediate_Hash[0] += A;
+  context->Intermediate_Hash[1] += B;
+  context->Intermediate_Hash[2] += C;
+  context->Intermediate_Hash[3] += D;
+  context->Intermediate_Hash[4] += E;
+  context->Message_Block_Index = 0;
+}
+
+/*
+ * SHA1Finalize
+ *
+ * Description:
+ *   This helper function finishes off the digest calculations.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The SHA context to update.
+ *   Pad_Byte: [in]
+ *     The last byte to add to the message block before the 0-padding
+ *     and length.  This will contain the last bits of the message
+ *     followed by another single bit.  If the message was an
+ *     exact multiple of 8-bits long, Pad_Byte will be 0x80.
+ *
+ * Returns:
+ *   sha Error Code.
+ *
+ */
+static void SHA1Finalize(SHA1Context *context, uint8_t Pad_Byte)
+{
+  int i;
+  SHA1PadMessage(context, Pad_Byte);
+  /* message may be sensitive, clear it out */
+  for (i = 0; i < SHA1_Message_Block_Size; ++i)
+    context->Message_Block[i] = 0;
+  context->Length_High = 0;     /* and clear length */
+  context->Length_Low = 0;
+  context->Computed = 1;
+}
+
+/*
+ * SHA1PadMessage
+ *
+ * Description:
+ *   According to the standard, the message must be padded to the next
+ *   even multiple of 512 bits.  The first padding bit must be a '1'.
+ *   The last 64 bits represent the length of the original message.
+ *   All bits in between should be 0.  This helper function will pad
+ *   the message according to those rules by filling the Message_Block
+ *   array accordingly.  When it returns, it can be assumed that the
+ *   message digest has been computed.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The context to pad.
+ *   Pad_Byte: [in]
+ *     The last byte to add to the message block before the 0-padding
+ *     and length.  This will contain the last bits of the message
+ *     followed by another single bit.  If the message was an
+ *     exact multiple of 8-bits long, Pad_Byte will be 0x80.
+ *
+ * Returns:
+ *   Nothing.
+ */
+static void SHA1PadMessage(SHA1Context *context, uint8_t Pad_Byte)
+{
+  /*
+   * Check to see if the current message block is too small to hold
+   * the initial padding bits and length.  If so, we will pad the
+   * block, process it, and then continue padding into a second
+   * block.
+   */
+  if (context->Message_Block_Index >= (SHA1_Message_Block_Size - 8)) {
+    context->Message_Block[context->Message_Block_Index++] = Pad_Byte;
+    while (context->Message_Block_Index < SHA1_Message_Block_Size)
+      context->Message_Block[context->Message_Block_Index++] = 0;
+
+    SHA1ProcessMessageBlock(context);
+  } else
+    context->Message_Block[context->Message_Block_Index++] = Pad_Byte;
+
+  while (context->Message_Block_Index < (SHA1_Message_Block_Size - 8))
+    context->Message_Block[context->Message_Block_Index++] = 0;
+  /*
+   * Store the message length as the last 8 octets
+   */
+  context->Message_Block[56] = (uint8_t) (context->Length_High >> 24);
+  context->Message_Block[57] = (uint8_t) (context->Length_High >> 16);
+  context->Message_Block[58] = (uint8_t) (context->Length_High >> 8);
+  context->Message_Block[59] = (uint8_t) (context->Length_High);
+  context->Message_Block[60] = (uint8_t) (context->Length_Low >> 24);
+  context->Message_Block[61] = (uint8_t) (context->Length_Low >> 16);
+  context->Message_Block[62] = (uint8_t) (context->Length_Low >> 8);
+  context->Message_Block[63] = (uint8_t) (context->Length_Low);
+
+  SHA1ProcessMessageBlock(context);
+}


### PR DESCRIPTION
This pull request adds support for computing the SHA1 message digest and support for base64 encoding and decoding.

For an example showing how to use `make-digest-provider`, see examples/mbedtls.

The examples are very much WIP. I included them here as a preview to help "digest", so to speak, the `make-digest-provider` interface. I think it will be a while before the examples are actually ready to land on master, so I plan to prune them when we rebase this.

I left the code changes as WIP commits because I want to point out the need for something more in our error-pair mechanism. The db code already uses an extended error pair. I borrowed that in mbedtls.c, but we may want something else. Developing that mechanism may well be out of scope for this pull request, so we may scale back to something simpler (and remove the symbol cases from the match in `open-digest*` since I didn't feel ready to use it in mbedtls.c yet).