### PR TITLE
HTTP paths must start with /

### DIFF
--- a/src/swish/http.ms
+++ b/src/swish/http.ms
@@ -137,6 +137,8 @@
                    "0123")))]
     [#(EXIT #(invalid-http-path "/.."))
      (catch (test "GET /.. HTTP/1.1\r\n\r\n"))]
+    [#(EXIT #(invalid-http-path "foo"))
+     (catch (test "GET foo HTTP/1.1\r\n\r\n"))]
     [#(EXIT #(bad-arg http:respond "foo"))
      (catch (test "GET /mat?cmd=bad+arg&bad=foo HTTP/1.1\r\n\r\n"))]
     [#(EXIT #(invalid-content-length "none"))


### PR DESCRIPTION
The code should check for absolute paths and then remove the leading / when forming the full path.