### PR TITLE
use sealed records when possible for greater efficiency

### DIFF
--- a/doc/swish/db.tex
+++ b/doc/swish/db.tex
@@ -101,31 +101,50 @@ guardian via \code{make-foreign-handle-guardian}.
 \paragraph* {dictionary parameters}\index{db!parameters}
 \begin{itemize}
 
-\item \code{current-database} stores a Scheme record:\newline
-  \code{(define-record-type database (fields (mutable
-    handle)))}\newline The \code{handle} is set to \code{\#f} when
-  the database is closed.
+\item \code{current-database} stores a Scheme record:
+  \begin{alltt}
+(define-record-type database
+  (fields
+   (immutable filename)
+   (immutable create-time)
+   (mutable handle)))
+  \end{alltt}\antipar
+  The \code{handle} is set to \code{\#f} when the database is closed.
 
-\item \code{statement-cache} stores a Scheme record:\newline
-  \code{(define-record-type cache (fields (immutable ht) (mutable
-    waketime) (mutable lazy-statements)))}\newline
+\item \code{statement-cache} stores a Scheme record:
+  \begin{alltt}
+(define-record-type cache
+  (fields
+   (immutable ht)
+   (mutable waketime)
+   (mutable lazy-statements)))
+  \end{alltt}\antipar
   The \code{waketime} is the next time the cache will attempt to
   remove dead entries.
 
-  The hash table, \code{ht}, maps SQL strings to a Scheme
-  record:\newline \code{(define-record-type entry (fields
-    (immutable stmt) (mutable timestamp)))}\newline
+  The hash table, \code{ht}, maps SQL strings to a Scheme record:
+  \begin{alltt}
+(define-record-type entry
+  (fields
+   (immutable stmt)
+   (mutable timestamp)))
+  \end{alltt}\antipar
 
   When a SQL string is not found in the cache,
   \code{osi\_prepare\_statement} is used with the
   \code{current-database} to make a SQLite statement. The raw
-  statement handle is stored in a Scheme record:\newline
-  \code{(define-record-type statement (fields (immutable handle)
-    (immutable database)))}\newline
-  The statement is finalized using
-  \code{osi\_finalize\_statement} when it is removed from the
-  cache. \code{osi\_close\_database} will finalize any remaining
-  statements associated with the database.
+  statement handle is stored in a Scheme record:
+  \begin{alltt}
+(define-record-type statement
+  (fields
+   (immutable database)
+   (immutable sql)
+   (immutable create-time)
+   (mutable handle)))
+  \end{alltt}\antipar
+  The statement is finalized using \code{osi\_finalize\_statement}
+  when it is removed from the cache. \code{osi\_close\_database} will
+  finalize any remaining statements associated with the database.
 
   When a SQL string is found in the cache, the entry's
   \code{timestamp} is updated. Entries older than 5 minutes will

--- a/src/swish/db.ss
+++ b/src/swish/db.ss
@@ -301,6 +301,7 @@
 
   (define-record-type cache
     (nongenerative)
+    (sealed #t)
     (fields
      (immutable ht)
      (mutable waketime)
@@ -312,6 +313,7 @@
 
   (define-record-type entry
     (nongenerative)
+    (sealed #t)
     (fields
      (immutable stmt)
      (mutable timestamp))
@@ -360,6 +362,7 @@
 
   (define-record-type database
     (nongenerative)
+    (sealed #t)
     (fields
      (immutable filename)
      (immutable create-time)
@@ -386,6 +389,7 @@
 
   (define-record-type statement
     (nongenerative)
+    (sealed #t)
     (fields
      (immutable database)
      (immutable sql)

--- a/src/swish/digest.ss
+++ b/src/swish/digest.ss
@@ -66,6 +66,7 @@
   (define-record-type digest
     (parent digest-provider)
     (nongenerative)
+    (sealed #t)
     (fields
      (mutable ctx)
      (immutable algorithm)

--- a/src/swish/erlang.ss
+++ b/src/swish/erlang.ss
@@ -141,6 +141,7 @@
 
   (define-record-type msg
     (nongenerative)
+    (sealed #t)
     (fields
      (immutable contents))
     (parent q)
@@ -151,12 +152,14 @@
 
   (define-record-type mon
     (nongenerative)
+    (sealed #t)
     (fields
      (immutable origin)
      (immutable target)))
 
   (define-record-type pcb
     (nongenerative)
+    (sealed #t)
     (fields
      (immutable id)
      (immutable create-time)

--- a/src/swish/io.ss
+++ b/src/swish/io.ss
@@ -126,6 +126,7 @@
 
   (define-record-type osi-port
     (nongenerative)
+    (sealed #t)
     (fields
      (immutable name)
      (immutable create-time)
@@ -290,6 +291,7 @@
 
   (define-record-type %type-reporter
     (nongenerative)
+    (sealed #t)
     (fields
      (immutable name)
      (immutable count)
@@ -405,6 +407,7 @@
 
   (define-record-type path-watcher
     (nongenerative)
+    (sealed #t)
     (fields
      (immutable path)
      (immutable create-time)
@@ -770,6 +773,7 @@
 
   (define-record-type listener
     (nongenerative)
+    (sealed #t)
     (fields
      (immutable address)
      (immutable port-number)
@@ -874,6 +878,7 @@
 
   (define-record-type sighandler
     (nongenerative)
+    (sealed #t)
     (fields
      (immutable signum)
      (immutable create-time)

--- a/src/swish/mat.ss
+++ b/src/swish/mat.ss
@@ -58,6 +58,7 @@
 
   (define-record-type (%mat make-mat mat?)
     (nongenerative)
+    (sealed #t)
     (fields
      (immutable name)
      (immutable tags)


### PR DESCRIPTION
Sealed record types perform record type checks very efficiently, so let's use them whenever possible.