### PR TITLE
handle errors with cyclic structures

### DIFF
--- a/src/swish/log-db.ms
+++ b/src/swish/log-db.ms
@@ -66,5 +66,9 @@
      (coerce
       (json:make-object
        [foo 123]
-       [bar (list 1 "two" (json:make-object [zip #t]))]))])
+       [bar (list 1 "two" (json:make-object [zip #t]))]))]
+    ["#0=(1 . #0#)"
+     (coerce '#0=(1 . #0#))]
+    ["#(error \"Exception occurred with condition components:\\n  0. &irritants: #0=(1 . #0#).\")"
+     (coerce (make-irritants-condition '#1=(1 . #1#)))])
    'ok))

--- a/src/swish/log-db.ss
+++ b/src/swish/log-db.ss
@@ -188,21 +188,22 @@
      [(process? x) (process->child-id x)]
      [(date? x) (format-rfc2822 x)]
      [(condition? x)
-      (let ([op (open-output-string)])
-        (display-condition x op)
-        (write-char #\. op)
-        (let ([reason-string (get-output-string op)]
-              [stack-string
-               (and (continuation-condition? x)
-                    (let ([op (open-output-string)])
-                      (dump-stack (condition-continuation x) op 'default)
-                      (get-output-string op)))])
-          (format "~s"
-            (if stack-string
-                `#(error ,reason-string ,stack-string)
-                `#(error ,reason-string)))))]
+      (parameterize ([print-graph #t])
+        (let ([op (open-output-string)])
+          (display-condition x op)
+          (write-char #\. op)
+          (let ([reason-string (get-output-string op)]
+                [stack-string
+                 (and (continuation-condition? x)
+                      (let ([op (open-output-string)])
+                        (dump-stack (condition-continuation x) op 'default)
+                        (get-output-string op)))])
+            (format "~s"
+              (if stack-string
+                  `#(error ,reason-string ,stack-string)
+                  `#(error ,reason-string))))))]
      [(json:object? x) (json:object->string x)]
-     [else (format "~s" x)]))
+     [else (parameterize ([print-graph #t]) (format "~s" x))]))
 
   (define-syntax (log-sql x)
     (syntax-case x ()

--- a/web/swish/errors.ss
+++ b/web/swish/errors.ss
@@ -98,4 +98,5 @@
       (with-db [db (log-file) SQLITE_OPEN_READONLY]
         (do-query db sql limit offset type func)))))
 
+(print-graph #t)
 (dispatch)


### PR DESCRIPTION
The coerce function in log-db.ss needs to enable print-graph to avoid warnings from cyclic structures, and the errors web page needs to enable print-graph when it processes these potentially cyclic structures.