### PR TITLE
add spawn-os-process-detached

### DIFF
--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -2516,6 +2516,22 @@ If \code{osi\_spawn} returns error pair \code{(\var{who}
   \var{errno})} is raised.
 
 % ----------------------------------------------------------------------------
+\defineentry{spawn-os-process-detached}
+\begin{procedure}
+  \code{(spawn-os-process-detached \var{path} \var{args})}
+\end{procedure}
+\returns{} an integer operating-system process identifier
+
+The \code{spawn-os-process-detached} procedure calls
+\code{osi\_spawn\_detached} to spawn an operating system process with
+the string \var{path} and list of string-valued \var{args}.  It
+returns an integer operating-system process identifier.
+
+If \code{osi\_spawn\_detached} returns error pair \code{(\var{who}
+  . \var{errno})}, exception \code{\#(io-error \var{path} \var{who}
+  \var{errno})} is raised.
+
+% ----------------------------------------------------------------------------
 \defineentry{stat-directory?}
 \begin{procedure}
   \code{(stat-directory? \var{x})}

--- a/doc/swish/osi.tex
+++ b/doc/swish/osi.tex
@@ -529,6 +529,17 @@ When the process exits, the callback list \code{(\var{callback}
 integer exit status, and \var{term-signal} is the integer termination
 signal or 0 if the process did not terminate because of a signal.
 
+\defineentry{osi\_spawn\_detached}
+\begin{function}
+  \code{ptr osi\_spawn\_detached(const char* \var{path}, ptr \var{args});}
+\end{function}
+
+The \code{osi\_spawn\_detached} function uses the \code{uv\_spawn}
+function to create a process with the list of string-valued \var{args}
+and the \code{UV\_PROCESS\_DETACHED} flag set. It returns an integer
+identifying the process when the process has been successfully created
+and an error pair otherwise.
+
 \defineentry{osi\_get\_pid}
 \begin{function}
   \code{int osi\_get\_pid();}

--- a/src/swish/io.ms
+++ b/src/swish/io.ms
@@ -184,7 +184,13 @@
     [(osi_spawn . ,_)
      (osi_spawn* "*" '(0) (lambda (os-pid exit-status term-signal) 'ok))]
     [(osi_spawn . ,_)
-     (osi_spawn* "*" '("x" . 0) (lambda (os-pid exit-status term-signal) 'ok))])
+     (osi_spawn* "*" '("x" . 0) (lambda (os-pid exit-status term-signal) 'ok))]
+    [#(EXIT #(io-error "*!*" uv_spawn ,_))
+     (catch (spawn-os-process-detached "*!*" '()))]
+    [(osi_spawn_detached . ,_)
+     (osi_spawn_detached* "*" '(0))]
+    [(osi_spawn_detached . ,_)
+     (osi_spawn_detached* "*" '("x" . 0))])
    'ok))
 
 (isolate-mat files ()

--- a/src/swish/io.ss
+++ b/src/swish/io.ss
@@ -91,6 +91,7 @@
    signal-handler
    signal-handler-count
    spawn-os-process
+   spawn-os-process-detached
    stat-directory?
    stat-regular-file?
    tcp-listener-count
@@ -852,6 +853,13 @@
            (make-iport name (@make-osi-port name from-stderr) #t))
          os-pid)]
        [(,who . ,errno) (io-error path who errno)])))
+
+  (define (spawn-os-process-detached path args)
+    (unless (and (list? args) (for-all string? args))
+      (bad-arg 'spawn-os-process-detached args))
+    (match (osi_spawn_detached* path args)
+      [(,who . ,errno) (io-error path who errno)]
+      [,os-pid os-pid]))
 
   ;; TCP/IP Ports
 

--- a/src/swish/osi.h
+++ b/src/swish/osi.h
@@ -76,6 +76,7 @@ EXPORT ptr osi_close_port(uptr port, ptr callback);
 // Process
 EXPORT void osi_exit(int status);
 EXPORT ptr osi_spawn(const char* path, ptr args, ptr callback);
+EXPORT ptr osi_spawn_detached(const char* path, ptr args);
 EXPORT ptr osi_kill(int pid, int signum);
 EXPORT ptr osi_start_signal(int signum);
 EXPORT ptr osi_stop_signal(uptr signal);

--- a/src/swish/osi.ss
+++ b/src/swish/osi.ss
@@ -100,14 +100,16 @@
    osi_reset_statement
    osi_reset_statement*
    osi_set_quantum
-   osi_start_signal
-   osi_start_signal*
-   osi_stop_signal
-   osi_stop_signal*
    osi_spawn
    osi_spawn*
+   osi_spawn_detached
+   osi_spawn_detached*
+   osi_start_signal
+   osi_start_signal*
    osi_step_statement
    osi_step_statement*
+   osi_stop_signal
+   osi_stop_signal*
    osi_unlink
    osi_unlink*
    osi_watch_path
@@ -170,6 +172,7 @@
   ;; Process
   (fdefine osi_exit (status int) void)
   (define-osi osi_spawn (path string) (args ptr) (callback ptr))
+  (define-osi osi_spawn_detached (path string) (args ptr))
   (define-osi osi_kill (pid int) (signum int))
 
   ;; File System

--- a/src/swish/run.c
+++ b/src/swish/run.c
@@ -94,6 +94,7 @@ static void swish_init(void) {
   add_foreign(osi_start_signal);
   add_foreign(osi_stop_signal);
   add_foreign(osi_spawn);
+  add_foreign(osi_spawn_detached);
   add_foreign(osi_step_statement);
   add_foreign(osi_unlink);
   add_foreign(osi_watch_path);


### PR DESCRIPTION
This change adds `spawn-os-process-detached` for cases when we want to fire-and-forget and external process. This is useful when starting processes in user-space that do not require the overhead of being a service.

Testing is light because the external process is detached and thus hard to monitor. There are two cases of particular interest that can be done manually. 1) Fire up and external process, then exit Swish. The external process should remain. 2) Fire up an external process, then have it exit. Swish should remain and not crash (which would happen if we included invalid callback pointers in the osi process struct).