### PR TITLE
Enable db gen-server support for URI filenames, in-memory, and temporary databases

### DIFF
--- a/doc/swish/db.tex
+++ b/doc/swish/db.tex
@@ -50,8 +50,8 @@ transaction. In order to allow other processes access to the database,
 lazy transactions should be closed occasionally. To support this, it
 tracks a count of entries in the current transaction. A transaction is
 committed when the threshold of 10,000 is reached, the message queue
-of the \code{db} is empty, or when a direct transaction is
-requested.  Each database is created with write-ahead logging enabled
+of the \code{db} is empty, or when a direct transaction is requested.
+By default, each database is created with write-ahead logging enabled
 to prevent write operations from blocking on queries made from another
 connection.
 
@@ -141,16 +141,14 @@ guardian via \code{make-foreign-handle-guardian}.
 
 \end{itemize}
 
-\genserver{db}{init} The \code{init} procedure takes a filename and
-mode symbol and attempts to open that database, setting
-\code{journal\_mode} to ``wal'' if \var{mode} is
-\code{create}. The handle returned from \code{osi\_open\_database} is
-wrapped in a \var{database} record that is registered with a
-foreign-handle guardian using the type name \code{databases}.
-The foreign-handle guardian hooks
-the garbage collector so that dead databases are
-closed even if the \code{db} gen-server fails to close them for any
-reason.
+\genserver{db}{init} The \code{init} procedure takes a filename, mode
+symbol, and an initialization procedure and attempts to open that
+database and invoke the initialization procedure.  The handle returned
+from \code{osi\_open\_database} is wrapped in a \var{database} record
+that is registered with a foreign-handle guardian using the type name
+\code{databases}.  The foreign-handle guardian hooks the garbage
+collector so that dead databases are closed even if the \code{db}
+gen-server fails to close them for any reason.
 
 The gen-server traps exits so that it can close the database in its
 \code{terminate} procedure.
@@ -220,7 +218,7 @@ queries in less than one second.
 
 \defineentry{db:start\&link}
 \begin{procedure}
-  \code{(db:start\&link \var{name} \var{filename} \var{mode})}
+  \code{(db:start\&link \var{name} \var{filename} \var{mode} \opt{\var{db-init}})}
 \end{procedure}
 \returns{}
 \code{\#(ok \var{pid})} $|$
@@ -248,6 +246,12 @@ to \code{osi\_open\_database}:
 \item \code{create} combines the SQLite flags \code{(logor
   SQLITE\_OPEN\_READWRITE \code{SQLITE\_OPEN\_CREATE})}.
 \end{itemize}
+
+\var{db-init} is a procedure that takes one argument, a database
+record instance. The return value is ignored. When the \var{mode} is
+\code{create} and \var{filename} is not a special SQLite filename, the
+default procedure sets \code{journal\_mode} to ``wal''; otherwise, no
+additional initialization occurs.
 
 The SQLite constants can be found in \texttt{sqlite3.h} or
 online~\cite{sqlite}.

--- a/src/swish/Mf-a6le
+++ b/src/swish/Mf-a6le
@@ -22,7 +22,7 @@ SwishLibs := ../../${BUILD}/bin/libosi.so ../../${BUILD}/lib/swish_kernel.o
 	$C -I"${SCHEME_INCLUDE}" -I"${LIBUV_INCLUDE}" -c $<
 
 sqlite3.o: sqlite3.h sqlite3.c
-	$C -DSQLITE_ENABLE_JSON1 -DSQLITE_THREADSAFE=2 ${HUSH} -c sqlite3.c
+	$C -DSQLITE_ENABLE_JSON1 -DSQLITE_THREADSAFE=2 -DSQLITE_USE_URI=1 ${HUSH} -c sqlite3.c
 
 ${UvLib}/libuv.a: ${UvInclude}
 	  cd ../../libuv; "${PYTHON}" gyp_uv.py -Duv_library=static_library -Dtarget_arch="x64" -f make

--- a/src/swish/Mf-a6nt
+++ b/src/swish/Mf-a6nt
@@ -14,7 +14,7 @@ SwishLibs := ../../${BUILD}/bin/libuv.dll ../../${BUILD}/bin/sqlite3.dll ../../$
 	$C /DSCHEME_LIB=${SCHEME_LIB_PREFIX} /I"${SCHEME_INCLUDE}" /I"${LIBUV_INCLUDE}" /c $<
 
 sqlite3.obj: sqlite3.h sqlite3.c
-	$C /DSQLITE_API=__declspec\(dllexport\) /DSQLITE_ENABLE_JSON1 /DSQLITE_THREADSAFE=2 /c sqlite3.c
+	$C /DSQLITE_API=__declspec\(dllexport\) /DSQLITE_ENABLE_JSON1 /DSQLITE_THREADSAFE=2 /DSQLITE_USE_URI=1 /c sqlite3.c
 
 ../../${BUILD}/bin/sqlite3.dll ../../${BUILD}/bin/sqlite3.lib: sqlite3.obj
 	${LD} /dll /out:../../${BUILD}/bin/sqlite3.dll sqlite3.obj

--- a/src/swish/Mf-a6osx
+++ b/src/swish/Mf-a6osx
@@ -16,7 +16,7 @@ SwishLibs := ../../${BUILD}/bin/libosi.dylib ../../${BUILD}/lib/swish_kernel.o
 	$C -I"${SCHEME_INCLUDE}" -I"${LIBUV_INCLUDE}" -c $<
 
 sqlite3.o: sqlite3.h sqlite3.c
-	$C -DSQLITE_ENABLE_JSON1 -DSQLITE_THREADSAFE=2 -c sqlite3.c
+	$C -DSQLITE_ENABLE_JSON1 -DSQLITE_THREADSAFE=2 -DSQLITE_USE_URI=1 -c sqlite3.c
 
 ${UvLib}/libuv.a: ${UvInclude}
 	cd ../../libuv; "${PYTHON}" gyp_uv.py -Duv_library=static_library -Dtarget_arch="x64" -f xcode

--- a/src/swish/Mf-arm32le
+++ b/src/swish/Mf-arm32le
@@ -16,7 +16,7 @@ SwishLibs := ../../${BUILD}/bin/libosi.so ../../${BUILD}/lib/swish_kernel.o
 	$C -I"${SCHEME_INCLUDE}" -I"${LIBUV_INCLUDE}" -c $<
 
 sqlite3.o: sqlite3.h sqlite3.c
-	$C -DSQLITE_ENABLE_JSON1 -DSQLITE_THREADSAFE=2 -c sqlite3.c
+	$C -DSQLITE_ENABLE_JSON1 -DSQLITE_THREADSAFE=2 -DSQLITE_USE_URI=1 -c sqlite3.c
 
 ${UvLib}/libuv.a: ${UvInclude}
 	  cd ../../libuv; "${PYTHON}" gyp_uv.py -Duv_library=static_library -Dtarget_arch="arm" -f make

--- a/src/swish/Mf-i3le
+++ b/src/swish/Mf-i3le
@@ -22,7 +22,7 @@ SwishLibs := ../../${BUILD}/bin/libosi.so ../../${BUILD}/lib/swish_kernel.o
 	$C -I"${SCHEME_INCLUDE}" -I"${LIBUV_INCLUDE}" -c $<
 
 sqlite3.o: sqlite3.h sqlite3.c
-	$C -DSQLITE_ENABLE_JSON1 -DSQLITE_THREADSAFE=2 ${HUSH} -c sqlite3.c
+	$C -DSQLITE_ENABLE_JSON1 -DSQLITE_THREADSAFE=2 -DSQLITE_USE_URI=1 ${HUSH} -c sqlite3.c
 
 ${UvLib}/libuv.a: ${UvInclude}
 	  cd ../../libuv; "${PYTHON}" gyp_uv.py -Duv_library=static_library -Dtarget_arch="ia32" -f make

--- a/src/swish/Mf-i3nt
+++ b/src/swish/Mf-i3nt
@@ -14,7 +14,7 @@ SwishLibs := ../../${BUILD}/bin/libuv.dll ../../${BUILD}/bin/sqlite3.dll ../../$
 	$C /DSCHEME_LIB=${SCHEME_LIB_PREFIX} /I"${SCHEME_INCLUDE}" /I"${LIBUV_INCLUDE}" /c $<
 
 sqlite3.obj: sqlite3.h sqlite3.c
-	$C /DSQLITE_API=__declspec\(dllexport\) /DSQLITE_ENABLE_JSON1 /DSQLITE_THREADSAFE=2 /c sqlite3.c
+	$C /DSQLITE_API=__declspec\(dllexport\) /DSQLITE_ENABLE_JSON1 /DSQLITE_THREADSAFE=2 /DSQLITE_USE_URI=1 /c sqlite3.c
 
 ../../${BUILD}/bin/sqlite3.dll ../../${BUILD}/bin/sqlite3.lib: sqlite3.obj
 	${LD} /dll /out:../../${BUILD}/bin/sqlite3.dll sqlite3.obj

--- a/src/swish/db.ms
+++ b/src/swish/db.ms
@@ -31,8 +31,6 @@
  (swish testing)
  )
 
-(define filename (path-combine (data-dir) "test-db.db3"))
-
 (define-syntax (echo-sql x)
   (syntax-case x ()
     [(k sql)
@@ -151,8 +149,7 @@
   (define goodies
     (append '(#f) (make-integers 63) (make-doubles) (make-strings)
       (make-blobs)))
-  (catch (remove-file filename))
-  (match-let* ([#(ok ,db) (db:start&link #f filename 'create)])
+  (match-let* ([#(ok ,db) (db:start&link #f ":memory:" 'create)])
     (transaction db
       (execute "create table data(x)")
       (for-each (lambda (x) (execute "insert into data(x) values(?)" x))
@@ -167,14 +164,12 @@
          (check x (execute "select x from data where rowid=?" id))
          (+ id 1))
        1 goodies))
-    (db:stop db)
-    (catch (remove-file filename))))
+    (db:stop db)))
 
 (isolate-mat m1 ()
-  (catch (remove-file filename))
   (match-let*
-   ([#(ok ,db) (db:start&link #f filename 'create)]
-    [,@filename (db:filename db)]
+   ([#(ok ,db) (db:start&link #f ":memory:" 'create)]
+    [":memory:" (db:filename db)]
     [created-tables
      (transaction db
        (execute "CREATE TABLE table1 (col1, col2, col3)")
@@ -216,8 +211,7 @@
         (columns "SELECT col1,col2,col3 AS Column3 FROM table1"))]
      [#(EXIT failed-transaction)
       (catch (transaction db (raise 'failed-transaction)))])
-    (db:stop db)
-    (catch (remove-file filename)))))
+    (db:stop db))))
 
 (mat errors ()
   (match-let*
@@ -312,7 +306,32 @@
 
 (isolate-mat db-guardian ()
   (let ([g (make-guardian)])
-    (g (sqlite:open filename (+ SQLITE_OPEN_READWRITE SQLITE_OPEN_CREATE)))
+    (g (sqlite:open ":memory:" (+ SQLITE_OPEN_READWRITE SQLITE_OPEN_CREATE)))
     (gc)
-    (assert (handle-gone? (g))))
-  (catch (remove-file filename)))
+    (assert (handle-gone? (g)))))
+
+(isolate-mat db-open ()
+  (match-let*
+   ([,filename (path-combine (data-dir) "test-db.db3")]
+    [#(ok ,file) (db:start&link #f filename 'create)]
+    [#(ok ,tmp) (db:start&link #f "" 'create)]
+    [#(ok ,mem) (db:start&link #f ":memory:" 'create)]
+    [#(ok ,shared1) (db:start&link #f "file::memory:?cache=shared" 'create)]
+    [#(ok ,shared2) (db:start&link #f "file::memory:?cache=shared" 'create)]
+    [#(ok ,init)
+     (db:start&link #f ":memory:" 'create
+       (let ([me self])
+         (lambda (db)
+           (send me `#(init ,(execute-sql db "pragma journal_mode"))))))]
+    [#(init (#("memory"))) (receive (after 1000 (raise 'timeout)) [,x x])])
+
+   ;; Verify in-memory using shared cache connects to same data
+   (transaction shared1
+     (execute "CREATE TABLE table1 (col1, col2, col3)")
+     (execute "INSERT INTO table1 (col1, col2, col3) VALUES(?,?,?)" 1 2 3))
+   (match-let*
+    ([(#(1 2 3))
+      (transaction shared2 (execute "SELECT col1, col2, col3 FROM table1"))])
+
+    (db:stop file)
+    (catch (remove-file filename)))))

--- a/src/swish/sqlite3.h
+++ b/src/swish/sqlite3.h
@@ -123,9 +123,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.28.0"
-#define SQLITE_VERSION_NUMBER 3028000
-#define SQLITE_SOURCE_ID      "2019-04-16 19:49:53 884b4b7e502b4e991677b53971277adfaf0a04a284f8e483e2553d0f83156b50"
+#define SQLITE_VERSION        "3.29.0"
+#define SQLITE_VERSION_NUMBER 3029000
+#define SQLITE_SOURCE_ID      "2019-07-10 17:32:03 fc82b73eaac8b36950e527f12c4b5dc1e147e6f4ad2217ae43ad82882a88bfa6"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -1296,8 +1296,14 @@ typedef struct sqlite3_api_routines sqlite3_api_routines;
 ** ^The flags argument to xAccess() may be [SQLITE_ACCESS_EXISTS]
 ** to test for the existence of a file, or [SQLITE_ACCESS_READWRITE] to
 ** test whether a file is readable and writable, or [SQLITE_ACCESS_READ]
-** to test whether a file is at least readable.   The file can be a
-** directory.
+** to test whether a file is at least readable.  The SQLITE_ACCESS_READ
+** flag is never actually used and is not implemented in the built-in
+** VFSes of SQLite.  The file is named by the second argument and can be a
+** directory. The xAccess method returns [SQLITE_OK] on success or some
+** non-zero error code if there is an I/O error or if the name of
+** the file given in the second argument is illegal.  If SQLITE_OK
+** is returned, then non-zero or zero is written into *pResOut to indicate
+** whether or not the file is accessible.  
 **
 ** ^SQLite will always allocate at least mxPathname+1 bytes for the
 ** output buffer xFullPathname.  The exact size of the output buffer
@@ -2198,6 +2204,7 @@ struct sqlite3_mem_methods {
 ** features include but are not limited to the following:
 ** <ul>
 ** <li> The [PRAGMA writable_schema=ON] statement.
+** <li> The [PRAGMA journal_mode=OFF] statement.
 ** <li> Writes to the [sqlite_dbpage] virtual table.
 ** <li> Direct writes to [shadow tables].
 ** </ul>
@@ -2213,6 +2220,34 @@ struct sqlite3_mem_methods {
 ** integer into which is written 0 or 1 to indicate whether the writable_schema
 ** is enabled or disabled following this call.
 ** </dd>
+**
+** [[SQLITE_DBCONFIG_LEGACY_ALTER_TABLE]]
+** <dt>SQLITE_DBCONFIG_LEGACY_ALTER_TABLE</dt>
+** <dd>The SQLITE_DBCONFIG_LEGACY_ALTER_TABLE option activates or deactivates
+** the legacy behavior of the [ALTER TABLE RENAME] command such it
+** behaves as it did prior to [version 3.24.0] (2018-06-04).  See the
+** "Compatibility Notice" on the [ALTER TABLE RENAME documentation] for
+** additional information. This feature can also be turned on and off
+** using the [PRAGMA legacy_alter_table] statement.
+** </dd>
+**
+** [[SQLITE_DBCONFIG_DQS_DML]]
+** <dt>SQLITE_DBCONFIG_DQS_DML</td>
+** <dd>The SQLITE_DBCONFIG_DQS_DML option activates or deactivates
+** the legacy [double-quoted string literal] misfeature for DML statement
+** only, that is DELETE, INSERT, SELECT, and UPDATE statements. The
+** default value of this setting is determined by the [-DSQLITE_DQS]
+** compile-time option.
+** </dd>
+**
+** [[SQLITE_DBCONFIG_DQS_DDL]]
+** <dt>SQLITE_DBCONFIG_DQS_DDL</td>
+** <dd>The SQLITE_DBCONFIG_DQS option activates or deactivates
+** the legacy [double-quoted string literal] misfeature for DDL statements,
+** such as CREATE TABLE and CREATE INDEX. The
+** default value of this setting is determined by the [-DSQLITE_DQS]
+** compile-time option.
+** </dd>
 ** </dl>
 */
 #define SQLITE_DBCONFIG_MAINDBNAME            1000 /* const char* */
@@ -2227,7 +2262,10 @@ struct sqlite3_mem_methods {
 #define SQLITE_DBCONFIG_RESET_DATABASE        1009 /* int int* */
 #define SQLITE_DBCONFIG_DEFENSIVE             1010 /* int int* */
 #define SQLITE_DBCONFIG_WRITABLE_SCHEMA       1011 /* int int* */
-#define SQLITE_DBCONFIG_MAX                   1011 /* Largest DBCONFIG */
+#define SQLITE_DBCONFIG_LEGACY_ALTER_TABLE    1012 /* int int* */
+#define SQLITE_DBCONFIG_DQS_DML               1013 /* int int* */
+#define SQLITE_DBCONFIG_DQS_DDL               1014 /* int int* */
+#define SQLITE_DBCONFIG_MAX                   1014 /* Largest DBCONFIG */
 
 /*
 ** CAPI3REF: Enable Or Disable Extended Result Codes
@@ -7319,7 +7357,8 @@ SQLITE_API int sqlite3_test_control(int op, ...);
 #define SQLITE_TESTCTRL_SORTER_MMAP             24
 #define SQLITE_TESTCTRL_IMPOSTER                25
 #define SQLITE_TESTCTRL_PARSER_COVERAGE         26
-#define SQLITE_TESTCTRL_LAST                    26  /* Largest TESTCTRL */
+#define SQLITE_TESTCTRL_RESULT_INTREAL          27
+#define SQLITE_TESTCTRL_LAST                    27  /* Largest TESTCTRL */
 
 /*
 ** CAPI3REF: SQL Keyword Checking


### PR DESCRIPTION
- Updated to SQLite 3.29.0
- Enabled SQLITE_USE_URI compile-time option
- Changed db.ms to use in-memory databases throughout, except for the test where we test a variety of valid SQLite filenames
