### PR TITLE
minor testing fixes

### DIFF
--- a/src/swish/app.ms
+++ b/src/swish/app.ms
@@ -412,7 +412,8 @@
             [locking-up 'ok])
           (printf "armed and ready\n")
           (send (whereis 'bad-sup) 'disarm)
-          (receive (after 1000 (osi_exit 4)))))
+          ;; Travis ta6osx build occasionally takes > 5s of real time
+          (receive (after 10000 (osi_exit 4)))))
       '("expected non-zero exit")))
    [#(EXIT `(<os-process-failed> [exit-status 2] ,stdout))
     (match-regexps '(seek "armed and ready") stdout)]))

--- a/src/swish/mat.ss
+++ b/src/swish/mat.ss
@@ -235,12 +235,15 @@
           ;; record revision information after loading mats, but before running mats
           (write-meta-data mo-op 'software-info (software-info))
           (write-meta-data mo-op 'date (format-rfc2822 (current-date)))
-          (write-meta-data mo-op 'timestamp (erlang:now)))
+          (write-meta-data mo-op 'timestamp (erlang:now))
+          (flush-output-port mo-op))
         (for-each
          (lambda (mat/name)
            (run-mat mat/name reporter incl-tags excl-tags))
          (or mat/names (all-mats)))
-        (when mo-op (write-meta-data mo-op 'completed #t))
+        (when mo-op
+          (write-meta-data mo-op 'completed #t)
+          (flush-output-port mo-op))
         (let-values ([(pass fail skip) (get-tally)])
           (case progress
             [none (void)]
@@ -291,7 +294,8 @@
 
   (define (make-write-summary op)
     (lambda (r)
-      (json:write op r 0)))
+      (json:write op r 0)
+      (flush-output-port op)))
 
   (define (run-mats-to-file filename)
     (define test-file (string-append "to " filename))


### PR DESCRIPTION
- flush mat output give better odds of parsing test results on failure
- bump timeout in application-shutdown test that seems to upset ta6osx