### PR TITLE
fix bugs in pregexp look-behind matching

### DIFF
--- a/doc/reference.bib
+++ b/doc/reference.bib
@@ -61,6 +61,14 @@
   note = {\url{http://www.erlang.se/doc/programming_rules.shtml}}
 }
 
+@book{friedl:regex,
+  author = {Jeffrey E. F. Friedl},
+  title = {{Mastering Regular Expressions}},
+  year = {2002},
+  edition = "second",
+  publisher = {O'Reilly}
+}
+
 @misc{gen-server-ref,
   title = {Erlang gen\_server module},
   key = {Erlang gen-server module},
@@ -109,7 +117,7 @@
   author = {Dorai Sitaram},
   title = {{pregexp: Portable Regular Expressions for Scheme and Common Lisp}},
   year = {2005},
-  note = {\url{http://ds26gte.github.io/pregexp/index.html}}
+  note = {\url{https://ds26gte.github.io/pregexp/}}
 }
 
 @book{programming-erlang,
@@ -202,6 +210,14 @@
   booktitle = {{Proceedings of the ACM SIGPLAN '90 Conference on Programming Language Design and Implementation}},
   year = {1990},
   pages = {66--77}
+}
+
+@book{pperl,
+  author = {Larry Wall and Tom Christiansen and Jon Orwant},
+  title = {{Programming Perl}},
+  edition = "third",
+  year = {2000},
+  publisher = {O'Reilly}
 }
 
 @misc{winusb,

--- a/doc/swish/chapters.tex
+++ b/doc/swish/chapters.tex
@@ -2,6 +2,7 @@
 \input{swish/app}
 \input{swish/osi}
 \input{swish/erlang}
+\input{swish/pregexp}
 \input{swish/gen-server}
 \input{swish/event-mgr}
 \input{swish/gatekeeper}

--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -2736,8 +2736,7 @@ reason from Swish into an English string.
 \subsection{String Utilities}
 
 The string utilities below are found in the \code{(swish
-  string-utils)} library. For regular expression support, see the
-\code{(swish pregexp)} library described in~\cite{pregexp}.
+  string-utils)} library.
 
 % ----------------------------------------------------------------------------
 \defineentry{ends-with?}
@@ -2854,18 +2853,6 @@ comparisons.
 
 The \code{symbol-append} procedure returns the symbol formed by
 appending the symbols passed as arguments.
-
-% ----------------------------------------------------------------------------
-\defineentry{re}
-\begin{syntax}
-  \code{(re \var{regexp})}
-\end{syntax}
-\expandsto{}
-\code{(pregexp \var{regexp})}
-
-If \var{regexp} is a literal string, the \code{re} macro expands to the
-result of evaluating \code{(pregexp\ \var{regexp})} at expand time.
-Otherwise it expands into a run-time call to \code{pregexp}.
 
 \subsection {Message Digests}
 

--- a/doc/swish/pregexp.tex
+++ b/doc/swish/pregexp.tex
@@ -1,0 +1,817 @@
+% Copyright (c) 1999-2015, Dorai Sitaram.
+% All rights reserved.
+
+% Permission to copy, modify, distribute, and use this work or
+% a modified copy of this work, for any purpose, is hereby
+% granted, provided that the copy includes this copyright
+% notice, and in the case of a modified copy, also includes a
+% notice of modification.  This work is provided as is, with
+% no warranty of any kind.
+
+% Modifications are copyright 2020 Beckman Coulter, Inc.
+
+% Permission is hereby granted, free of charge, to any person
+% obtaining a copy of this software and associated documentation files
+% (the "Software"), to deal in the Software without restriction,
+% including without limitation the rights to use, copy, modify, merge,
+% publish, distribute, sublicense, and/or sell copies of the Software,
+% and to permit persons to whom the Software is furnished to do so,
+% subject to the following conditions:
+%
+% The above copyright notice and this permission notice shall be
+% included in all copies or substantial portions of the Software.
+%
+% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+% EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+% MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+% NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+% BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+% ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+% CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+% SOFTWARE.
+
+\chapter {Regular Expressions}\label{chap:pregexp}
+
+\section {Introduction}
+
+The regular expressions library \code{(swish pregexp)} is a derivative
+of pregexp: Portable Regular Expressions for Scheme and Common
+Lisp~\cite{pregexp}. It provides regular expressions modeled on
+Perl's~\cite{friedl:regex,pperl} and includes such powerful directives
+as numeric and non-greedy quantifiers, capturing and non-capturing
+clustering, POSIX character classes, selective case- and
+space-insensitivity, back-references, alternation, backtrack pruning,
+positive and negative look-ahead and look-behind, in addition to the
+more basic directives familiar to all regexp users.
+
+A \emph{regexp} is a string that describes a pattern.  A regexp
+matcher tries to \emph{match} this pattern against (a portion of)
+another string, which we will call the \emph{text string}.  The text
+string is treated as raw text and not as a pattern.
+
+Most of the characters in a regexp pattern are meant to match
+occurrences of themselves in the text string.  Thus, the pattern
+\code{"abc"} matches a string that contains the characters \code{a},
+\code{b}, \code{c} in succession.
+
+In the regexp pattern, some characters act as \emph{metacharacters},
+and some character sequences act as \emph{metasequences}.  That is,
+they specify something other than their literal selves.  For example,
+in the pattern \code{"a.c"}, the characters \code{a} and \code{c} do
+stand for themselves but the \emph{metacharacter} `\code{.}'  can
+match \emph{any} character (other than newline).  Therefore, the
+pattern \code{"a.c"} matches an \code{a}, followed by \emph{any}
+character, followed by a \code{c}.
+
+If we needed to match the character `\code{.}' itself, we
+\emph{escape} it, i.e., precede it with a backslash
+(\code{\textbackslash}).  The character sequence
+\code{{\textbackslash}.} is thus a \emph{metasequence}, since it
+doesn't match itself but rather just `\code{.}'.  So, to match
+\code{a} followed by a literal `\code{.}' followed by \code{c}, we use
+the regexp pattern
+\code{"a{\textbackslash}{\textbackslash}.c"}.\footnote{The double
+  backslash is an artifact of Scheme strings, not the regexp pattern
+  itself.  When we want a literal backslash inside a Scheme string, we
+  must escape it so that it shows up in the string at all. Scheme
+  strings use backslash as the escape character, so we end up with two
+  backslashes.} Another example of a metasequence is
+\code{{\textbackslash}t}, which is a readable way to represent the tab
+character.
+
+We will call the string representation of a regexp the
+\emph{U-regexp}, where \emph{U} can be taken to mean {\em Unix-style}
+or \emph{universal}, because this notation for regexps is universally
+familiar.  Our implementation uses an intermediate tree-like
+representation called the \emph{S-regexp}, where \emph{S} can stand
+for \emph{Scheme}, \emph{symbolic}, or \emph{s-expression}.  S-regexps
+are more verbose and less readable than U-regexps, but they are much
+easier for Scheme's recursive procedures to navigate.
+
+\section {Programming Interface}
+
+% ----------------------------------------------------------------------------
+\defineentry{pregexp}
+\begin{procedure}
+  \code{(pregexp \var{regexp})}
+\end{procedure}
+\returns{} an S-regexp
+
+The \code{pregexp} procedure takes a U-regexp string \var{regexp} and
+returns an S-regexp.
+
+% ----------------------------------------------------------------------------
+\defineentry{re}
+\begin{syntax}
+  \code{(re \var{regexp})}
+\end{syntax}
+\expandsto{}
+\code{(pregexp \var{regexp})}
+
+If \var{regexp} is a literal string, the \code{re} macro expands to the
+result of evaluating \code{(pregexp\ \var{regexp})} at expand time.
+Otherwise it expands into a run-time call to \code{pregexp}.
+
+% ----------------------------------------------------------------------------
+\defineentry{pregexp-match-positions}
+\begin{procedure}
+  \code{(pregexp-match-positions \var{pat} \var{str} \opt{\var{start} \opt{\var{end}}})}
+\end{procedure}
+\returns{} \code{((\var{s}~.~\var{e}) \ldots)} or \code{\#f}
+
+The \code{pregexp-match-positions} procedure takes a regexp pattern
+\var{pat} and a text string \var{str} and returns a \emph{match} if
+the regexp matches (some part of) the text string between the
+inclusive \var{start} index (defaults to 0) and the exclusive
+\var{end} index (defaults to the length of \var{str}).
+
+The regexp may be either a U- or an S-regexp.
+\code{pregexp-match-positions} will internally compile a U-regexp to
+an S-regexp before proceeding with the matching.  If you find yourself
+calling \code{pregexp-match-positions} repeatedly with the same
+U-regexp, it may be advisable to explicitly convert the latter into an
+S-regexp once beforehand, using \code{pregexp}, to save needless
+recompilation.
+
+\code{pregexp-match-positions} returns a list of \emph{index pairs} if
+the regexp matches the string and \code{\#f} if it does not
+match. Index pair \code{(\var{s}~.~\var{e})} gives the inclusive
+starting index \var{s} and exclusive ending index \var{e} of the
+matching substring with respect to \var{str}. The first index pair
+indicates the entire match, and subsequent pairs indicate
+submatches. Some of the submatches may be \code{\#f}.
+
+% ----------------------------------------------------------------------------
+\defineentry{pregexp-match}
+\begin{procedure}
+  \code{(pregexp-match \var{pat} \var{str} \opt{\var{start} \opt{\var{end}}})}
+\end{procedure}
+\returns{} list of matching substrings or \code{\#f}
+
+The \code{pregexp-match} procedure is called like
+\code{pregexp-match-positions}, but instead of returning index pairs,
+it returns the matching substrings. The first substring is the entire
+match, and subsequent substrings are submatches, some of which may be
+\code{\#f}.
+
+% ----------------------------------------------------------------------------
+\defineentry{pregexp-split}
+\begin{procedure}
+  \code{(pregexp-split \var{pat} \var{str})}
+\end{procedure}
+\returns{} list of substrings from \var{str}
+
+The \code{pregexp-split} procedure takes two arguments, a regexp
+pattern \var{pat} and a text string \var{str}, and returns a list of
+substrings of the text string, where the pattern identifies the
+delimiter separating the substrings. The returned substrings do not
+include the delimiter.
+
+If the pattern can match an empty string, then the list of all the
+single-character substrings is returned.
+
+To identify one or more spaces as the delimiter, take care to use the
+regexp \code{" +"}, not \code{" *"}.
+
+% ----------------------------------------------------------------------------
+\defineentry{pregexp-replace}
+\begin{procedure}
+  \code{(pregexp-replace \var{pat} \var{str} \var{ins})}
+\end{procedure}
+\returns{} a string
+
+The \code{pregexp-replace} procedure replaces the matched portion of
+the text string by another string.  The first argument is the pattern
+\var{pat}, the second the text string \var{str}, and the third is the
+string to be inserted \var{ins}, which may contain back-references
+(see \S\ref{sec:pregexp-back-references}).
+
+If the pattern doesn't occur in the text string, the returned string
+is identical (\code{eq?}) to \var{str}.
+
+% ----------------------------------------------------------------------------
+\defineentry{pregexp-replace*}
+\begin{procedure}
+  \code{(pregexp-replace* \var{pat} \var{str} \var{ins})}
+\end{procedure}
+\returns{} a string
+
+The \code{pregexp-replace*} procedure replaces \emph{all} matches of
+regexp \var{pat} in the text string \var{str} by the insert string
+\var{ins}, which may contain back-references (see
+\S\ref{sec:pregexp-back-references}).
+
+As with \code{pregexp-replace}, if the pattern doesn't occur in the
+text string, the returned string is identical (\code{eq?}) to
+\var{str}.
+
+% ----------------------------------------------------------------------------
+\defineentry{pregexp-quote}
+\begin{procedure}
+  \code{(pregexp-quote \var{str})}
+\end{procedure}
+\returns{} a U-regexp
+
+The \code{pregexp-quote} procedure takes an arbitrary string \var{str}
+and returns a U-regexp string that precisely represents it.  In
+particular, characters in the input string that could serve as regexp
+metacharacters are escaped with a backslash, so that they safely match
+only themselves.
+
+\code{pregexp-quote} is useful when building a composite regexp from a
+mix of regexp strings and verbatim strings.
+
+\section {The Regexp Pattern Language}
+
+\subsection {Basic Assertions}
+
+The \emph{assertions} \code{\textasciicircum} and \code{\$} identify
+the beginning and the end of the text string respectively.  They
+ensure that their adjoining regexps match at the beginning or end of
+the text string.  Examples:
+
+\code{(pregexp-match-positions "{\textasciicircum}contact" "first contact")}
+$\Rightarrow$ \code{\#f}
+
+The regexp fails to match because \code{contact} does not occur at the
+beginning of the text string.
+
+\code{(pregexp-match-positions "laugh\$" "laugh laugh laugh laugh")}
+$\Rightarrow$ \code{((18 . 23))}.
+
+The regexp matches the \emph{last} \code{laugh}.
+
+The metasequence \code{{\textbackslash}b} asserts that a \emph{word
+  boundary} exists.
+
+\code{(pregexp-match-positions "yack{\textbackslash\textbackslash}b"
+  "yackety yack")} $\Rightarrow$ \code{((8 . 12))}
+
+The \code{yack} in \code{yackety} doesn't end at a word boundary so it
+isn't matched.  The second \code{yack} does and is.
+
+The metasequence \code{{\textbackslash}B} has the opposite effect to
+\code{{\textbackslash}b}.  It asserts that a word boundary does not
+exist.
+
+\code{(pregexp-match-positions "an{\textbackslash\textbackslash}B" "an
+  analysis")} $\Rightarrow$ \code{((3 . 5))}
+
+The \code{an} that doesn't end in a word boundary is matched.
+
+\subsection {Characters and Character Classes}
+
+Typically a character in the regexp matches the same character in the
+text string.  Sometimes it is necessary or convenient to use a regexp
+metasequence to refer to a single character.  Thus, metasequences
+\code{{\textbackslash}n}, \code{{\textbackslash}r},
+\code{{\textbackslash}t}, and \code{{\textbackslash}.}  match the
+newline, return, tab, and period characters respectively.
+
+The \emph{metacharacter} period (\code{.}) matches \emph{any}
+character other than newline.
+
+\code{(pregexp-match "p.t" "pet")} $\Rightarrow$ \code{("pet")}
+
+It also matches \code{pat}, \code{pit}, \code{pot}, \code{put}, and
+\code{p8t} but not \code{peat} or \code{pfffft}.
+
+A \emph{character class} matches any one character from a set of
+characters. A typical format for this is the \emph{bracketed character
+  class} \code{[}\ldots\code{]}, which matches any one character from
+the non-empty sequence of characters enclosed within the
+brackets.\footnote{Requiring a bracketed character class to be
+  non-empty is not a limitation, since an empty character class can be
+  more easily represented by an empty string.}  Thus
+\code{"p[aeiou]t"} matches \code{pat}, \code{pet}, \code{pit},
+\code{pot}, \code{put} and nothing else.
+
+Inside the brackets, a hyphen (\code{-}) between two characters
+specifies the ASCII range between the characters.  For example,
+\code{"ta[b-dgn-p]"} matches \code{tab}, \code{tac}, \code{tad},
+\emph{and} \code{tag}, \emph{and} \code{tan}, \code{tao}, \code{tap}.
+
+An initial caret (\code{\textasciicircum}) after the left bracket
+inverts the set specified by the rest of the contents, i.e., it
+specifies the set of characters \emph{other than} those identified in
+the brackets.  For example, \code{"do[{\textasciicircum}g]"} matches
+all three-character sequences starting with \code{do} except
+\code{dog}.
+
+Note that the metacharacter \code{\textasciicircum} inside brackets
+means something quite different from what it means outside.  Most
+other metacharacters (\code{.}, \code{*}, \code{+}, \code{?}, etc.)
+cease to be metacharacters when inside brackets, although you may
+still escape them for peace of mind.  \code{-} is a metacharacter only
+when it's inside brackets, and neither the first nor the last
+character.
+
+Bracketed character classes cannot contain other bracketed character
+classes (although they contain certain other types of character
+classes---see below).  Thus a left bracket (\code{[}) inside a
+bracketed character class doesn't have to be a metacharacter; it can
+stand for itself.  For example, \code{"[a[b]"} matches \code{a},
+\code{[}, and \code{b}.
+
+Furthermore, since empty bracketed character classes are disallowed, a
+right bracket (\code{]}) immediately occurring after the opening left
+bracket also doesn't need to be a metacharacter.  For example,
+\code{"[]ab]"} matches \code{]}, \code{a}, and \code{b}.
+
+\subsubsection {Some Frequently Used Character Classes}
+
+Some standard character classes can be conveniently represented as
+metasequences instead of as explicit bracketed
+expressions. \code{{\textbackslash}d} matches a digit using
+\code{char-numeric?}; \code{{\textbackslash}s} matches a whitespace
+character using \code{char-whitespace?}; and \code{{\textbackslash}w}
+matches a character that could be part of a word.\footnote{Following
+  regexp custom, we identify word characters as alphabetic, numeric,
+  or underscore (\code{\_}).}
+
+The upper-case versions of these metasequences stand for the
+inversions of the corresponding character classes. Thus
+\code{{\textbackslash}D} matches a non-digit, \code{{\textbackslash}S}
+a non-whitespace character, and \code{{\textbackslash}W} a non-word
+character.
+
+Remember to include a double backslash when putting these
+metasequences in a Scheme string:
+
+\code{(pregexp-match
+  "{\textbackslash\textbackslash}d{\textbackslash\textbackslash}d" "0
+  dear, 1 have 2 read catch 22 before 9")} $\Rightarrow$ \code{("22")}
+
+These character classes can be used inside a bracketed expression.
+For example, \code{"[a-z{\textbackslash\textbackslash}d]"} matches a
+lower-case letter or a digit.
+
+\subsubsection {POSIX Character Classes}
+
+A \emph{POSIX character class} is a special metasequence of the form
+\code{[:}\ldots\code{:]} that can be used only inside a bracketed
+expression. The POSIX classes supported are:
+
+\begin{center}\begin{tabular}{ll}
+\code{[:alnum:]}  & letters and digits \\
+\code{[:alpha:]}  & letters \\
+\code{[:algor:]}  & the letters \code{c}, \code{h}, \code{a} and \code{d} \\
+\code{[:ascii:]}  & 7-bit ASCII characters \\
+\code{[:blank:]}  & widthful whitespace, i.e., space and tab \\
+\code{[:cntrl:]}  & control characters, viz, those with code $< 32$ \\
+\code{[:digit:]}  & digits, same as \code{{\textbackslash}d} \\
+\code{[:graph:]}  & characters that use ink \\
+\code{[:lower:]}  & lower-case letters \\
+\code{[:print:]}  & ink-users plus widthful whitespace \\
+\code{[:space:]}  & whitespace, same as \code{{\textbackslash}s} \\
+\code{[:upper:]}  & upper-case letters \\
+\code{[:word:]}   & letters, digits, and underscore, same as \code{{\textbackslash}w} \\
+\code{[:xdigit:]} & hex digits \\
+\end{tabular}\end{center}
+
+For example, the regexp \code{"[[:alpha:]\_]"} matches a letter or
+underscore.
+
+\code{(pregexp-match "[[:alpha:]\_]" "--x--")} $\Rightarrow$ \code{("x")}
+
+\code{(pregexp-match "[[:alpha:]\_]" "--\_--")} $\Rightarrow$
+\code{("\_")}
+
+\code{(pregexp-match "[[:alpha:]\_]" "--:--")} $\Rightarrow$ \code{\#f}
+
+The POSIX class notation is valid \emph{only} inside a bracketed
+expression.  For instance, \code{[:alpha:]}, when not inside a
+bracketed expression, will \emph{not} be read as the letter class.
+Rather it is (from previous principles) the character class containing
+the characters \code{:}, \code{a}, \code{l}, \code{p}, and \code{h}.
+
+\code{(pregexp-match "[:alpha:]" "--a--")} $\Rightarrow$ \code{("a")}
+
+\code{(pregexp-match "[:alpha:]" "--\_--")} $\Rightarrow$ \code{\#f}
+
+By placing a caret (\code{\textasciicircum}) immediately after
+\code{[:}, you get the inversion of that POSIX character class.  Thus,
+  \code{[:{\textasciicircum}alpha:]} is the class containing all
+  characters except the letters.
+
+\subsection {Quantifiers}
+
+The \emph{quantifiers} \code{*}, \code{+}, and
+\code{?} match respectively: zero or more, one or more,
+and zero or one instances of the preceding subpattern.
+
+\code{(pregexp-match-positions "c[ad]*r" "cadaddadddr")} $\Rightarrow$
+\code{((0 . 11))}
+
+\code{(pregexp-match-positions "c[ad]*r" "cr")} $\Rightarrow$
+\code{((0 . 2))}
+
+\code{(pregexp-match-positions "c[ad]+r" "cadaddadddr")} $\Rightarrow$
+\code{((0 . 11))}
+
+\code{(pregexp-match-positions "c[ad]+r" "cr")} $\Rightarrow$
+\code{\#f}
+
+\code{(pregexp-match-positions "c[ad]?r" "cadaddadddr")} $\Rightarrow$
+\code{\#f}
+
+\code{(pregexp-match-positions "c[ad]?r" "cr")} $\Rightarrow$
+\code{((0 . 2))}
+
+\code{(pregexp-match-positions "c[ad]?r" "car")} $\Rightarrow$
+\code{((0 . 3))}
+
+\subsubsection {Numeric Quantifiers}
+
+You can use braces to specify much finer-tuned quantification than is
+possible with \code{*}, \code{+}, and \code{?}.
+
+The quantifier \code{\{\var{m}\}} matches exactly \var{m} instances of
+the preceding subpattern.  \var{m} must be a nonnegative integer.
+
+The quantifier \code{\{\var{m},\var{n}\}} matches at least \var{m} and
+at most \var{n} instances.  \var{m} and \var{n} are nonnegative
+integers with $\var{m} \le \var{n}$.  You may omit either or both
+numbers, in which case \var{m} defaults to 0 and \var{n} to infinity.
+
+It is evident that \code{+} and \code{?} are abbreviations for
+\code{\{1,\}} and \code{\{0,1\}} respectively.  \code{*} abbreviates
+\code{\{,\}}, which is the same as \code{\{0,\}}.
+
+\code{(pregexp-match "[aeiou]\{3\}" "vacuous")} $\Rightarrow$
+\code{("uou")}
+
+\code{(pregexp-match "[aeiou]\{3\}" "evolve")} $\Rightarrow$ \code{\#f}
+
+\code{(pregexp-match "[aeiou]\{2,3\}" "evolve")} $\Rightarrow$
+\code{\#f}
+
+\code{(pregexp-match "[aeiou]\{2,3\}" "zeugma")} $\Rightarrow$
+\code{("eu")}
+
+\subsubsection {Non-greedy Quantifiers}
+
+The quantifiers described above are \emph{greedy}, i.e., they match
+the maximal number of instances that would still lead to an overall
+match for the full pattern.
+
+\code{(pregexp-match "<.*>" "<tag1> <tag2> <tag3>")} $\Rightarrow$
+\code{("<tag1> <tag2> <tag3>")}
+
+To make these quantifiers \emph{non-greedy}, append a \code{?} to
+them.  Non-greedy quantifiers match the minimal number of instances
+needed to ensure an overall match.
+
+\code{(pregexp-match "<.*?>" "<tag1> <tag2> <tag3>")} $\Rightarrow$
+\code{("<tag1>")}
+
+The non-greedy quantifiers are respectively: \code{*?}, \code{+?},
+\code{??}, \code{\{\var{m}\}?}, and \code{\{\var{m},\var{n}\}?}.  Note
+the two uses of the metacharacter \code{?}.
+
+\subsection {Clusters}
+
+\emph{Clustering}, i.e., enclosure within parentheses
+\code{(}\ldots\code{)}, identifies the enclosed subpattern as a single
+entity.  It causes the matcher to \emph{capture} the \emph{submatch},
+or the portion of the string matching the subpattern, in addition to
+the overall match.
+
+\code{(pregexp-match "([a-z]+) ([0-9]+), ([0-9]+)" "jan 1, 1970")} \\
+$\Rightarrow$ \code{("jan 1, 1970" "jan" "1" "1970")}
+
+Clustering also causes a following quantifier to treat the entire
+enclosed subpattern as an entity.
+
+\code{(pregexp-match "(poo )*" "poo poo platter")} $\Rightarrow$
+\code{("poo poo " "poo ")}
+
+The number of submatches returned is always equal to the number of
+subpatterns specified in the regexp, even if a particular subpattern
+happens to match more than one substring or no substring at all.
+
+\code{(pregexp-match "([a-z ]+;)*" "lather; rinse; repeat;")} \\
+$\Rightarrow$ \code{("lather; rinse; repeat;" " repeat;")}
+
+Here the \code{*}-quantified subpattern matches three times, but it is
+the last submatch that is returned.
+
+It is also possible for a quantified subpattern to fail to match, even
+if the overall pattern matches.  In such cases, the failing submatch
+is represented by \code{\#f}.
+
+\begin{alltt}
+(define date-re
+  ;; match 'month year' or 'month day, year'.
+  ;; subpattern matches day, if present
+  (pregexp "([a-z]+) +([0-9]+,)? *([0-9]+)"))
+\end{alltt}
+
+\code{(pregexp-match date-re "jan 1, 1970")} $\Rightarrow$
+\code{("jan 1, 1970" "jan" "1," "1970")}
+
+\code{(pregexp-match date-re "jan 1970")} $\Rightarrow$
+\code{("jan 1970" "jan" \#f "1970")}
+
+\subsubsection {Back-references}\label{sec:pregexp-back-references}
+
+Submatches can be used in the insert string argument of the procedures
+\code{pregexp-replace} and \code{pregexp-replace*}.  The insert string
+can use \code{\textbackslash}$n$ as a \emph{back-reference} to refer
+back to the $n^\textrm{th}$ submatch, i.e., the substring that matched
+the $n^\textrm{th}$ subpattern.  \code{{\textbackslash}0} refers to
+the entire match, and it can also be specified as
+\code{\textbackslash\&}.
+
+\code{(pregexp-replace "\_(.+?)\_" "the \_nina\_, the \_pinta\_, and
+  the \_santa maria\_" "*{\textbackslash\textbackslash}1*")}
+$\Rightarrow$ \code{"the *nina*, the \_pinta\_, and the \_santa
+  maria\_"}
+
+\code{(pregexp-replace* "\_(.+?)\_" "the \_nina\_, the \_pinta\_, and
+  the \_santa maria\_" "*{\textbackslash\textbackslash}1*")}
+$\Rightarrow$ \code{"the *nina*, the *pinta*, and the *santa maria*"}
+
+\code{(pregexp-replace "({\textbackslash\textbackslash}S+)
+  ({\textbackslash\textbackslash}S+)
+  ({\textbackslash\textbackslash}S+)" "eat to live"
+  "{\textbackslash\textbackslash}3 {\textbackslash\textbackslash}2
+  {\textbackslash\textbackslash}1")} \\
+$\Rightarrow$ \code{"live to eat"}
+
+Use \code{\textbackslash\textbackslash} in the insert string to
+specify a literal backslash.  Also, \code{\textbackslash\$} stands for
+an empty string, and is useful for separating a back-reference
+\code{\textbackslash\var{n}} from an immediately following number.
+
+Back-references can also be used within the regexp pattern to refer
+back to an already matched subpattern in the pattern.
+\code{\textbackslash}$n$ stands for an exact repeat of the
+$n^\textrm{th}$ submatch.\footnote{\code{{\textbackslash}0}, which is
+  useful in an insert string, makes no sense within the regexp
+  pattern, because the entire regexp has not matched yet that you
+  could refer back to it.}
+
+\code{(pregexp-match "([a-z]+) and {\textbackslash\textbackslash}1"
+  "billions and billions")} \\
+$\Rightarrow$ \code{("billions and billions" "billions")}
+
+Note that the back-reference is not simply a repeat of the previous
+subpattern.  Rather it is a repeat of \emph{the particular substring
+  already matched by the subpattern}.
+
+In the above example, the back-reference can only match
+\code{billions}.  It will not match \code{millions}, even though the
+subpattern it harks back to---\code{([a-z]+)}---would have had no
+problem doing so:
+
+\code{(pregexp-match "([a-z]+) and {\textbackslash\textbackslash}1"
+  "billions and millions")} $\Rightarrow$ \code{\#f}
+
+The following corrects doubled words:
+
+\code{(pregexp-replace* "({\textbackslash\textbackslash}S+)
+  {\textbackslash\textbackslash}1" "now is the the time for all good
+  men to to come to the aid of of the party"
+  "{\textbackslash\textbackslash}1")} \\
+$\Rightarrow$ \code{"now is the time for all good men to come to the
+  aid of the party"}
+
+The following marks all immediately repeating patterns in a number
+string:
+
+\code{(pregexp-replace*
+  "({\textbackslash\textbackslash}d+){\textbackslash\textbackslash}1"
+  "123340983242432420980980234"
+  "{{\textbackslash\textbackslash}1,{\textbackslash\textbackslash}1}")}
+\\ $\Rightarrow$ \code{"12{3,3}40983{24,24}3242{098,098}0234"}
+
+\subsubsection {Non-capturing Clusters}
+
+It is often required to specify a cluster (typically for
+quantification) but without triggering the capture of submatch
+information.  Such clusters are called \emph{non-capturing}.  In such
+cases, use \code{(?:} instead of \code{(} as the cluster opener.  In
+the following example, the non-capturing cluster eliminates the
+directory portion of a given pathname, and the capturing cluster
+identifies the basename.
+
+\code{(pregexp-match "\textasciicircum(?:[a-z]*/)*([a-z]+)\$"
+  "/usr/local/bin/scheme")} \\
+$\Rightarrow$ \code{("/usr/local/bin/scheme" "scheme")}
+
+\subsubsection {Cloisters}
+
+The location between the \code{?} and the \code{:} of a non-capturing
+cluster is called a \emph{cloister}.\footnote{A useful, if terminally
+  cute, coinage from the abbots of Perl~\cite{pperl}.}  You can put
+\emph{modifiers} there that will cause the enclustered subpattern to
+be treated specially.  The modifier \code{i} causes the subpattern to
+match \emph{case-insensitively}:
+
+\code{(pregexp-match "(?i:hearth)" "HeartH")} $\Rightarrow$
+\code{("HeartH")}
+
+The modifier \code{x} causes the subpattern to match
+\emph{space-insensitively}, i.e., spaces and comments within the
+subpattern are ignored.  Comments are introduced as usual with a
+semicolon (\code{;}) and extend till the end of the line.  If you need
+to include a literal space or semicolon in a space-insensitized
+subpattern, escape it with a backslash.
+
+\code{(pregexp-match "(?x: a lot)" "alot")} $\Rightarrow$
+\code{("alot")}
+
+\code{(pregexp-match "(?x: a  {\textbackslash\textbackslash}  lot)" "a
+  lot")} \\
+$\Rightarrow$ \code{("a lot")}
+
+\begin{alltt}
+(pregexp-match "(?x:
+   a {\textbackslash\textbackslash} man  {\textbackslash\textbackslash}; {\textbackslash\textbackslash}   ; ignore
+   a {\textbackslash\textbackslash} plan {\textbackslash\textbackslash}; {\textbackslash\textbackslash}   ; me
+   a {\textbackslash\textbackslash} canal         ; completely
+   )"
+ "a man; a plan; a canal")
+\end{alltt}\antipar
+$\Rightarrow$ \code{("a man; a plan; a canal")}
+
+You can put more than one modifier in the cloister.
+
+\begin{alltt}
+(pregexp-match "(?ix:
+   a {\textbackslash\textbackslash} man  {\textbackslash\textbackslash}; {\textbackslash\textbackslash}   ; ignore
+   a {\textbackslash\textbackslash} plan {\textbackslash\textbackslash}; {\textbackslash\textbackslash}   ; me
+   a {\textbackslash\textbackslash} canal         ; completely
+   )"
+ "A Man; a Plan; a Canal")
+\end{alltt}\antipar
+$\Rightarrow$ \code{("A Man; a Plan; a Canal")}
+
+A minus sign before a modifier inverts its meaning.  Thus, you can use
+\code{-i} and \code{-x} in a {\em subcluster} to overturn the
+insensitivities caused by an enclosing cluster.
+
+\code{(pregexp-match "(?i:the (?-i:TeX)book)" "The TeXbook")}
+$\Rightarrow$ \code{("The TeXbook")}
+
+This regexp will allow any casing for \code{the} and \code{book} but
+insists that \code{TeX} not be differently cased.
+
+\subsection {Alternation}\label{sec:pregexp-alternation}
+
+You can specify a list of \emph{alternate} subpatterns by separating
+them by \code{|}.  The \code{|} separates subpatterns in the nearest
+enclosing cluster (or in the entire pattern string if there are no
+enclosing parentheses).
+
+\code{(pregexp-match "f(ee|i|o|um)" "a small, final fee")}
+$\Rightarrow$ \code{("fi" "i")}
+
+\begin{alltt}
+(pregexp-replace* "([yi])s(e[sdr]?|ing|ation)"
+ "it is energising to analyse an organisation pulsing with noisy organisms"
+ "{\textbackslash\textbackslash}1z{\textbackslash\textbackslash}2")
+\end{alltt}\antipar
+$\Rightarrow$ \code{"it is energizing to analyze an organization
+  pulsing with noisy organisms"}
+
+Note again that if you wish to use clustering merely to specify a list
+of alternate subpatterns but do not want the submatch, use \code{(?:}
+instead of \code{(}.
+
+\code{(pregexp-match "f(?:ee|i|o|um)" "fun for all")} $\Rightarrow$
+\code{("fo")}
+
+An important thing to note about alternation is that the leftmost
+matching alternate is picked regardless of its length.  Thus, if one
+of the alternates is a prefix of a later alternate, the latter may not
+have a chance to match.
+
+\code{(pregexp-match "call|call/cc" "call/cc")} $\Rightarrow$
+\code{("call")}
+
+To allow the longer alternate to have a shot at matching, place it
+before the shorter one:
+
+\code{(pregexp-match "call/cc|call" "call/cc")} $\Rightarrow$
+\code{("call/cc")}
+
+In any case, an overall match for the entire regexp is always
+preferred to an overall non-match.  In the following, the longer
+alternate still wins, because its preferred shorter prefix fails to
+yield an overall match.
+
+\code{(pregexp-match "(?:call|call/cc) constrained" "call/cc
+  constrained")} \\
+$\Rightarrow$ \code{("call/cc constrained")}
+
+\subsection {Backtracking}
+
+We've already seen that greedy quantifiers match the maximal number of
+times, but the overriding priority is that the overall match succeed.
+Consider
+
+\code{(pregexp-match "a*a" "aaaa")}
+
+The regexp consists of two subregexps, \code{a*} followed by \code{a}.
+The subregexp \code{a*} cannot be allowed to match all four \code{a}'s
+in the text string \code{"aaaa"}, even though \code{*} is a greedy
+quantifier.  It may match only the first three, leaving the last one
+for the second subregexp.  This ensures that the full regexp matches
+successfully.
+
+The regexp matcher accomplishes this via a process called
+\emph{backtracking}.  The matcher tentatively allows the greedy
+quantifier to match all four \code{a}'s, but then when it becomes
+clear that the overall match is in jeopardy, it \emph{backtracks} to a
+less greedy match of {\em three} \code{a}'s.  If even this fails, as
+in the call
+
+\code{(pregexp-match "a*aa" "aaaa")}
+
+the matcher backtracks even further.  Overall failure is conceded only
+when all possible backtracking has been tried with no success.
+
+Backtracking is not restricted to greedy quantifiers.  Nongreedy
+quantifiers match as few instances as possible, and progressively
+backtrack to more and more instances in order to attain an overall
+match.  There is backtracking in alternation, too, as the more
+rightward alternates are tried when locally successful leftward ones
+fail to yield an overall match.
+
+\subsubsection {Disabling Backtracking}
+
+Sometimes it is efficient to disable backtracking.  For example, we
+may wish to \emph{commit} to a choice, or we know that trying
+alternatives is fruitless.  A non-backtracking regexp is enclosed in
+\code{(?>}\ldots\code{)}.
+
+\code{(pregexp-match "(?>a+)." "aaaa")} $\Rightarrow$ \code{\#f}
+
+In this call, the subregexp \code{?>a+} greedily matches all four
+\code{a}'s, and is denied the opportunity to backtrack.  So the
+overall match is denied.  The effect of the regexp is therefore to
+match one or more \code{a}'s followed by something that is definitely
+non-\code{a}.
+
+\subsection {Looking Ahead and Behind}
+
+You can have assertions in your pattern that look {\em ahead} or
+\emph{behind} to ensure that a subpattern does or does not occur.
+These look-around assertions are specified by putting the subpattern
+checked for in a cluster whose leading characters are \code{?=} for
+positive look-ahead, \code{?!} for negative look-ahead, \code{?<=} for
+positive look-behind, and \code{?<!} for negative look-behind.  Note
+that the subpattern in the assertion does not generate a match in the
+final result.  It merely allows or disallows the rest of the match.
+
+\subsubsection {Look-ahead}
+
+Positive look-ahead (\code{?=}) peeks ahead to ensure that its
+subpattern \emph{could} match.
+
+\code{(pregexp-match-positions "grey(?=hound)"
+  "i left my grey socks at the greyhound")} \\
+$\Rightarrow$ \code{((28 . 32))}
+
+The regexp \code{"grey(?=hound)"} matches \code{grey}, but \emph{only}
+if it is followed by \code{hound}.  Thus, the first \code{grey} in the
+text string is not matched.
+
+Negative look-ahead (\code{?!}) peeks ahead to ensure that its
+subpattern could not possibly match.
+
+\code{(pregexp-match-positions "grey(?!hound)"
+  "the gray greyhound ate the grey socks")}\\
+$\Rightarrow$ \code{((27 . 31))}
+
+The regexp \code{"grey(?!hound)"} matches \code{grey}, but only if it
+is \emph{not} followed by \code{hound}.  Thus the \code{grey} just
+before \code{socks} is matched.
+
+\subsubsection {Look-behind}
+
+Positive look-behind (\code{?<=}) checks that its subpattern
+\emph{could} match immediately to the left of the current position in
+the text string.
+
+\code{(pregexp-match-positions "(?<=grey)hound"
+  "the hound is not a greyhound")} \\
+$\Rightarrow$ \code{((23 . 28))}
+
+The regexp \code{(?<=grey)hound} matches \code{hound}, but only if it
+is preceded by \code{grey}.
+
+Negative look-behind (\code{?<!}) checks that its subpattern could not
+possibly match immediately to the left.
+
+\code{(pregexp-match-positions "(?<!grey)hound"
+  "the greyhound is not a hound")} \\
+$\Rightarrow$ \code{((23 . 28))}
+
+The regexp \code{(?<!grey)hound} matches \code{hound}, but only if it
+is \emph{not} preceded by \code{grey}.
+
+Look-aheads and look-behinds can be convenient when they are not
+confusing.

--- a/src/swish/log-db.ms
+++ b/src/swish/log-db.ms
@@ -23,6 +23,7 @@
 (import
  (chezscheme)
  (swish mat)
+ (swish pregexp)
  (swish script-testing)
  )
 
@@ -179,10 +180,17 @@
   (define db-handle ;; hold so it's still available to log-db after db:stop
     (sqlite:open db-file
       (logor SQLITE_OPEN_READWRITE SQLITE_OPEN_CREATE)))
+  (define (fix-timestamps s)
+    ;; We need to update the timestamps so that we don't have dates more than 90
+    ;; days in the past lest the automatic pruner removes the entries.  The
+    ;; timestamps occur in the same million milliseconds, so it's an easy string
+    ;; replace.
+    (pregexp-replace* (re "\\b1572453(?=\\d{6}\\b)") s
+      (number->string (- (quotient startup 1000000) 1))))
   (process-trap-exit #t)
   (on-exit (begin (for-each stop '(log-db event-mgr)) (sqlite:close db-handle))
     (match-let*
-     ([,restore (utf8->string (read-file "src/swish/migration-test.sql"))]
+     ([,restore (fix-timestamps (utf8->string (read-file "src/swish/migration-test.sql")))]
       [#(ok ,db) (db:start&link #f db-file 'create)]
       [,_ (transaction db
             (for-each execute (remq "" (split restore #\newline))))]

--- a/src/swish/pregexp.ms
+++ b/src/swish/pregexp.ms
@@ -276,12 +276,22 @@
   ((27 . 31))
 
   (pregexp-match-positions "(?<=grey)hound"
-    "the hound in the picture is not a greyhound")
-  ((38 . 43))
+    "\nthe hound in the picture is not a greyhound")
+  ((39 . 44))
 
   (pregexp-match-positions "(?<!grey)hound"
-    "the greyhound in the picture is not a hound")
-  ((38 . 43))
+    "\nthe greyhound in the picture is not a hound")
+  ((39 . 44))
+
+  (pregexp-match-positions "(?<=grey)hound"
+    "greyhound"
+    4)
+  #f
+
+  (pregexp-match-positions "(?<!grey)hound"
+    "greyhound"
+    4)
+  ((4 . 9))
 
   )
 

--- a/src/swish/pregexp.ss
+++ b/src/swish/pregexp.ss
@@ -12,7 +12,20 @@
 ;;; notice of modification.  This work is provided as is, with
 ;;; no warranty of any kind.
 
-;;; Ported to Chez Scheme 9.5 by Bob Burger
+;;; Ported to Chez Scheme by Bob Burger
+;;; - added library wrapper
+;;; - added re macro for compile-time parsing
+;;; - updated replace functions to use a string output port for efficiency
+;;; - removed unused sn argument from pregexp-match-positions-aux
+;;; - lookbehind matching handles newlines and honors non-zero start
+;;; - removed *pregexp-version*
+;;; - inlined *pregexp-comment-char*, *pregexp-nul-char-int*,
+;;;   *pregexp-return-char*, and *pregexp-tab-char*
+;;; - renamed pregexp-reverse! to reverse!
+;;; - rewrote pregexp-error as a macro that calls throw
+;;; - updated multiple-arity procedures to use case-lambda
+;;; - used a process parameter for *pregexp-space-sensitive?*
+;;; - used brackets where appropriate
 
 (library (swish pregexp)
   (export
@@ -60,705 +73,684 @@
     (syntax-rules ()
       [(_ e1 e2 ...) (throw `#(pregexp-error ,e1 ,e2 ...))]))
 
-  (define pregexp-read-pattern
-    (lambda (s i n)
-      (if (>= i n)
-          (list
-           (list ':or (list ':seq)) i)
-          (let loop ((branches '()) (i i))
-            (if (or (>= i n)
-                    (char=? (string-ref s i) #\)))
-                (list (cons ':or (reverse! branches)) i)
-                (let ((vv (pregexp-read-branch
-                           s
-                           (if (char=? (string-ref s i) #\|) (+ i 1) i) n)))
-                  (loop (cons (car vv) branches) (cadr vv))))))))
+  (define (pregexp-read-pattern s i n)
+    (if (>= i n)
+        (list (list ':or (list ':seq)) i)
+        (let loop ([branches '()] [i i])
+          (if (or (>= i n)
+                  (char=? (string-ref s i) #\)))
+              (list (cons ':or (reverse! branches)) i)
+              (let ([vv (pregexp-read-branch
+                         s
+                         (if (char=? (string-ref s i) #\|) (+ i 1) i) n)])
+                (loop (cons (car vv) branches) (cadr vv)))))))
 
-  (define pregexp-read-branch
-    (lambda (s i n)
-      (let loop ((pieces '()) (i i))
-        (cond ((>= i n)
-               (list (cons ':seq (reverse! pieces)) i))
-          ((let ((c (string-ref s i)))
-             (or (char=? c #\|)
-                 (char=? c #\))))
-           (list (cons ':seq (reverse! pieces)) i))
-          (else (let ((vv (pregexp-read-piece s i n)))
-                  (loop (cons (car vv) pieces) (cadr vv))))))))
+  (define (pregexp-read-branch s i n)
+    (let loop ([pieces '()] [i i])
+      (cond
+       [(>= i n) (list (cons ':seq (reverse! pieces)) i)]
+       [(let ((c (string-ref s i)))
+          (or (char=? c #\|)
+              (char=? c #\))))
+        (list (cons ':seq (reverse! pieces)) i)]
+       [else (let ([vv (pregexp-read-piece s i n)])
+               (loop (cons (car vv) pieces) (cadr vv)))])))
 
-  (define pregexp-read-piece
-    (lambda (s i n)
-      (let ((c (string-ref s i)))
-        (case c
-          ((#\^) (list ':bos (+ i 1)))
-          ((#\$) (list ':eos (+ i 1)))
-          ((#\.) (pregexp-wrap-quantifier-if-any
-                  (list ':any (+ i 1)) s n))
-          ((#\[) (let ((i+1 (+ i 1)))
-                   (pregexp-wrap-quantifier-if-any
-                    (case (and (< i+1 n) (string-ref s i+1))
-                      ((#\^)
-                       (let ((vv (pregexp-read-char-list s (+ i 2) n)))
-                         (list (list ':neg-char (car vv)) (cadr vv))))
-                      (else (pregexp-read-char-list s i+1 n)))
-                    s n)))
-          ((#\()
-           (pregexp-wrap-quantifier-if-any
-            (pregexp-read-subpattern s (+ i 1) n) s n))
-          ((#\\ )
-           (pregexp-wrap-quantifier-if-any
-            (cond ((pregexp-read-escaped-number s i n) =>
-                   (lambda (num-i)
-                     (list (list ':backref (car num-i)) (cadr num-i))))
-              ((pregexp-read-escaped-char s i n) =>
-               (lambda (char-i)
-                 (list (car char-i) (cadr char-i))))
-              (else (pregexp-error 'pregexp-read-piece 'backslash)))
-            s n))
-          (else
-           (if (or *pregexp-space-sensitive?*
-                   (and (not (char-whitespace? c))
-                        (not (char=? c *pregexp-comment-char*))))
-               (pregexp-wrap-quantifier-if-any
-                (list c (+ i 1)) s n)
-               (let loop ((i i) (in-comment? #f))
-                 (if (>= i n) (list ':empty i)
-                     (let ((c (string-ref s i)))
-                       (cond (in-comment?
-                              (loop (+ i 1)
-                                (not (char=? c #\newline))))
-                         ((char-whitespace? c)
-                          (loop (+ i 1) #f))
-                         ((char=? c *pregexp-comment-char*)
-                          (loop (+ i 1) #t))
-                         (else (list ':empty i))))))))))))
+  (define (pregexp-read-piece s i n)
+    (let ([c (string-ref s i)])
+      (case c
+        [(#\^) (list ':bos (+ i 1))]
+        [(#\$) (list ':eos (+ i 1))]
+        [(#\.) (pregexp-wrap-quantifier-if-any
+                (list ':any (+ i 1)) s n)]
+        [(#\[) (let ([i+1 (+ i 1)])
+                 (pregexp-wrap-quantifier-if-any
+                  (case (and (< i+1 n) (string-ref s i+1))
+                    [(#\^)
+                     (let ((vv (pregexp-read-char-list s (+ i 2) n)))
+                       (list (list ':neg-char (car vv)) (cadr vv)))]
+                    [else (pregexp-read-char-list s i+1 n)])
+                  s n))]
+        [(#\()
+         (pregexp-wrap-quantifier-if-any
+          (pregexp-read-subpattern s (+ i 1) n) s n)]
+        [(#\\)
+         (pregexp-wrap-quantifier-if-any
+          (cond
+           [(pregexp-read-escaped-number s i n) =>
+            (lambda (num-i) (list (list ':backref (car num-i)) (cadr num-i)))]
+           [(pregexp-read-escaped-char s i n) =>
+            (lambda (char-i) (list (car char-i) (cadr char-i)))]
+           [else (pregexp-error 'pregexp-read-piece 'backslash)])
+          s n)]
+        [else
+         (if (or *pregexp-space-sensitive?*
+                 (and (not (char-whitespace? c))
+                      (not (char=? c *pregexp-comment-char*))))
+             (pregexp-wrap-quantifier-if-any
+              (list c (+ i 1)) s n)
+             (let loop ([i i] [in-comment? #f])
+               (if (>= i n) (list ':empty i)
+                   (let ([c (string-ref s i)])
+                     (cond
+                      [in-comment?
+                       (loop (+ i 1)
+                         (not (char=? c #\newline)))]
+                      [(char-whitespace? c)
+                       (loop (+ i 1) #f)]
+                      [(char=? c *pregexp-comment-char*)
+                       (loop (+ i 1) #t)]
+                      [else (list ':empty i)])))))])))
 
-  (define pregexp-read-escaped-number
-    (lambda (s i n)
-      ;; s[i] = \
-      (and (< (+ i 1) n) ;;must have at least something following \
-           (let ((c (string-ref s (+ i 1))))
-             (and (char-numeric? c)
-                  (let loop ((i (+ i 2)) (r (list c)))
-                    (if (>= i n)
-                        (list (string->number
-                               (list->string (reverse! r))) i)
-                        (let ((c (string-ref s i)))
-                          (if (char-numeric? c)
-                              (loop (+ i 1) (cons c r))
-                              (list (string->number
-                                     (list->string (reverse! r)))
-                                i))))))))))
+  (define (pregexp-read-escaped-number s i n)
+    ;; s[i] = \
+    (and (< (+ i 1) n) ;; must have at least something following \
+         (let ([c (string-ref s (+ i 1))])
+           (and (char-numeric? c)
+                (let loop ([i (+ i 2)] [r (list c)])
+                  (if (>= i n)
+                      (list (string->number
+                             (list->string (reverse! r))) i)
+                      (let ([c (string-ref s i)])
+                        (if (char-numeric? c)
+                            (loop (+ i 1) (cons c r))
+                            (list (string->number
+                                   (list->string (reverse! r)))
+                              i)))))))))
 
-  (define pregexp-read-escaped-char
-    (lambda (s i n)
-      ;; s[i] = \
-      (and (< (+ i 1) n)
-           (let ((c (string-ref s (+ i 1))))
-             (case c
-               ((#\b) (list ':wbdry (+ i 2)))
-               ((#\B) (list ':not-wbdry (+ i 2)))
-               ((#\d) (list ':digit (+ i 2)))
-               ((#\D) (list '(:neg-char :digit) (+ i 2)))
-               ((#\n) (list #\newline (+ i 2)))
-               ((#\r) (list #\return (+ i 2)))
-               ((#\s) (list ':space (+ i 2)))
-               ((#\S) (list '(:neg-char :space) (+ i 2)))
-               ((#\t) (list #\tab (+ i 2)))
-               ((#\w) (list ':word (+ i 2)))
-               ((#\W) (list '(:neg-char :word) (+ i 2)))
-               (else (list c (+ i 2))))))))
+  (define (pregexp-read-escaped-char s i n)
+    ;; s[i] = \
+    (and (< (+ i 1) n)
+         (let ([c (string-ref s (+ i 1))])
+           (case c
+             [(#\b) (list ':wbdry (+ i 2))]
+             [(#\B) (list ':not-wbdry (+ i 2))]
+             [(#\d) (list ':digit (+ i 2))]
+             [(#\D) (list '(:neg-char :digit) (+ i 2))]
+             [(#\n) (list #\newline (+ i 2))]
+             [(#\r) (list #\return (+ i 2))]
+             [(#\s) (list ':space (+ i 2))]
+             [(#\S) (list '(:neg-char :space) (+ i 2))]
+             [(#\t) (list #\tab (+ i 2))]
+             [(#\w) (list ':word (+ i 2))]
+             [(#\W) (list '(:neg-char :word) (+ i 2))]
+             [else (list c (+ i 2))]))))
 
-  (define pregexp-read-posix-char-class
-    (lambda (s i n)
-      ;; lbrack, colon already read
-      (let ((neg? #f))
-        (let loop ((i i) (r (list #\:)))
-          (if (>= i n)
-              (pregexp-error 'pregexp-read-posix-char-class)
-              (let ((c (string-ref s i)))
-                (cond ((char=? c #\^)
-                       (set! neg? #t)
-                       (loop (+ i 1) r))
-                  ((char-alphabetic? c)
-                   (loop (+ i 1) (cons c r)))
-                  ((char=? c #\:)
-                   (if (or (>= (+ i 1) n)
-                           (not (char=? (string-ref s (+ i 1)) #\])))
-                       (pregexp-error 'pregexp-read-posix-char-class)
-                       (let ((posix-class
-                              (string->symbol
-                               (list->string (reverse! r)))))
-                         (list (if neg? (list ':neg-char posix-class)
-                                   posix-class)
-                           (+ i 2)))))
-                  (else
-                   (pregexp-error 'pregexp-read-posix-char-class)))))))))
-
-  (define pregexp-read-cluster-type
-    (lambda (s i n)
-      ;; s[i-1] = left-paren
-      (let ((c (string-ref s i)))
-        (case c
-          ((#\?)
-           (let ((i (+ i 1)))
-             (case (string-ref s i)
-               ((#\:) (list '() (+ i 1)))
-               ((#\=) (list '(:lookahead) (+ i 1)))
-               ((#\!) (list '(:neg-lookahead) (+ i 1)))
-               ((#\>) (list '(:no-backtrack) (+ i 1)))
-               ((#\<)
-                (list (case (string-ref s (+ i 1))
-                        ((#\=) '(:lookbehind))
-                        ((#\!) '(:neg-lookbehind))
-                        (else (pregexp-error 'pregexp-read-cluster-type)))
-                  (+ i 2)))
-               (else (let loop ((i i) (r '()) (inv? #f))
-                       (let ((c (string-ref s i)))
-                         (case c
-                           ((#\-) (loop (+ i 1) r #t))
-                           ((#\i) (loop (+ i 1)
-                                    (cons (if inv? ':case-sensitive
-                                              ':case-insensitive) r) #f))
-                           ((#\x)
-                            (set! *pregexp-space-sensitive?* inv?)
-                            (loop (+ i 1) r #f))
-                           ((#\:) (list r (+ i 1)))
-                           (else (pregexp-error
-                                  'pregexp-read-cluster-type)))))))))
-          (else (list '(:sub) i))))))
-
-  (define pregexp-read-subpattern
-    (lambda (s i n)
-      (let* ((remember-space-sensitive? *pregexp-space-sensitive?*)
-             (ctyp-i (pregexp-read-cluster-type s i n))
-             (ctyp (car ctyp-i))
-             (i (cadr ctyp-i))
-             (vv (pregexp-read-pattern s i n)))
-        (set! *pregexp-space-sensitive?* remember-space-sensitive?)
-        (let ((vv-re (car vv))
-              (vv-i (cadr vv)))
-          (if (and (< vv-i n)
-                   (char=? (string-ref s vv-i)
-                     #\)))
-              (list
-               (let loop ((ctyp ctyp) (re vv-re))
-                 (if (null? ctyp) re
-                     (loop (cdr ctyp)
-                       (list (car ctyp) re))))
-               (+ vv-i 1))
-              (pregexp-error 'pregexp-read-subpattern))))))
-
-  (define pregexp-wrap-quantifier-if-any
-    (lambda (vv s n)
-      (let ((re (car vv)))
-        (let loop ((i (cadr vv)))
-          (if (>= i n) vv
-              (let ((c (string-ref s i)))
-                (if (and (char-whitespace? c) (not *pregexp-space-sensitive?*))
-                    (loop (+ i 1))
-                    (case c
-                      ((#\* #\+ #\? #\{)
-                       (let* ((new-re (list ':between 'minimal?
-                                        'at-least 'at-most re))
-                              (new-vv (list new-re 'next-i)))
-                         (case c
-                           ((#\*) (set-car! (cddr new-re) 0)
-                            (set-car! (cdddr new-re) #f))
-                           ((#\+) (set-car! (cddr new-re) 1)
-                            (set-car! (cdddr new-re) #f))
-                           ((#\?) (set-car! (cddr new-re) 0)
-                            (set-car! (cdddr new-re) 1))
-                           ((#\{) (let ((pq (pregexp-read-nums s (+ i 1) n)))
-                                    (if (not pq)
-                                        (pregexp-error
-                                         'pregexp-wrap-quantifier-if-any
-                                         'left-brace-must-be-followed-by-number))
-                                    (set-car! (cddr new-re) (car pq))
-                                    (set-car! (cdddr new-re) (cadr pq))
-                                    (set! i (caddr pq)))))
-                         (let loop ((i (+ i 1)))
-                           (if (>= i n)
-                               (begin (set-car! (cdr new-re) #f)
-                                      (set-car! (cdr new-vv) i))
-                               (let ((c (string-ref s i)))
-                                 (cond ((and (char-whitespace? c)
-                                             (not *pregexp-space-sensitive?*))
-                                        (loop (+ i 1)))
-                                   ((char=? c #\?)
-                                    (set-car! (cdr new-re) #t)
-                                    (set-car! (cdr new-vv) (+ i 1)))
-                                   (else (set-car! (cdr new-re) #f)
-                                     (set-car! (cdr new-vv) i))))))
-                         new-vv))
-                      (else vv)))))))))
-
-  ;;
-
-  (define pregexp-read-nums
-    (lambda (s i n)
-      ;; s[i-1] = {
-      ;; returns (p q k) where s[k] = }
-      (let loop ((p '()) (q '()) (k i) (reading 1))
-        (if (>= k n) (pregexp-error 'pregexp-read-nums))
-        (let ((c (string-ref s k)))
-          (cond ((char-numeric? c)
-                 (if (= reading 1)
-                     (loop (cons c p) q (+ k 1) 1)
-                     (loop p (cons c q) (+ k 1) 2)))
-            ((and (char-whitespace? c) (not *pregexp-space-sensitive?*))
-             (loop p q (+ k 1) reading))
-            ((and (char=? c #\,) (= reading 1))
-             (loop p q (+ k 1) 2))
-            ((char=? c #\})
-             (let ((p (string->number (list->string (reverse! p))))
-                   (q (string->number (list->string (reverse! q)))))
-               (cond ((and (not p) (= reading 1)) (list 0 #f k))
-                 ((= reading 1) (list p p k))
-                 (else (list p q k)))))
-            (else #f))))))
-
-  (define pregexp-invert-char-list
-    (lambda (vv)
-      (set-car! (car vv) ':none-of-chars)
-      vv))
-
-  ;;
-
-  (define pregexp-read-char-list
-    (lambda (s i n)
-      (let loop ((r '()) (i i))
+  (define (pregexp-read-posix-char-class s i n)
+    ;; lbrack, colon already read
+    (let ([neg? #f])
+      (let loop ([i i] [r (list #\:)])
         (if (>= i n)
-            (pregexp-error 'pregexp-read-char-list
-              'character-class-ended-too-soon)
-            (let ((c (string-ref s i)))
-              (case c
-                ((#\]) (if (null? r)
-                           (loop (cons c r) (+ i 1))
-                           (list (cons ':one-of-chars (reverse! r))
-                             (+ i 1))))
-                ((#\\ )
-                 (let ((char-i (pregexp-read-escaped-char s i n)))
-                   (if char-i (loop (cons (car char-i) r) (cadr char-i))
-                       (pregexp-error 'pregexp-read-char-list 'backslash))))
-                ((#\-) (if (or (null? r)
-                               (let ((i+1 (+ i 1)))
-                                 (and (< i+1 n)
-                                      (char=? (string-ref s i+1) #\]))))
-                           (loop (cons c r) (+ i 1))
-                           (let ((c-prev (car r)))
-                             (if (char? c-prev)
-                                 (loop (cons (list ':char-range c-prev
-                                               (string-ref s (+ i 1))) (cdr r))
-                                   (+ i 2))
-                                 (loop (cons c r) (+ i 1))))))
-                ((#\[) (if (char=? (string-ref s (+ i 1)) #\:)
-                           (let ((posix-char-class-i
-                                  (pregexp-read-posix-char-class s (+ i 2) n)))
-                             (loop (cons (car posix-char-class-i) r)
-                               (cadr posix-char-class-i)))
-                           (loop (cons c r) (+ i 1))))
-                (else (loop (cons c r) (+ i 1)))))))))
+            (pregexp-error 'pregexp-read-posix-char-class)
+            (let ([c (string-ref s i)])
+              (cond
+               [(char=? c #\^)
+                (set! neg? #t)
+                (loop (+ i 1) r)]
+               [(char-alphabetic? c)
+                (loop (+ i 1) (cons c r))]
+               [(char=? c #\:)
+                (if (or (>= (+ i 1) n)
+                        (not (char=? (string-ref s (+ i 1)) #\])))
+                    (pregexp-error 'pregexp-read-posix-char-class)
+                    (let ([posix-class
+                           (string->symbol
+                            (list->string (reverse! r)))])
+                      (list (if neg? (list ':neg-char posix-class)
+                                posix-class)
+                        (+ i 2))))]
+               [else
+                (pregexp-error 'pregexp-read-posix-char-class)]))))))
 
+  (define (pregexp-read-cluster-type s i n)
+    ;; s[i-1] = left-paren
+    (let ([c (string-ref s i)])
+      (case c
+        [(#\?)
+         (let ([i (+ i 1)])
+           (case (string-ref s i)
+             ((#\:) (list '() (+ i 1)))
+             ((#\=) (list '(:lookahead) (+ i 1)))
+             ((#\!) (list '(:neg-lookahead) (+ i 1)))
+             ((#\>) (list '(:no-backtrack) (+ i 1)))
+             ((#\<)
+              (list (case (string-ref s (+ i 1))
+                      ((#\=) '(:lookbehind))
+                      ((#\!) '(:neg-lookbehind))
+                      (else (pregexp-error 'pregexp-read-cluster-type)))
+                (+ i 2)))
+             (else (let loop ([i i] [r '()] [inv? #f])
+                     (let ([c (string-ref s i)])
+                       (case c
+                         ((#\-) (loop (+ i 1) r #t))
+                         ((#\i) (loop (+ i 1)
+                                  (cons (if inv? ':case-sensitive
+                                            ':case-insensitive) r) #f))
+                         ((#\x)
+                          (set! *pregexp-space-sensitive?* inv?)
+                          (loop (+ i 1) r #f))
+                         ((#\:) (list r (+ i 1)))
+                         (else (pregexp-error
+                                'pregexp-read-cluster-type))))))))]
+        [else (list '(:sub) i)])))
 
-  ;;
+  (define (pregexp-read-subpattern s i n)
+    (let* ([remember-space-sensitive? *pregexp-space-sensitive?*]
+           [ctyp-i (pregexp-read-cluster-type s i n)]
+           [ctyp (car ctyp-i)]
+           [i (cadr ctyp-i)]
+           [vv (pregexp-read-pattern s i n)])
+      (set! *pregexp-space-sensitive?* remember-space-sensitive?)
+      (let ([vv-re (car vv)]
+            [vv-i (cadr vv)])
+        (if (and (< vv-i n)
+                 (char=? (string-ref s vv-i)
+                   #\)))
+            (list
+             (let loop ([ctyp ctyp] [re vv-re])
+               (if (null? ctyp) re
+                   (loop (cdr ctyp)
+                     (list (car ctyp) re))))
+             (+ vv-i 1))
+            (pregexp-error 'pregexp-read-subpattern)))))
 
-  (define pregexp-string-match
-    (lambda (s1 s i n sk fk)
-      (let ((n1 (string-length s1)))
-        (if (> n1 n) (fk)
-            (let loop ((j 0) (k i))
-              (cond ((>= j n1) (sk k))
-                ((>= k n) (fk))
-                ((char=? (string-ref s1 j) (string-ref s k))
-                 (loop (+ j 1) (+ k 1)))
-                (else (fk))))))))
+  (define (pregexp-wrap-quantifier-if-any vv s n)
+    (let ([re (car vv)])
+      (let loop ([i (cadr vv)])
+        (if (>= i n) vv
+            (let ([c (string-ref s i)])
+              (if (and (char-whitespace? c) (not *pregexp-space-sensitive?*))
+                  (loop (+ i 1))
+                  (case c
+                    [(#\* #\+ #\? #\{)
+                     (let* ([new-re (list ':between 'minimal?
+                                      'at-least 'at-most re)]
+                            [new-vv (list new-re 'next-i)])
+                       (case c
+                         ((#\*) (set-car! (cddr new-re) 0)
+                          (set-car! (cdddr new-re) #f))
+                         ((#\+) (set-car! (cddr new-re) 1)
+                          (set-car! (cdddr new-re) #f))
+                         ((#\?) (set-car! (cddr new-re) 0)
+                          (set-car! (cdddr new-re) 1))
+                         ((#\{) (let ([pq (pregexp-read-nums s (+ i 1) n)])
+                                  (if (not pq)
+                                      (pregexp-error
+                                       'pregexp-wrap-quantifier-if-any
+                                       'left-brace-must-be-followed-by-number))
+                                  (set-car! (cddr new-re) (car pq))
+                                  (set-car! (cdddr new-re) (cadr pq))
+                                  (set! i (caddr pq)))))
+                       (let loop ([i (+ i 1)])
+                         (if (>= i n)
+                             (begin (set-car! (cdr new-re) #f)
+                                    (set-car! (cdr new-vv) i))
+                             (let ([c (string-ref s i)])
+                               (cond
+                                [(and (char-whitespace? c)
+                                      (not *pregexp-space-sensitive?*))
+                                 (loop (+ i 1))]
+                                [(char=? c #\?)
+                                 (set-car! (cdr new-re) #t)
+                                 (set-car! (cdr new-vv) (+ i 1))]
+                                [else (set-car! (cdr new-re) #f)
+                                  (set-car! (cdr new-vv) i)]))))
+                       new-vv)]
+                    [else vv])))))))
 
-  (define pregexp-char-word?
-    (lambda (c)
-      ;;too restrictive for Scheme but this
-      ;;is what \w is in most regexp notations
-      (or (char-alphabetic? c)
-          (char-numeric? c)
-          (char=? c #\_))))
+  (define (pregexp-read-nums s i n)
+    ;; s[i-1] = {
+    ;; returns (p q k) where s[k] = }
+    (let loop ([p '()] [q '()] [k i] [reading 1])
+      (if (>= k n) (pregexp-error 'pregexp-read-nums))
+      (let ([c (string-ref s k)])
+        (cond
+         [(char-numeric? c)
+          (if (= reading 1)
+              (loop (cons c p) q (+ k 1) 1)
+              (loop p (cons c q) (+ k 1) 2))]
+         [(and (char-whitespace? c) (not *pregexp-space-sensitive?*))
+          (loop p q (+ k 1) reading)]
+         [(and (char=? c #\,) (= reading 1))
+          (loop p q (+ k 1) 2)]
+         [(char=? c #\})
+          (let ([p (string->number (list->string (reverse! p)))]
+                [q (string->number (list->string (reverse! q)))])
+            (cond
+             [(and (not p) (= reading 1)) (list 0 #f k)]
+             [(= reading 1) (list p p k)]
+             [else (list p q k)]))]
+         [else #f]))))
 
-  (define pregexp-at-word-boundary?
-    (lambda (s i n)
-      (or (= i 0) (>= i n)
-          (let ((c/i (string-ref s i))
-                (c/i-1 (string-ref s (- i 1))))
-            (let ((c/i/w? (pregexp-check-if-in-char-class?
-                           c/i ':word))
-                  (c/i-1/w? (pregexp-check-if-in-char-class?
-                             c/i-1 ':word)))
-              (or (and c/i/w? (not c/i-1/w?))
-                  (and (not c/i/w?) c/i-1/w?)))))))
+  (define (pregexp-invert-char-list vv)
+    (set-car! (car vv) ':none-of-chars)
+    vv)
 
-  (define pregexp-check-if-in-char-class?
-    (lambda (c char-class)
-      (case char-class
-        ((:any) (not (char=? c #\newline)))
-        ((:alnum) (or (char-alphabetic? c) (char-numeric? c)))
-        ((:alpha) (char-alphabetic? c))
-        ((:ascii) (< (char->integer c) 128))
-        ((:blank) (or (char=? c #\space) (char=? c #\tab)))
-        ((:cntrl) (< (char->integer c) 32))
-        ((:digit) (char-numeric? c))
-        ((:graph) (and (>= (char->integer c) 32)
-                       (not (char-whitespace? c))))
-        ((:lower) (char-lower-case? c))
-        ((:print) (>= (char->integer c) 32))
-        ((:punct) (and (>= (char->integer c) 32)
-                       (not (char-whitespace? c))
-                       (not (char-alphabetic? c))
-                       (not (char-numeric? c))))
-        ((:space) (char-whitespace? c))
-        ((:upper) (char-upper-case? c))
-        ((:word) (or (char-alphabetic? c)
-                     (char-numeric? c)
-                     (char=? c #\_)))
-        ((:xdigit) (or (char-numeric? c)
-                       (char-ci=? c #\a) (char-ci=? c #\b)
-                       (char-ci=? c #\c) (char-ci=? c #\d)
-                       (char-ci=? c #\e) (char-ci=? c #\f)))
-        (else (pregexp-error 'pregexp-check-if-in-char-class?)))))
+  (define (pregexp-read-char-list s i n)
+    (let loop ([r '()] [i i])
+      (if (>= i n)
+          (pregexp-error 'pregexp-read-char-list
+            'character-class-ended-too-soon)
+          (let ([c (string-ref s i)])
+            (case c
+              [(#\]) (if (null? r)
+                         (loop (cons c r) (+ i 1))
+                         (list (cons ':one-of-chars (reverse! r))
+                           (+ i 1)))]
+              [(#\\)
+               (let ([char-i (pregexp-read-escaped-char s i n)])
+                 (if char-i (loop (cons (car char-i) r) (cadr char-i))
+                     (pregexp-error 'pregexp-read-char-list 'backslash)))]
+              [(#\-) (if (or (null? r)
+                             (let ([i+1 (+ i 1)])
+                               (and (< i+1 n)
+                                    (char=? (string-ref s i+1) #\]))))
+                         (loop (cons c r) (+ i 1))
+                         (let ([c-prev (car r)])
+                           (if (char? c-prev)
+                               (loop (cons (list ':char-range c-prev
+                                             (string-ref s (+ i 1))) (cdr r))
+                                 (+ i 2))
+                               (loop (cons c r) (+ i 1)))))]
+              [(#\[) (if (char=? (string-ref s (+ i 1)) #\:)
+                         (let ([posix-char-class-i
+                                (pregexp-read-posix-char-class s (+ i 2) n)])
+                           (loop (cons (car posix-char-class-i) r)
+                             (cadr posix-char-class-i)))
+                         (loop (cons c r) (+ i 1)))]
+              [else (loop (cons c r) (+ i 1))])))))
 
-  (define pregexp-list-ref
-    (lambda (s i)
-      ;;like list-ref but returns #f if index is
-      ;;out of bounds
-      (let loop ((s s) (k 0))
-        (cond ((null? s) #f)
-          ((= k i) (car s))
-          (else (loop (cdr s) (+ k 1)))))))
+  (define (pregexp-string-match s1 s i n sk fk)
+    (let ([n1 (string-length s1)])
+      (if (> n1 n) (fk)
+          (let loop ([j 0] [k i])
+            (cond
+             [(>= j n1) (sk k)]
+             [(>= k n) (fk)]
+             [(char=? (string-ref s1 j) (string-ref s k))
+              (loop (+ j 1) (+ k 1))]
+             [else (fk)])))))
 
-  ;;re is a compiled regexp.  It's a list that can't be
-  ;;nil.  pregexp-match-positions-aux returns a 2-elt list whose
-  ;;car is the string-index following the matched
-  ;;portion and whose cadr contains the submatches.
-  ;;The proc returns false if there's no match.
+  (define (pregexp-char-word? c)
+    ;; too restrictive for Scheme but this
+    ;; is what \w is in most regexp notations
+    (or (char-alphabetic? c)
+        (char-numeric? c)
+        (char=? c #\_)))
 
-  ;;Am spelling loop- as loup- because these shouldn't
-  ;;be translated into CL loops by scm2cl (although
-  ;;they are tail-recursive in Scheme)
+  (define (pregexp-at-word-boundary? s i n)
+    (or (= i 0) (>= i n)
+        (let ([c/i (string-ref s i)]
+              [c/i-1 (string-ref s (- i 1))])
+          (let ([c/i/w? (pregexp-check-if-in-char-class?
+                         c/i ':word)]
+                [c/i-1/w? (pregexp-check-if-in-char-class?
+                           c/i-1 ':word)])
+            (or (and c/i/w? (not c/i-1/w?))
+                (and (not c/i/w?) c/i-1/w?))))))
 
-  (define pregexp-make-backref-list
-    (lambda (re)
-      (let sub ((re re))
-        (if (pair? re)
-            (let ((car-re (car re))
-                  (sub-cdr-re (sub (cdr re))))
-              (if (eqv? car-re ':sub)
-                  (cons (cons re #f) sub-cdr-re)
-                  (append (sub car-re) sub-cdr-re)))
-            '()))))
+  (define (pregexp-check-if-in-char-class? c char-class)
+    (case char-class
+      [(:any) (not (char=? c #\newline))]
+      [(:alnum) (or (char-alphabetic? c) (char-numeric? c))]
+      [(:alpha) (char-alphabetic? c)]
+      [(:ascii) (< (char->integer c) 128)]
+      [(:blank) (or (char=? c #\space) (char=? c #\tab))]
+      [(:cntrl) (< (char->integer c) 32)]
+      [(:digit) (char-numeric? c)]
+      [(:graph) (and (>= (char->integer c) 32)
+                     (not (char-whitespace? c)))]
+      [(:lower) (char-lower-case? c)]
+      [(:print) (>= (char->integer c) 32)]
+      [(:punct) (and (>= (char->integer c) 32)
+                     (not (char-whitespace? c))
+                     (not (char-alphabetic? c))
+                     (not (char-numeric? c)))]
+      [(:space) (char-whitespace? c)]
+      [(:upper) (char-upper-case? c)]
+      [(:word) (or (char-alphabetic? c)
+                   (char-numeric? c)
+                   (char=? c #\_))]
+      [(:xdigit) (or (char-numeric? c)
+                     (char-ci=? c #\a) (char-ci=? c #\b)
+                     (char-ci=? c #\c) (char-ci=? c #\d)
+                     (char-ci=? c #\e) (char-ci=? c #\f))]
+      [else (pregexp-error 'pregexp-check-if-in-char-class?)]))
 
-  (define pregexp-match-positions-aux
-    (lambda (re s start n i)
-      (let ((identity (lambda (x) x))
-            (backrefs (pregexp-make-backref-list re))
-            (case-sensitive? #t))
-        (let sub ((re re) (i i) (sk identity) (fk (lambda () #f)))
-          (cond ((eqv? re ':bos)
-                 (if (= i start) (sk i) (fk))
-                 )
-            ((eqv? re ':eos)
-             (if (>= i n) (sk i) (fk))
-             )
-            ((eqv? re ':empty)
-             (sk i))
-            ((eqv? re ':wbdry)
-             (if (pregexp-at-word-boundary? s i n)
-                 (sk i)
-                 (fk)))
-            ((eqv? re ':not-wbdry)
-             (if (pregexp-at-word-boundary? s i n)
-                 (fk)
-                 (sk i)))
-            ((and (char? re) (< i n))
-             (if ((if case-sensitive? char=? char-ci=?)
-                  (string-ref s i) re)
-                 (sk (+ i 1)) (fk)))
-            ((and (not (pair? re)) (< i n))
-             (if (pregexp-check-if-in-char-class?
-                  (string-ref s i) re)
-                 (sk (+ i 1)) (fk)))
-            ((and (pair? re) (eqv? (car re) ':char-range) (< i n))
-             (let ((c (string-ref s i)))
-               (if (let ((c< (if case-sensitive? char<=? char-ci<=?)))
-                     (and (c< (cadr re) c)
-                          (c< c (caddr re))))
-                   (sk (+ i 1)) (fk))))
-            ((pair? re)
-             (case (car re)
-               ((:char-range)
-                (if (>= i n) (fk)
-                    (pregexp-error 'pregexp-match-positions-aux)))
-               ((:one-of-chars)
-                (if (>= i n) (fk)
-                    (let loup-one-of-chars ((chars (cdr re)))
-                      (if (null? chars) (fk)
-                          (sub (car chars) i sk
-                            (lambda ()
-                              (loup-one-of-chars (cdr chars))))))))
-               ((:neg-char)
-                (if (>= i n) (fk)
+  (define (pregexp-list-ref s i)
+    ;; like list-ref but returns #f if index is out of bounds
+    (let loop ([s s] [k 0])
+      (cond
+       [(null? s) #f]
+       [(= k i) (car s)]
+       [else (loop (cdr s) (+ k 1))])))
+
+  ;; re is a compiled regexp.  It's a list that can't be
+  ;; nil.  pregexp-match-positions-aux returns a 2-elt list whose
+  ;; car is the string-index following the matched
+  ;; portion and whose cadr contains the submatches.
+  ;; The proc returns false if there's no match.
+
+  (define (pregexp-make-backref-list re)
+    (let sub ([re re])
+      (if (pair? re)
+          (let ([car-re (car re)]
+                [sub-cdr-re (sub (cdr re))])
+            (if (eq? car-re ':sub)
+                (cons (cons re #f) sub-cdr-re)
+                (append (sub car-re) sub-cdr-re)))
+          '())))
+
+  (define (pregexp-match-positions-aux re s start n i)
+    (let ([identity (lambda (x) x)]
+          [backrefs (pregexp-make-backref-list re)]
+          [case-sensitive? #t])
+      (let sub ([re re] [i i] [sk identity] [fk (lambda () #f)])
+        (cond
+         [(eq? re ':bos)
+          (if (= i start) (sk i) (fk))]
+         [(eq? re ':eos)
+          (if (>= i n) (sk i) (fk))]
+         [(eq? re ':empty)
+          (sk i)]
+         [(eq? re ':wbdry)
+          (if (pregexp-at-word-boundary? s i n)
+              (sk i)
+              (fk))]
+         [(eq? re ':not-wbdry)
+          (if (pregexp-at-word-boundary? s i n)
+              (fk)
+              (sk i))]
+         [(and (char? re) (< i n))
+          (if ((if case-sensitive? char=? char-ci=?)
+               (string-ref s i) re)
+              (sk (+ i 1)) (fk))]
+         [(and (not (pair? re)) (< i n))
+          (if (pregexp-check-if-in-char-class?
+               (string-ref s i) re)
+              (sk (+ i 1)) (fk))]
+         [(and (pair? re) (eq? (car re) ':char-range) (< i n))
+          (let ([c (string-ref s i)])
+            (if (let ([c< (if case-sensitive? char<=? char-ci<=?)])
+                  (and (c< (cadr re) c)
+                       (c< c (caddr re))))
+                (sk (+ i 1)) (fk)))]
+         [(pair? re)
+          (case (car re)
+            [(:char-range)
+             (if (>= i n) (fk)
+                 (pregexp-error 'pregexp-match-positions-aux))]
+            [(:one-of-chars)
+             (if (>= i n) (fk)
+                 (let loop-one-of-chars ([chars (cdr re)])
+                   (if (null? chars) (fk)
+                       (sub (car chars) i sk
+                         (lambda ()
+                           (loop-one-of-chars (cdr chars)))))))]
+            [(:neg-char)
+             (if (>= i n) (fk)
+                 (sub (cadr re) i
+                   (lambda (i1) (fk))
+                   (lambda () (sk (+ i 1)))))]
+            [(:seq)
+             (let loop-seq ([res (cdr re)] [i i])
+               (if (null? res) (sk i)
+                   (sub (car res) i
+                     (lambda (i1)
+                       (loop-seq (cdr res) i1))
+                     fk)))]
+            [(:or)
+             (let loop-or ([res (cdr re)])
+               (if (null? res) (fk)
+                   (sub (car res) i
+                     (lambda (i1)
+                       (or (sk i1)
+                           (loop-or (cdr res))))
+                     (lambda () (loop-or (cdr res))))))]
+            [(:backref)
+             (let* ([c (pregexp-list-ref backrefs (cadr re))]
+                    [backref
+                     (cond
+                      [c => cdr]
+                      [else
+                       (pregexp-error 'pregexp-match-positions-aux
+                         'non-existent-backref re)
+                       #f])])
+               (if backref
+                   (pregexp-string-match
+                    (substring s (car backref) (cdr backref))
+                    s i n (lambda (i) (sk i)) fk)
+                   (sk i)))]
+            [(:sub)
+             (sub (cadr re) i
+               (lambda (i1)
+                 (set-cdr! (assv re backrefs) (cons i i1))
+                 (sk i1)) fk)]
+            [(:lookahead)
+             (let ([found-it?
                     (sub (cadr re) i
-                      (lambda (i1) (fk))
-                      (lambda () (sk (+ i 1))))))
-               ((:seq)
-                (let loup-seq ((res (cdr re)) (i i))
-                  (if (null? res) (sk i )
-                      (sub (car res) i
-                        (lambda (i1 )
-                          (loup-seq (cdr res) i1))
-                        fk))))
-               ((:or)
-                (let loup-or ((res (cdr re)))
-                  (if (null? res) (fk)
-                      (sub (car res) i
-                        (lambda (i1 )
-                          (or (sk i1 )
-                              (loup-or (cdr res))))
-                        (lambda () (loup-or (cdr res)))))))
-               ((:backref)
-                (let* ((c (pregexp-list-ref backrefs (cadr re)))
-                       (backref
-                        (cond (c => cdr)
-                          (else
-                           (pregexp-error 'pregexp-match-positions-aux
-                             'non-existent-backref re)
-                           #f))))
-                  (if backref
-                      (pregexp-string-match
-                       (substring s (car backref) (cdr backref))
-                       s i n (lambda (i) (sk i)) fk)
-                      (sk i))))
-               ((:sub)
-                (sub (cadr re) i
-                  (lambda (i1)
-                    (set-cdr! (assv re backrefs) (cons i i1))
-                    (sk i1)) fk))
-               ((:lookahead)
-                (let ((found-it?
-                       (sub (cadr re) i
-                         identity (lambda () #f))))
-                  (if found-it? (sk i) (fk))))
-               ((:neg-lookahead)
-                (let ((found-it?
-                       (sub (cadr re) i
-                         identity (lambda () #f))))
-                  (if found-it? (fk) (sk i))))
-               ((:lookbehind)
-                (let ((found-it?
-                       (fluid-let ((n i))
-                         (let loup-lookbehind ((re (cadr re)) (i i))
-                           (sub re i (lambda (i) (= i n))
-                             (lambda ()
-                               (and (> i start)
-                                    (loup-lookbehind re (- i 1)))))))))
-                  (if found-it? (sk i) (fk))))
-               ((:neg-lookbehind)
-                (let ((found-it?
-                       (fluid-let ((n i))
-                         (let loup-lookbehind ((re (cadr re)) (i i))
-                           (sub re i (lambda (i) (= i n))
-                             (lambda ()
-                               (and (> i start)
-                                    (loup-lookbehind re (- i 1)))))))))
-                  (if found-it? (fk) (sk i))))
-               ((:no-backtrack)
-                (let ((found-it? (sub (cadr re) i
-                                   identity (lambda () #f))))
-                  (if found-it?
-                      (sk found-it?)
-                      (fk))))
-               ((:case-sensitive :case-insensitive)
-                (let ((old case-sensitive?))
-                  (set! case-sensitive?
-                    (eqv? (car re) ':case-sensitive))
-                  (sub (cadr re) i
-                    (lambda (i1)
-                      (set! case-sensitive? old)
-                      (sk i1))
-                    (lambda ()
-                      (set! case-sensitive? old)
-                      (fk)))))
-               ((:between)
-                (let* ((maximal? (not (cadr re)))
-                       (p (caddr re))
-                       (q (cadddr re))
-                       (could-loop-infinitely? (and maximal? (not q)))
-                       (re (car (cddddr re))))
-                  (let loup-p ((k 0) (i i))
-                    (if (< k p)
-                        (sub re i
-                          (lambda (i1 )
-                            (if (and could-loop-infinitely?
-                                     (= i1 i))
-                                (pregexp-error
-                                 'pregexp-match-positions-aux
-                                 'greedy-quantifier-operand-could-be-empty))
-                            (loup-p (+ k 1) i1 ))
-                          fk)
-                        (let ((q (and q (- q p))))
-                          (let loup-q ((k 0) (i i))
-                            (let ((fk (lambda ()
-                                        (sk i ))))
-                              (if (and q (>= k q)) (fk)
-                                  (if maximal?
-                                      (sub re i
-                                        (lambda (i1)
-                                          (if (and could-loop-infinitely?
-                                                   (= i1 i))
-                                              (pregexp-error
-                                               'pregexp-match-positions-aux
-                                               'greedy-quantifier-operand-could-be-empty))
-                                          (or (loup-q (+ k 1) i1)
-                                              (fk)))
-                                        fk)
-                                      (or (fk)
-                                          (sub re i
-                                            (lambda (i1)
-                                              (loup-q (+ k 1) i1))
-                                            fk)))))))))))
-               (else (pregexp-error 'pregexp-match-positions-aux))))
-            ((>= i n) (fk))
-            (else (pregexp-error 'pregexp-match-positions-aux))))
-        (let ((backrefs (map cdr backrefs)))
-          (and (car backrefs) backrefs)))))
+                      identity (lambda () #f))])
+               (if found-it? (sk i) (fk)))]
+            [(:neg-lookahead)
+             (let ([found-it?
+                    (sub (cadr re) i
+                      identity (lambda () #f))])
+               (if found-it? (fk) (sk i)))]
+            [(:lookbehind)
+             (let ([found-it?
+                    (fluid-let ([n i])
+                      (let loop-lookbehind ([re (cadr re)] [i i])
+                        (sub re i (lambda (i) (= i n))
+                          (lambda ()
+                            (and (> i start)
+                                 (loop-lookbehind re (- i 1)))))))])
+               (if found-it? (sk i) (fk)))]
+            [(:neg-lookbehind)
+             (let ([found-it?
+                    (fluid-let ([n i])
+                      (let loop-lookbehind ([re (cadr re)] [i i])
+                        (sub re i (lambda (i) (= i n))
+                          (lambda ()
+                            (and (> i start)
+                                 (loop-lookbehind re (- i 1)))))))])
+               (if found-it? (fk) (sk i)))]
+            [(:no-backtrack)
+             (let ([found-it? (sub (cadr re) i
+                                identity (lambda () #f))])
+               (if found-it?
+                   (sk found-it?)
+                   (fk)))]
+            [(:case-sensitive :case-insensitive)
+             (let ([old case-sensitive?])
+               (set! case-sensitive?
+                 (eq? (car re) ':case-sensitive))
+               (sub (cadr re) i
+                 (lambda (i1)
+                   (set! case-sensitive? old)
+                   (sk i1))
+                 (lambda ()
+                   (set! case-sensitive? old)
+                   (fk))))]
+            [(:between)
+             (let* ([maximal? (not (cadr re))]
+                    [p (caddr re)]
+                    [q (cadddr re)]
+                    [could-loop-infinitely? (and maximal? (not q))]
+                    [re (car (cddddr re))])
+               (let loop-p ([k 0] [i i])
+                 (if (< k p)
+                     (sub re i
+                       (lambda (i1)
+                         (if (and could-loop-infinitely?
+                                  (= i1 i))
+                             (pregexp-error
+                              'pregexp-match-positions-aux
+                              'greedy-quantifier-operand-could-be-empty))
+                         (loop-p (+ k 1) i1))
+                       fk)
+                     (let ([q (and q (- q p))])
+                       (let loop-q ([k 0] [i i])
+                         (let ([fk (lambda () (sk i))])
+                           (if (and q (>= k q)) (fk)
+                               (if maximal?
+                                   (sub re i
+                                     (lambda (i1)
+                                       (if (and could-loop-infinitely?
+                                                (= i1 i))
+                                           (pregexp-error
+                                            'pregexp-match-positions-aux
+                                            'greedy-quantifier-operand-could-be-empty))
+                                       (or (loop-q (+ k 1) i1)
+                                           (fk)))
+                                     fk)
+                                   (or (fk)
+                                       (sub re i
+                                         (lambda (i1)
+                                           (loop-q (+ k 1) i1))
+                                         fk))))))))))]
+            [else (pregexp-error 'pregexp-match-positions-aux)])]
+         [(>= i n) (fk)]
+         [else (pregexp-error 'pregexp-match-positions-aux)]))
+      (let ([backrefs (map cdr backrefs)])
+        (and (car backrefs) backrefs))))
 
-  (define pregexp-replace-aux
-    (lambda (str ins n backrefs)
-      (let loop ((i 0) (r ""))
-        (if (>= i n) r
-            (let ((c (string-ref ins i)))
-              (if (char=? c #\\ )
-                  (let* ((br-i (pregexp-read-escaped-number ins i n))
-                         (br (if br-i (car br-i)
-                                 (if (char=? (string-ref ins (+ i 1)) #\&) 0
-                                     #f)))
-                         (i (if br-i (cadr br-i)
-                                (if br (+ i 2)
-                                    (+ i 1)))))
-                    (if (not br)
-                        (let ((c2 (string-ref ins i)))
-                          (loop (+ i 1)
-                            (if (char=? c2 #\$) r
-                                (string-append r (string c2)))))
-                        (loop i
-                          (let ((backref (pregexp-list-ref backrefs br)))
-                            (if backref
-                                (string-append r
-                                  (substring str (car backref) (cdr backref)))
-                                r)))))
-                  (loop (+ i 1) (string-append r (string c)))))))))
+  (define (put-substring p str start end)
+    (put-string p str start (- end start)))
 
-  (define pregexp
-    (lambda (s)
-      (set! *pregexp-space-sensitive?* #t) ;;in case it got corrupted
-      (list ':sub (car (pregexp-read-pattern s 0 (string-length s))))))
+  (define (pregexp-replace-aux str ins n backrefs p)
+    (let loop ([i 0])
+      (when (< i n)
+        (let ([c (string-ref ins i)])
+          (cond
+           [(char=? c #\\)
+            (let* ([br-i (pregexp-read-escaped-number ins i n)]
+                   [br (if br-i
+                           (car br-i)
+                           (if (char=? (string-ref ins (+ i 1)) #\&)
+                               0
+                               #f))]
+                   [i (if br-i
+                          (cadr br-i)
+                          (if br
+                              (+ i 2)
+                              (+ i 1)))])
+              (if (not br)
+                  (let ([c2 (string-ref ins i)])
+                    (unless (char=? c2 #\$)
+                      (put-char p c2))
+                    (loop (+ i 1)))
+                  (let ([backref (pregexp-list-ref backrefs br)])
+                    (when backref
+                      (put-substring p str (car backref) (cdr backref)))
+                    (loop i))))]
+           [else
+            (put-char p c)
+            (loop (+ i 1))])))))
+
+  (define (pregexp s)
+    (set! *pregexp-space-sensitive?* #t) ;; in case it got corrupted
+    (list ':sub (car (pregexp-read-pattern s 0 (string-length s)))))
 
   (define pregexp-match-positions
-    (lambda (pat str . opt-args)
-      (cond ((string? pat) (set! pat (pregexp pat)))
-        ((pair? pat) #t)
-        (else (pregexp-error 'pregexp-match-positions
-                'pattern-must-be-compiled-or-string-regexp
-                pat)))
-      (let* ((str-len (string-length str))
-             (start (if (null? opt-args) 0
-                        (let ((start (car opt-args)))
-                          (set! opt-args (cdr opt-args))
-                          start)))
-             (end (if (null? opt-args) str-len
-                      (car opt-args))))
-        (let loop ((i start))
+    (case-lambda
+     [(pat str)
+      (pregexp-match-positions pat str 0)]
+     [(pat str start)
+      (pregexp-match-positions pat str start (string-length str))]
+     [(pat str start end)
+      (let ([pat (cond
+                  [(string? pat) (pregexp pat)]
+                  [(pair? pat) pat]
+                  [else (pregexp-error 'pregexp-match-positions
+                          'pattern-must-be-compiled-or-string-regexp
+                          pat)])])
+        (let loop ([i start])
           (and (<= i end)
                (or (pregexp-match-positions-aux pat str start end i)
-                   (loop (+ i 1))))))))
+                   (loop (+ i 1))))))]))
 
   (define pregexp-match
-    (lambda (pat str . opt-args)
-      (let ((ix-prs (apply pregexp-match-positions pat str opt-args)))
+    (case-lambda
+     [(pat str) (pregexp-match pat str 0)]
+     [(pat str start) (pregexp-match pat str start (string-length str))]
+     [(pat str start end)
+      (let ([ix-prs (pregexp-match-positions pat str start end)])
         (and ix-prs
              (map
               (lambda (ix-pr)
                 (and ix-pr
                      (substring str (car ix-pr) (cdr ix-pr))))
-              ix-prs)))))
+              ix-prs)))]))
 
-  (define pregexp-split
-    (lambda (pat str)
-      ;;split str into substrings, using pat as delimiter
-      (let ((n (string-length str)))
-        (let loop ((i 0) (r '()) (picked-up-one-undelimited-char? #f))
-          (cond ((>= i n) (reverse! r))
-            ((pregexp-match-positions pat str i n)
-             =>
-             (lambda (y)
-               (let ((jk (car y)))
-                 (let ((j (car jk)) (k (cdr jk)))
-                   ;;(printf "j = ~a;; k = ~a;; i = ~a~n" j k i)
-                   (cond ((= j k)
-                          ;;(printf "producing ~s~n" (substring str i (+ j 1)))
-                          (loop (+ k 1)
-                            (cons (substring str i (+ j 1)) r) #t))
-                     ((and (= j i) picked-up-one-undelimited-char?)
-                      (loop k r #f))
-                     (else
-                      ;;(printf "producing ~s~n" (substring str i j))
-                      (loop k (cons (substring str i j) r) #f)))))))
-            (else (loop n (cons (substring str i n) r) #f)))))))
+  (define (pregexp-split pat str)
+    ;; split str into substrings, using pat as delimiter
+    (let ([n (string-length str)])
+      (let loop ([i 0] [r '()] [picked-up-one-undelimited-char? #f])
+        (cond
+         [(>= i n) (reverse! r)]
+         [(pregexp-match-positions pat str i n) =>
+          (lambda (y)
+            (let ([jk (car y)])
+              (let ([j (car jk)] [k (cdr jk)])
+                (cond
+                 [(= j k)
+                  (loop (+ k 1)
+                    (cons (substring str i (+ j 1)) r) #t)]
+                 [(and (= j i) picked-up-one-undelimited-char?)
+                  (loop k r #f)]
+                 [else
+                  (loop k (cons (substring str i j) r) #f)]))))]
+         [else (loop n (cons (substring str i n) r) #f)]))))
 
-  (define pregexp-replace
-    (lambda (pat str ins)
-      (let* ((n (string-length str))
-             (pp (pregexp-match-positions pat str 0 n)))
-        (if (not pp) str
-            (let ((ins-len (string-length ins))
-                  (m-i (caar pp))
-                  (m-n (cdar pp)))
-              (string-append
-               (substring str 0 m-i)
-               (pregexp-replace-aux str ins ins-len pp)
-               (substring str m-n n)))))))
+  (define (pregexp-replace pat str ins)
+    (let* ([n (string-length str)]
+           [pp (pregexp-match-positions pat str 0 n)])
+      (if (not pp)
+          str
+          (let ([ins-len (string-length ins)]
+                [m-i (caar pp)]
+                [m-n (cdar pp)]
+                [p (open-output-string)])
+            (put-substring p str 0 m-i)
+            (pregexp-replace-aux str ins ins-len pp p)
+            (put-substring p str m-n n)
+            (get-output-string p)))))
 
-  (define pregexp-replace*
-    (lambda (pat str ins)
-      ;;return str with every occurrence of pat
-      ;;replaced by ins
-      (let ((pat (if (string? pat) (pregexp pat) pat))
-            (n (string-length str))
-            (ins-len (string-length ins)))
-        (let loop ((i 0) (r ""))
-          ;;i = index in str to start replacing from
-          ;;r = already calculated prefix of answer
-          (if (>= i n) r
-              (let ((pp (pregexp-match-positions pat str i n)))
-                (if (not pp)
-                    (if (= i 0)
-                        ;;this implies pat didn't match str at
-                        ;;all, so let's return original str
-                        str
-                        ;;else: all matches already found and
-                        ;;replaced in r, so let's just
-                        ;;append the rest of str
-                        (string-append
-                         r (substring str i n)))
-                    (loop (cdar pp)
-                      (string-append
-                       r
-                       (substring str i (caar pp))
-                       (pregexp-replace-aux str ins ins-len pp))))))))))
+  (define (pregexp-replace* pat str ins)
+    ;; return str with every occurrence of pat
+    ;; replaced by ins
+    (let ([pat (if (string? pat) (pregexp pat) pat)]
+          [n (string-length str)]
+          [ins-len (string-length ins)]
+          [p (open-output-string)])
+      (let loop ([i 0])
+        ;; i = index in str to start replacing from
+        ;; r = already calculated prefix of answer
+        (if (>= i n)
+            (get-output-string p)
+            (let ([pp (pregexp-match-positions pat str i n)])
+              (cond
+               [pp
+                (put-substring p str i (caar pp))
+                (pregexp-replace-aux str ins ins-len pp p)
+                (loop (cdar pp))]
+               [(= i 0)
+                ;; this implies pat didn't match str at
+                ;; all, so let's return original str
+                str]
+               [else
+                ;; all matches already found and
+                ;; replaced in r, so let's just
+                ;; append the rest of str
+                (put-substring p str i n)
+                (get-output-string p)]))))))
 
-  (define pregexp-quote
-    (lambda (s)
-      (let loop ((i (- (string-length s) 1)) (r '()))
-        (if (< i 0) (list->string r)
-            (loop (- i 1)
-              (let ((c (string-ref s i)))
-                (if (memv c '(#\\ #\. #\? #\* #\+ #\| #\^ #\$
-                              #\[ #\] #\{ #\} #\( #\)))
-                    (cons #\\ (cons c r))
-                    (cons c r)))))))))
+  (define (pregexp-quote s)
+    (let loop ([i (- (string-length s) 1)] [r '()])
+      (if (< i 0) (list->string r)
+          (loop (- i 1)
+            (let ([c (string-ref s i)])
+              (if (memv c '(#\\ #\. #\? #\* #\+ #\| #\^ #\$
+                            #\[ #\] #\{ #\} #\( #\)))
+                  (cons #\\ (cons c r))
+                  (cons c r))))))))


### PR DESCRIPTION
- handle newline properly
- respect non-zero start position
- use string output ports in replace functions for efficiency
- tighten signatures for multiple-arity procedures
- use brackets instead of parentheses where appropriate