### PR TITLE
use LaTeX fonts in dot figures and fit to width

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ is not thread safe and should be used from the main thread only.
 - ginstall and realpath (can be installed through homebrew using `brew install coreutils`)
 - XCode and the command-line tools must be set
   (Xcode->Preferences->Locations->command line tools)
+- Latin Modern fonts from LaTeX (can be installed with Font Book from a location like `/usr/local/texlive/2019/texmf-dist/fonts/opentype/public/lm`)
 
 ## Windows
 

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -17,5 +17,6 @@
 *.thm
 *.toc
 /c-coding-standard.pdf
+/font.conf
 /scheme-coding-standard.pdf
 /swish.pdf

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -11,8 +11,15 @@ all: $(pdf)
 %.pdf: %.tex sagian.sty swish.sty reference.bib
 	./run-latex $*
 
-%.pdf: %.dot
-	dot -Tpdf -o $@ $<
+%.pdf: %.dot font.conf
+	FONTCONFIG_FILE=$${PWD}/font.conf dot -Tpdf -o $@ $<
+
+font.conf:
+	@echo '<?xml version="1.0"?>' > $@
+	@echo '<!DOCTYPE fontconfig SYSTEM "fonts.dtd">' >> $@
+	@echo '<fontconfig>' >> $@
+	@echo "  <dir>$$(dirname $$(kpsewhere lmroman10-regular.otf))</dir>" >> $@
+	@echo '</fontconfig>' >> $@
 
 swish :=\
   swish/*.tex\
@@ -24,5 +31,5 @@ swish.pdf: $(swish)
 
 .PHONY: clean
 clean:
-	rm -f $(pdf) *.aux *.bbl *.blg *.lof *.log *.lot *.out *.idx *.ind *.ilg *.toc *.thm swish/*.aux
+	rm -f $(pdf) *.aux *.bbl *.blg *.lof *.log *.lot *.out *.idx *.ind *.ilg *.toc *.thm swish/*.aux font.conf
 	find . -iname "*.dot" | sed "s/\.dot$$/\.pdf/" | xargs rm -f

--- a/doc/swish/http-tree.dot
+++ b/doc/swish/http-tree.dot
@@ -1,11 +1,11 @@
 digraph G {
   graph [margin=0];
-  node [shape=box,fontname="Courier",fontsize=11];
+  node [shape=box,fontname="Latin Modern Mono",fontsize=10];
   supervisor [label="http-sup",shape=ellipse];
   listener [label="http-listener"];
   cache [label="http-cache"];
-  hc1 [label="http-connection 1",fontname="Times-Roman"];
-  hc2 [label="http-connection 2",fontname="Times-Roman"];
+  hc1 [label="http-connection 1",fontname="Latin Modern Roman,"];
+  hc2 [label="http-connection 2",fontname="Latin Modern Roman,"];
   supervisor -> listener;
   supervisor -> cache;
   supervisor -> hc1;

--- a/doc/swish/intro-sup-tree.dot
+++ b/doc/swish/intro-sup-tree.dot
@@ -1,6 +1,6 @@
 digraph G {
   graph [margin=0,rankdir=LR];
-  node [shape=box,fontname="Courier",fontsize=10];
+  node [shape=box,fontname="Latin Modern Mono",fontsize=10];
   application [label="application"];
   mainsup [label="main-sup",shape=ellipse];
   eventmgr [label="event-mgr"];
@@ -11,8 +11,8 @@ digraph G {
   httpsup [label="http-sup",shape=ellipse];
   httpd [label="http-listener"];
   httpcache [label="http-cache"];
-  hc1 [label="http-connection 1",fontname="Times-Roman"];
-  hc2 [label="http-connection 2",fontname="Times-Roman"];
+  hc1 [label="http-connection 1",fontname="Latin Modern Roman,"];
+  hc2 [label="http-connection 2",fontname="Latin Modern Roman,"];
   application -> mainsup;
   mainsup -> application;
   mainsup -> eventmgr;

--- a/doc/swish/intro.tex
+++ b/doc/swish/intro.tex
@@ -74,7 +74,7 @@ to control re-entrancy.
 \section {Supervision Tree}\label{sec:default-supervision-tree}
 
 \begin{figure}
-  \center\includegraphics{swish/intro-sup-tree.pdf}
+  \center\includegraphics[keepaspectratio,width=\textwidth]{swish/intro-sup-tree.pdf}
   \caption{\label{fig:intro-sup-tree}Supervision Tree}
 \end{figure}
 


### PR DESCRIPTION
Chris pointed out that we had both pushed swish.pdf to gh-pages and wondered what the difference was. It looks like we getting different fonts in the `dot` output.

This is a sketch at using the LaTeX fonts in the figures so we generate the same output. I'm not 100% sure I've got the [fontconfig](https://www.freedesktop.org/software/fontconfig/fontconfig-user.html) stuff figured out, but this appeared to work.