### PR TITLE
Fix bugs in close_fd_port and osi_get_bytes_used

### DIFF
--- a/src/swish/osi.c
+++ b/src/swish/osi.c
@@ -610,7 +610,6 @@ ptr osi_get_argv() {
 
 size_t osi_get_bytes_used(void) {
 #if defined(__APPLE__)
-  malloc_zone_pressure_relief(NULL, 0);
   struct mstats ms = mstats();
   return ms.bytes_used;
 #elif defined(__GLIBC__)

--- a/src/swish/osi.c
+++ b/src/swish/osi.c
@@ -1118,7 +1118,7 @@ ptr osi_open_file(const char* path, int flags, int mode, ptr callback) {
   if (rc < 0) {
     Sunlock_object(callback);
     free(req);
-    return osi_make_error_pair("uv_fs_close", rc);
+    return osi_make_error_pair("uv_fs_open", rc);
   }
   return Strue;
 }

--- a/src/swish/run.c
+++ b/src/swish/run.c
@@ -275,7 +275,7 @@ int swish_service(int argc, const char* argv[]) {
   // but for now it's simpler to close poll_handle here and close osi_loop.
   uv_poll_stop(&poll_handle);
   uv_close((uv_handle_t*)&poll_handle, NULL);
-  uv_run(osi_loop, UV_RUN_NOWAIT);
+  osi_get_callbacks(0); // drop any callbacks since we're exiting
   g_exit.force = uv_loop_close(osi_loop);
   if (g_exit.force)
     _exit(status);

--- a/src/swish/shlibtest.c
+++ b/src/swish/shlibtest.c
@@ -20,15 +20,66 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#define SWISH_IMPORT
 #include "swish.h"
+#undef EXPORT
+#include <stdlib.h>
+
+#ifdef __APPLE__
+#include <malloc/malloc.h>
+#else
+#include <malloc.h>
+#endif
+
+#ifdef _WIN32
+#define EXPORT __declspec (dllexport)
+#else
+#define EXPORT
+#endif
+
+#define container_of(p, t, member) ((t*)((char*)(p)-offsetof(t, member)))
+#define malloc_container(t) ((t*)malloc(sizeof(t)))
 
 EXPORT int square(int n) {
   return n * n;
 }
 
+typedef struct {
+  uv_async_t async;
+  ptr callback;
+  ptr arg;
+} call_req_t;
+
+void close_cb(uv_handle_t* handle) {
+  call_req_t* call_req = container_of(handle, call_req_t, async);
+  free(call_req);
+}
+
+static void call_req_cb(uv_async_t* async) {
+  call_req_t* call_req = container_of(async, call_req_t, async);
+  ptr callback = call_req->callback;
+  ptr arg = call_req->arg;
+  Sunlock_object(callback);
+  Sunlock_object(arg);
+  osi_add_callback1(callback, Sstring(uv_err_name(UV_EROFS)));
+  osi_add_callback1(callback, arg);
+  uv_close((uv_handle_t*)&call_req->async, close_cb);
+}
+
 // make sure shared library can resolve functions from libuv, scheme, and osi
 EXPORT ptr call_it(ptr cb, ptr arg) {
-  osi_add_callback1(cb, Sstring(uv_err_name(UV_EROFS)));
-  osi_add_callback1(cb, arg);
+  call_req_t* req = malloc_container(call_req_t);
+  if (!req)
+    return osi_make_error_pair(__func__, UV_ENOMEM);
+  int rc = uv_async_init(osi_loop, &req->async, call_req_cb);
+  if (rc < 0)
+    return osi_make_error_pair("uv_async_init", rc);
+  rc = uv_async_send(&req->async);
+  if (rc < 0)
+    return osi_make_error_pair("uv_async_send", rc);
+  Slock_object(cb);
+  Slock_object(arg);
+  req->callback = cb;
+  req->arg = arg;
   return Strue;
 }


### PR DESCRIPTION
`close_fd_port` called `osi_add_callback1` outside of `osi_get_callbacks`, and this sometimes led to a panic with `#(event-loop-process-terminated #(bad-arg complete-io #<garbage>))`.

On macOS, the `malloc_zone_pressure_relief` call in `osi_get_bytes_used` sometimes causes an invalid memory reference, so I removed it.