### PR TITLE
Remove bad-syntax from (swish meta)

### DIFF
--- a/src/swish/erlang.ss
+++ b/src/swish/erlang.ss
@@ -1099,9 +1099,9 @@
                  (and (identifier? #'fn)
                       (let ([f (datum fn)])
                         (when (memq f '(make copy copy* is?))
-                          (bad-syntax "invalid field" x #'fn))
+                          (syntax-violation #f "invalid field" x #'fn))
                         (when (memq f seen)
-                          (bad-syntax "duplicate field" x #'fn))
+                          (syntax-violation #f "duplicate field" x #'fn))
                         (valid-fields? #'rest (cons f seen))))]
                 [() #t]
                 [_ #f])))
@@ -1146,9 +1146,9 @@
                     (identifier? #'fn)
                     (let ([f (datum fn)])
                       (when (memq f seen)
-                        (bad-syntax "duplicate field" x #'fn))
+                        (syntax-violation #f "duplicate field" x #'fn))
                       (unless (memq f '(field ...))
-                        (bad-syntax "unknown field" x #'fn))
+                        (syntax-violation #f "unknown field" x #'fn))
                       (valid? #'rest (cons f seen)))]
                    [() #t]
                    [_ #f])))
@@ -1234,10 +1234,10 @@
                ...
                [(name fn)
                 (identifier? #'fn)
-                (bad-syntax "unknown field" x #'fn)]
+                (syntax-violation #f "unknown field" x #'fn)]
                [(name fn expr)
                 (identifier? #'fn)
-                (bad-syntax "unknown field" x #'fn)]
+                (syntax-violation #f "unknown field" x #'fn)]
                ))
            (define-property name fields '(field ...)))]))
 

--- a/src/swish/meta.ss
+++ b/src/swish/meta.ss
@@ -24,7 +24,6 @@
 (library (swish meta)
   (export
    add-if-absent
-   bad-syntax
    collect-clauses
    compound-id
    find-clause
@@ -90,12 +89,6 @@
 
   (define (syntax-datum-eq? x y) (eq? (syntax->datum x) (syntax->datum y)))
 
-  (define (bad-syntax msg form subform)
-    (raise
-     (condition
-      (make-message-condition msg)
-      (make-syntax-violation form subform))))
-
   (define (collect-clauses form clauses valid-keys)
     (let lp ([clauses clauses] [seen '()])
       (if (snull? clauses)
@@ -103,9 +96,9 @@
           (let* ([clause (scar clauses)]
                  [key (syntax->datum (scar clause))])
             (unless (memq key valid-keys)
-              (bad-syntax "invalid clause" form clause))
+              (syntax-violation #f "invalid clause" form clause))
             (when (assq key seen)
-              (bad-syntax "duplicate clause" form clause))
+              (syntax-violation #f "duplicate clause" form clause))
             (lp (scdr clauses) (cons (cons key clause) seen))))))
 
   (define (find-clause key clauses)


### PR DESCRIPTION
Chez Scheme provides syntax-violation, so let's remove bad-syntax in favor of it. The bad-syntax form wasn't documented, and syntax-violation also includes the continuation.