### PR TITLE
Make HTTP limits parameters

### DIFF
--- a/doc/swish/http.tex
+++ b/doc/swish/http.tex
@@ -94,9 +94,7 @@ A URL which directs the system away from \code{(web-dir)} using
 explicitly checks for relative paths.
 
 The HTTP interface limits incoming data to protect against large
-memory allocation which may crash the system. URL requests are limited
-to 4,096 bytes. Headers are limited to 1,048,576 bytes. Posted content
-is limited to 4,194,304 bytes, not including uploaded files.
+memory allocation which may crash the system.
 
 The HTTP interface does not limit incoming file uploads. If the disk
 runs out of space, the handler process will exit with an I/O error.
@@ -171,6 +169,34 @@ directory of the current file.
 The \code{http-port-number} parameter specifies whether or not
 \code{http-sup:start\&link} should start the HTTP server and,
 if started, on what port that server should listen for connections.
+
+\defineentry{http-request-limit}
+\begin{parameter}
+  \code{http-request-limit}
+\end{parameter}
+\hasvalue{} a positive fixnum
+
+The \code{http-request-limit} parameter specifies the maximum length
+in bytes of the first line of an HTTP request. It defaults to 4,096.
+
+\defineentry{http-header-limit}
+\begin{parameter}
+  \code{http-header-limit}
+\end{parameter}
+\hasvalue{} a positive fixnum
+
+The \code{http-header-limit} parameter specifies the maximum length in
+bytes of the HTTP request headers. It defaults to 1,048,576.
+
+\defineentry{http-content-limit}
+\begin{parameter}
+  \code{http-content-limit}
+\end{parameter}
+\hasvalue{} a positive fixnum
+
+The \code{http-content-limit} parameter specifies the maximum length
+in bytes of the HTTP request content excluding uploaded files. It
+defaults to 4,194,304.
 
 \defineentry{http-sup:start\&link}
 \begin{procedure}

--- a/src/swish/base64.ss
+++ b/src/swish/base64.ss
@@ -21,7 +21,7 @@
 ;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ;; SOFTWARE.
 (library (swish base64)
- (export
+  (export
    base64-decode-bytevector
    base64-encode-bytevector
    base64url-decode-bytevector
@@ -197,6 +197,4 @@
                 (write-encoded base in)]
                [else
                 (write-padded base (get-bits in) (- next input-size))])))
-          out)))
-
-)
+          out))))

--- a/src/swish/compile.ss
+++ b/src/swish/compile.ss
@@ -69,14 +69,14 @@
   (cond
    [must-rebuild?
     (printf "compiling ~a\n" (path-last dest-file))
-    (unless
-     (verify-excluded-wpo
-      (parameterize ([library-extensions '((".ss" . ".so"))])
-        (compile-whole-library
-         (string-append lib-dir "/" (path-root src-file) ".wpo")
-         dest-file)))
-     (delete-file dest-file)
-     (abort))]
+    (let ([missing
+           (parameterize ([library-extensions '((".ss" . ".so"))])
+             (compile-whole-library
+              (string-append lib-dir "/" (path-root src-file) ".wpo")
+              dest-file))])
+      (unless (verify-excluded-wpo missing)
+        (delete-file dest-file)
+        (abort)))]
    [else (printf "~a is up to date\n" (path-last dest-file))]))
 
 ;; The custom library-search-handler here serves two purposes:

--- a/src/swish/db.ss
+++ b/src/swish/db.ss
@@ -612,6 +612,4 @@
            #\space)
           (collect-args #'(where ...)))])]))
 
-  (define SQLITE_STATUS_MEMORY_USED 0)
-
-)
+  (define SQLITE_STATUS_MEMORY_USED 0))

--- a/src/swish/digest.ss
+++ b/src/swish/digest.ss
@@ -63,7 +63,8 @@
       [close procedure?])
     ($make-digest-provider name open hash! get close))
 
-  (define-record-type digest (parent digest-provider)
+  (define-record-type digest
+    (parent digest-provider)
     (nongenerative)
     (fields
      (mutable ctx)
@@ -250,7 +251,7 @@
         [bv bytevector?]
         [block-size (lambda (x) (and (fixnum? x) (fx> x 0)))])
       (let ([md (open-digest* 'bytevector->hex-string algorithm #f
-                 (current-digest-provider))])
+                  (current-digest-provider))])
         (on-exit (close-digest md)
           (let ([len (bytevector-length bv)])
             (do ([i 0 (#3%fx+ i block-size)]) ((#3%fx>= i len))

--- a/src/swish/erlang.ss
+++ b/src/swish/erlang.ss
@@ -423,7 +423,8 @@
   (define dump-stack
     (let ()
       (define (source-path obj)
-        (call-with-values (lambda () (obj 'source-path))
+        (call-with-values
+          (lambda () (obj 'source-path))
           (case-lambda
            [() #f]
            [(path char)

--- a/src/swish/http.ms
+++ b/src/swish/http.ms
@@ -394,7 +394,15 @@
   (define header '(("Content-Length" . "bar") ("Content-Type" . "foo")))
   (define params '(("query" . "lookup") ("val" . "1")))
   (match-let*
-   ([#f (http:find-header "None" header)]
+   ([#(EXIT #(bad-arg http-port-number a)) (catch (http-port-number 'a))]
+    [#(EXIT #(bad-arg http-port-number -1)) (catch (http-port-number -1))]
+    [#(EXIT #(bad-arg http-request-limit a)) (catch (http-request-limit 'a))]
+    [#(EXIT #(bad-arg http-request-limit 0)) (catch (http-request-limit 0))]
+    [#(EXIT #(bad-arg http-header-limit a)) (catch (http-header-limit 'a))]
+    [#(EXIT #(bad-arg http-header-limit 0)) (catch (http-header-limit 0))]
+    [#(EXIT #(bad-arg http-content-limit a)) (catch (http-content-limit 'a))]
+    [#(EXIT #(bad-arg http-content-limit 0)) (catch (http-content-limit 0))]
+    [#f (http:find-header "None" header)]
     [#(EXIT #(bad-arg http:find-header None))
      (catch (http:find-header 'None header))]
     ["foo" (http:find-header "Content-Type" header)]

--- a/src/swish/json.ss
+++ b/src/swish/json.ss
@@ -189,7 +189,7 @@
                  [(<= #xDC00 x #xDFFF) (raise 'invalid-surrogate-pair)]
                  [else (write-char (integer->char x) op)]))]
              [else (unexpected-input c ip)]))
-           (read-string ip op)]
+         (read-string ip op)]
         [else (write-char c op) (read-string ip op)])))
 
   (define (read-4hexdig ip)

--- a/src/swish/testing.ss
+++ b/src/swish/testing.ss
@@ -340,7 +340,7 @@
             (do-eof-mats (port-position ip) deferred)))
         (define (do-eof-mats fp deferred)
           (call-with-values
-              (lambda () (catch (get-datum/annotations ip sfd fp)))
+            (lambda () (catch (get-datum/annotations ip sfd fp)))
             (case-lambda
              [(err) 'none]
              [(obj fp)


### PR DESCRIPTION
The arbitrary limits we set for the HTTP server should be parameters so that they can be modified for the particular application.