### PR TITLE
specify -lpthread for libosi.so on Linux

### DIFF
--- a/src/swish/Mf-a6le
+++ b/src/swish/Mf-a6le
@@ -13,7 +13,7 @@ SwishLibs := ../../${BUILD}/bin/libosi.so ../../${BUILD}/lib/swish_kernel.o
 	$C -o $@ $^ -Wl,-E ${SystemLibs}
 
 ../../${BUILD}/bin/libosi.so: ${OsiObj} ${UvLib}/libuv.a
-	$C -shared -L"${LIBUV_LIBPATH}" -o ../../${BUILD}/bin/libosi.so ${OsiObj} -luv -luuid
+	$C -shared -L"${LIBUV_LIBPATH}" -o ../../${BUILD}/bin/libosi.so ${OsiObj} -luv -luuid -lpthread
 
 ../../${BUILD}/lib/swish_kernel.o: ${UvLib}/libuv.a run.o ${OsiObj}
 	ld -melf_x86_64 -r -X -o $@ run.o ${OsiObj} "${SCHEME_LIBPATH}"/kernel.o -L"${LIBUV_LIBPATH}" -luv

--- a/src/swish/Mf-i3le
+++ b/src/swish/Mf-i3le
@@ -13,7 +13,7 @@ SwishLibs := ../../${BUILD}/bin/libosi.so ../../${BUILD}/lib/swish_kernel.o
 	$C -o $@ $^ -Wl,-E ${SystemLibs}
 
 ../../${BUILD}/bin/libosi.so: ${OsiObj} ${UvLib}/libuv.a
-	$C -shared -L"${LIBUV_LIBPATH}" -o ../../${BUILD}/bin/libosi.so ${OsiObj} -luv -luuid
+	$C -shared -L"${LIBUV_LIBPATH}" -o ../../${BUILD}/bin/libosi.so ${OsiObj} -luv -luuid -lpthread
 
 ../../${BUILD}/lib/swish_kernel.o: ${UvLib}/libuv.a run.o ${OsiObj}
 	ld -melf_i386 -r -X -o $@ run.o ${OsiObj} "${SCHEME_LIBPATH}"/kernel.o -L"${LIBUV_LIBPATH}" -luv


### PR DESCRIPTION
This is required for the default compiler on Ubuntu 19.10.