### PR TITLE
fix git revision determination when installed git is < v2.13

### DIFF
--- a/src/swish/Mf-base
+++ b/src/swish/Mf-base
@@ -30,7 +30,7 @@ all: ready ${CORE} ${AUXLIB} ${REMINDERS}
 	fi
 
 git.tmp-revision:
-	@git describe --always --exclude='*' --abbrev=40 --dirty > "$@"
+	@git describe --always --match none --abbrev=40 --dirty > "$@"
 
 chezscheme.tmp-revision:
 	@if [ ! -f "${SCHEME_REVISION_PATH}/revision" ]; then \


### PR DESCRIPTION
git-describe gained the --exclude option in v2.13, but
Ubuntu 16.04 ships an older version of git that lacks
this option. On such systems, the build initially fails:

 $ ./configure
 $ make
 error: unknown option 'exclude=*'
 ...
 Mf-base:33: recipe for target 'git.tmp-revision' failed

Unfortunately, this leaves an empty 'git.tmp-revision' file
in place, so simply retrying 'make' appears to succeed, but
may bake the wrong git revision into the swish executable.

We now use 'git describe --match none ...', which is supported
by older git versions, and assume that we'll never use "none"
as a tag name.