### PR TITLE
Restore interactive Ctrl-C behavior

### DIFF
--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -1481,6 +1481,16 @@ operation. To unblock the process, call \code{complete-io} from a
 callback function.
 
 % ----------------------------------------------------------------------------
+\defineentry{windows?}
+\begin{syntax}
+  \code{windows?}
+\end{syntax}
+\expandsto{} a boolean
+
+The \code{windows?} macro expands to \code{\#t} if the host is running
+Microsoft Windows and \code{\#f} if not.
+
+% ----------------------------------------------------------------------------
 \subsection {Tuples}
 
 For users of the concurrency model, a \emph{tuple}\index{tuple} is a

--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -105,8 +105,9 @@ process parameters to values, and the following mutable fields:
   dead
 \item \code{precedence}: wake time if sleeping or 0 if ready to run
 \item \code{flags}: fixnum with bit 0 set when sleeping, bit 1 set
-  when the process traps exits, and bit 2 set when the process is
-  blocked for I/O
+  when the process traps exits, bit 2 set when the process is
+  blocked for I/O, and bit 3 set when the process is pending a
+  keyboard interrupt
 \item \code{links}: list of linked processes
 \item \code{monitors}: list of monitors
 \item \code{src}: source location \code{\#(at \var{char-offset}
@@ -1367,6 +1368,7 @@ been redefined to use \code{make-process-parameter}:
 \code{command-line-arguments},
 \code{custom-port-buffer-size},
 \code{exit-handler},
+\code{keyboard-interrupt-handler}.
 \code{pretty-initial-indent},
 \code{pretty-line-length},
 \code{pretty-maximum-lines},
@@ -1413,6 +1415,16 @@ The \code{make-inherited-parameter} procedure calls
 \code{make-process-parameter} to create a per-process
 parameter procedure \var{p} and adds \var{p} to the
 \code{inherited-parameters} list before returning \var{p}.
+
+% -------------------------------------------------------------------------
+\defineentry{keyboard-interrupt}
+\begin{procedure}
+  \code{(keyboard-interrupt \var{process})}
+\end{procedure}
+\returns{} unspecified
+
+The \code{keyboard-interrupt} procedure causes \var{process} to call
+\code{((keyboard-interrupt-handler))} as soon as possible.
 
 % -------------------------------------------------------------------------
 \defineentry{on-exit}

--- a/src/swish/app.ss
+++ b/src/swish/app.ss
@@ -42,6 +42,7 @@
    (swish gatekeeper)
    (swish io)
    (swish log-db)
+   (swish meta)
    (swish osi)
    (swish pregexp)
    (swish software-info)
@@ -149,7 +150,17 @@
           (try-import)
           (parameterize ([waiter-prompt-string (if (opt 'quiet) "" ">")]
                          [repl-level (+ (repl-level) 1)])
-            (hook-interactive)
+            (define (trap-CTRL-C handler)
+              (meta-cond
+               [windows?
+                (signal-handler SIGBREAK handler)
+                (signal-handler SIGINT handler)]
+               [else
+                (signal-handler SIGINT handler)]))
+            (when (interactive?)
+              (trap-CTRL-C
+               (let ([p self])
+                 (lambda (n) (keyboard-interrupt p)))))
             (for-each load filenames)
             (new-cafe)))]
        [else                            ; script
@@ -169,106 +180,4 @@
               [,_ (void)])))])))
 
   (define (swish-start . args)
-    ($swish-start #f args run))
-
-  (module (hook-interactive)
-    ;; Provide CTRL-C for the repl with a custom binary input port
-    ;; that can be interrupted by CTRL-C to call the
-    ;; keyboard-interrupt-handler and then retry the read just as Chez
-    ;; Scheme does.
-    (define (hook-interactive)
-      (when ok-to-hook?
-        (let ([ip (make-console-input)]
-              [old-ip (#%$top-level-value '$console-input-port)])
-          ;; Chez Scheme uses $console-input-port to do smart flushing
-          ;; of console I/O.
-          (#%$set-top-level-value! '$console-input-port ip)
-          (console-input-port ip)
-          (current-input-port ip)
-          (close-port old-ip))
-        (trap-CTRL-C (let ([p self]) (lambda (n) (keyboard-interrupt p))))
-        (set! ok-to-hook? #f)))
-    (define ok-to-hook? (interactive?))
-    (meta define windows? (memq (machine-type) '(i3nt ti3nt a6nt ta6nt)))
-    (define (trap-CTRL-C handler)
-      (meta-cond
-       [windows?
-        (signal-handler SIGBREAK handler)
-        (signal-handler SIGINT handler)]
-       [else
-        (signal-handler SIGINT handler)]))
-    (define (make-console-input)
-      (define osip (open-fd-port "stdin-nb" 0 #f))
-      (define fp 0)
-      (define (r! bv start n)
-        (match (with-interrupts-disabled (@r! bv start n))
-          [,count
-           (guard (fixnum? count))
-           (set! fp (+ fp count))
-           count]
-          [interrupt
-           ((keyboard-interrupt-handler))
-           (r! bv start n)]
-          [`(catch ,r) (throw r)]))
-      (define (gp) fp)
-      (define (close) (close-osi-port osip))
-      (meta-cond
-       [windows?
-        ;; When CTRL-C or CTRL-BREAK is pressed in Windows, the read
-        ;; returns 0 immediately, and later the signal is processed.
-        ;; libuv could return UV_EINTR in this case, but it doesn't.
-        (define (@r! bv start n)
-          (match (try (read-osi-port osip bv start n -1))
-            [0 (call/1cc
-                (lambda (return)
-                  ;; Give Windows time to deliver the signal before we
-                  ;; close the input port.
-                  (parameterize ([keyboard-interrupt-handler
-                                  (lambda () (return 'interrupt))])
-                    (receive (after 200 0)))))]
-            [,r r]))]
-       [else
-        ;; When CTRL-C is pressed in Unix-like systems, the read
-        ;; returns EINTR, and libuv automatically retries. As a
-        ;; result, we spawn a separate reader process so that we can
-        ;; interrupt the read.
-        (define reader
-          (spawn
-           (lambda ()
-             (disable-interrupts)
-             (@read-loop #f))))
-        ;; cell: (pid . active?) is used to keep the reader process from
-        ;; responding to an interrupted read request.
-        (alias pid car)
-        (alias active? cdr)
-        (alias active?-set! set-cdr!)
-        (define (@read-loop r)
-          ;; r: result of read-osi-port or #f
-          (receive
-           [#(,bv ,start ,n ,cell)
-            (let ([r (or r (try (read-osi-port osip bv start n -1)))])
-              (cond
-               [(active? cell)
-                (active?-set! cell #f)
-                (send (pid cell) `#(,self ,r))
-                (@read-loop #f)]
-               [else
-                ;; We assume the next call will have the same bv,
-                ;; start & n, which the Chez Scheme transcoded-port
-                ;; appears to do.
-                (@read-loop r)]))]))
-        (define (@r! bv start n)
-          (define cell (cons self #t))
-          (send reader `#(,bv ,start ,n ,cell))
-          (call/1cc
-           (lambda (return)
-             (parameterize
-                 ([keyboard-interrupt-handler
-                   (lambda ()
-                     ;; Ignore when the reader has already responded.
-                     (when (active? cell)
-                       (active?-set! cell #f)
-                       (return 'interrupt)))])
-               (receive [#(,@reader ,r) r])))))])
-      (binary->utf8
-       (make-custom-binary-input-port "stdin-nb*" r! gp #f close)))))
+    ($swish-start #f args run)))

--- a/src/swish/erlang.ss
+++ b/src/swish/erlang.ss
@@ -361,7 +361,7 @@
 
   (define (keyboard-interrupt p)
     (unless (pcb? p)
-      (bad-arg 'interrupt p))
+      (bad-arg 'keyboard-interrupt p))
     (if (eq? p self)
         ((keyboard-interrupt-handler))
         (no-interrupts

--- a/src/swish/erlang.ss
+++ b/src/swish/erlang.ss
@@ -913,7 +913,8 @@
                                  (case-lambda
                                   [() (raise 'normal)]
                                   [(x . args) (throw x)]))
-                                (reset-handler (lambda () (done 'normal)))
+                                (reset-handler
+                                 (lambda () (done (make-fault 'reset))))
                                 (thunk)
                                 'normal))])
                         ;; Process finished

--- a/src/swish/io.ss
+++ b/src/swish/io.ss
@@ -101,6 +101,7 @@
   (import
    (chezscheme)
    (swish erlang)
+   (swish meta)
    (swish osi)
    )
 
@@ -459,11 +460,93 @@
   (define (make-console-input)
     (binary->utf8 (make-osi-input-port (open-fd-port "stdin-nb" 0 #f))))
 
+  (define (make-interruptable-console-input)
+    ;; Provide CTRL-C for the repl with a custom binary input port
+    ;; that can be interrupted by CTRL-C to call the
+    ;; keyboard-interrupt-handler and then retry the read just as Chez
+    ;; Scheme does.
+    (define osip (open-fd-port "stdin-nb" 0 #f))
+    (define fp 0)
+    (define (r! bv start n)
+      (match (with-interrupts-disabled (@r! bv start n))
+        [,count
+         (guard (fixnum? count))
+         (set! fp (+ fp count))
+         count]
+        [interrupt
+         ((keyboard-interrupt-handler))
+         (r! bv start n)]
+        [`(catch ,r) (throw r)]))
+    (define (gp) fp)
+    (define (close) (close-osi-port osip))
+    (meta-cond
+     [windows?
+      ;; When CTRL-C or CTRL-BREAK is pressed in Windows, the read
+      ;; returns 0 immediately, and later the signal is processed.
+      ;; libuv could return UV_EINTR in this case, but it doesn't.
+      (define (@r! bv start n)
+        (match (try (read-osi-port osip bv start n -1))
+          [0 (call/1cc
+              (lambda (return)
+                ;; Give Windows time to deliver the signal before we
+                ;; close the input port.
+                (parameterize ([keyboard-interrupt-handler
+                                (lambda () (return 'interrupt))])
+                  (receive (after 100 0)))))]
+          [,r r]))]
+     [else
+      ;; When CTRL-C is pressed in Unix-like systems, the read
+      ;; returns EINTR, and libuv automatically retries. As a
+      ;; result, we spawn a separate reader process so that we can
+      ;; interrupt the read.
+      (define reader
+        (spawn
+         (lambda ()
+           (disable-interrupts)
+           (@read-loop #f))))
+      ;; cell: (pid . active?) is used to keep the reader process from
+      ;; responding to an interrupted read request.
+      (alias pid car)
+      (alias active? cdr)
+      (alias active?-set! set-cdr!)
+      (define (@read-loop r)
+        ;; r: result of read-osi-port or #f
+        (receive
+         [#(,bv ,start ,n ,cell)
+          (let ([r (or r (try (read-osi-port osip bv start n -1)))])
+            (cond
+             [(active? cell)
+              (active?-set! cell #f)
+              (send (pid cell) `#(,self ,r))
+              (@read-loop #f)]
+             [else
+              ;; We assume the next call will have the same bv,
+              ;; start & n, which the Chez Scheme transcoded-port
+              ;; appears to do.
+              (@read-loop r)]))]))
+      (define (@r! bv start n)
+        (define cell (cons self #t))
+        (send reader `#(,bv ,start ,n ,cell))
+        (call/1cc
+         (lambda (return)
+           (parameterize
+               ([keyboard-interrupt-handler
+                 (lambda ()
+                   ;; Ignore when the reader has already responded.
+                   (when (active? cell)
+                     (active?-set! cell #f)
+                     (return 'interrupt)))])
+             (receive [#(,@reader ,r) r])))))])
+    (binary->utf8
+     (make-custom-binary-input-port "stdin-nb*" r! gp #f close)))
+
   (define hook-console-input
     (let ([hooked? #f])
       (lambda ()
         (unless hooked?
-          (let ([ip (make-console-input)])
+          (let ([ip (if (interactive?)
+                        (make-interruptable-console-input)
+                        (make-console-input))])
             ;; Chez Scheme uses $console-input-port to do smart
             ;; flushing of console I/O.
             (set! hooked? #t)

--- a/src/swish/meta.ss
+++ b/src/swish/meta.ss
@@ -39,6 +39,7 @@
    scdr
    snull?
    syntax-datum-eq?
+   windows?
    with-temporaries
    )
   (import (chezscheme))
@@ -167,6 +168,13 @@
         (lambda (ae)
           (rebuild x (annotation-expression ae)))]
        [else x])))
+
+  (define-syntax windows?
+    (meta-cond
+     [(memq (machine-type) '(i3nt ti3nt a6nt ta6nt))
+      (identifier-syntax #t)]
+     [else
+      (identifier-syntax #f)]))
 
   (define-syntax with-temporaries
     (syntax-rules ()


### PR DESCRIPTION
Quick sketch. Can we do something better?

```
$ swish
> (let f () (f))
^C
break> i
#<system continuation>              : q

break> q
>
```