### PR TITLE
fix bad-match in display-query.ss when query contains newline

### DIFF
--- a/src/swish/cli.ss
+++ b/src/swish/cli.ss
@@ -572,7 +572,7 @@
       (<arg-spec> open s [type short long usage])
       (define flag-char
         (and short
-             (pregexp-match "\\[-.\\]" (format-spec s))
+             (pregexp-match (re "\\[-.\\]") (format-spec s))
              short))
       (cons (and (memq 'show usage) #t)
         (or flag-char (format-spec s))))

--- a/src/swish/swish-build
+++ b/src/swish/swish-build
@@ -443,7 +443,7 @@
           (if (eof-object? line)
               als
               (lp
-               (match (pregexp-match "^trying (.*)\\.\\.\\.opened\r?$" line)
+               (match (pregexp-match (re "^trying (.*)\\.\\.\\.opened\r?$") line)
                  [(,_ ,fn)
                   (cons (cons (path-last fn) fn) als)]
                  [,_ als]))))))))

--- a/src/swish/swish-test
+++ b/src/swish/swish-test
@@ -572,8 +572,8 @@
 
 (define (path->file-uri path)
   (define (sanitize path)
-    (join (map http:percent-encode (pregexp-split "[\\\\/]" path)) "/"))
-  (match (pregexp-match "^([a-zA-Z]:)[\\\\/](.*)" path)
+    (join (map http:percent-encode (pregexp-split (re "[\\\\/]") path)) "/"))
+  (match (pregexp-match (re "^([a-zA-Z]:)[\\\\/](.*)") path)
     [(,_ ,anchor ,rest) (string-append "file://" anchor "/" (sanitize rest))]
     [#f (string-append "file://" (sanitize path))]))
 

--- a/web/swish/charts.ss
+++ b/web/swish/charts.ss
@@ -28,7 +28,7 @@
        (join (map (lambda (x) (format "'~a'" x)) names) #\,))))
 
 (define sanitize-column-name
-  (let ([regexp (pregexp "^json_extract\\(foreign_handles, '\\$.([^']*)'\\)")])
+  (let ([regexp (re "^json_extract\\(foreign_handles, '\\$.([^']*)'\\)")])
     (lambda (col)
       (match (pregexp-match regexp col)
         [(,_ ,col) col]

--- a/web/swish/display-query.ss
+++ b/web/swish/display-query.ss
@@ -76,7 +76,7 @@
            [else (stringify v)])))
 
   (define (remove-limit-offset str)
-    (stringify (match (pregexp-match "^(.*?) limit \\d+ offset \\d+$" str)
+    (stringify (match (pregexp-match "^((?:.|\\n)*?) limit \\d+ offset \\d+$" str)
                  [(,full ,match) match]
                  [(,no-limit) no-limit])))
 

--- a/web/swish/display-query.ss
+++ b/web/swish/display-query.ss
@@ -76,9 +76,10 @@
            [else (stringify v)])))
 
   (define (remove-limit-offset str)
-    (stringify (match (pregexp-match "^((?:.|\\n)*?) limit \\d+ offset \\d+$" str)
-                 [(,full ,match) match]
-                 [(,no-limit) no-limit])))
+    (stringify
+     (match (pregexp-match (re "^((?:.|\\n)*?) limit \\d+ offset \\d+$") str)
+       [(,full ,match) match]
+       [(,no-limit) no-limit])))
 
   (let ([stmt (sqlite:prepare db (format "~a limit ? offset ?" sql))])
     (on-exit (sqlite:finalize stmt)


### PR DESCRIPTION
This seems to fix a `bad-match` in display-query.ss when the diagnostics page "Log DB" query contains a newline:

```
select * from child
where type = 'supervisor'
```