### PR TITLE
Run tests in the order specified on command line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,11 @@ jobs:
       before_script:
         - git config core.autocrlf false; rm .git/index; git reset --hard
         - choco install make -y
+    - env: TARGET_MACHINE=a6nt
+      os: windows
+      before_script:
+        - git config core.autocrlf false; rm .git/index; git reset --hard
+        - choco install make -y
     - env: TARGET_MACHINE=a6nt CHEZ_BRANCH=master
       os: windows
       before_script:

--- a/src/swish/swish-test
+++ b/src/swish/swish-test
@@ -607,49 +607,45 @@
 (define (->report-filename filename)
   (string-append filename ".mo"))
 
-(define (extract-suites specs)
-  (let ([ht (make-hashtable string-hash string=?)])
-    (define (add-suite suite)
-      (when (may-have-mats? suite)
-        (hashtable-update! ht suite
-          (lambda (old)
-            (or old (make-hashtable string-hash string=?)))
-          #f)))
-    (let lp ([specs specs])
-      (cond
-       [(null? specs)
-        (let-values ([(keys vals) (hashtable-entries ht)])
-          (vector->list
-           (vector-map
-            (lambda (suite test-set)
-              (cons suite
-                (map string->symbol (vector->list (hashtable-keys test-set)))))
-            keys vals)))]
-       [(get-test-files (car specs)) =>
-        (lambda (files)
-          (for-each add-suite files)
-          (lp (cdr specs)))]
-       [(get-test-suite (car specs)) =>
-        (lambda (suite)
-          (add-suite suite)
-          (let ([tt (hashtable-ref ht suite #f)])
-            (define (add-test test)
-              (hashtable-set! tt test #t))
-            (let lp2 ([ls (cdr specs)])
-              (match ls
-                [() (lp ls)]
-                [("-t") (fail "option expects value: -t")]
-                [("-t" ,test . ,rest)
-                 (add-test test)
-                 (lp2 rest)]
-                [(,test . ,rest)
-                 (guard (not (or (directory? test) (get-test-suite test))))
-                 (add-test test)
-                 (lp2 rest)]
-                [,rest
-                 (lp rest)]))))]
-       [else
-        (fail "expected directory or suite: ~s" (car specs))]))))
+(define-tuple <pre-spec> suite test)
+
+(define (extract-pre-specs specs)
+  (define out (make-hashtable values =))
+  (define (add-suite! suite)
+    (when (may-have-mats? suite)
+      (hashtable-set! out (hashtable-size out)
+        (<pre-spec> make [suite suite] [test #f]))))
+  (define (add-test! suite test)
+    (hashtable-set! out (hashtable-size out)
+      (<pre-spec> make [suite suite] [test test])))
+  (let lp ([specs specs])
+    (cond
+     [(null? specs)
+      (vector->list
+       (vector-map cdr
+         (vector-sort (lambda (a b) (< (car a) (car b)))
+           (hashtable-cells out))))]
+     [(get-test-files (car specs)) =>
+      (lambda (files)
+        (for-each add-suite! files)
+        (lp (cdr specs)))]
+     [(get-test-suite (car specs)) =>
+      (lambda (suite)
+        (let lp2 ([added? #f] [ls (cdr specs)])
+          (match ls
+            [("-t") (fail "option expects value: -t")]
+            [("-t" ,test . ,rest)
+             (add-test! suite test)
+             (lp2 #t rest)]
+            [(,test . ,rest)
+             (guard (not (or (directory? test) (get-test-suite test))))
+             (add-test! suite test)
+             (lp2 #t rest)]
+            [,rest
+             (unless added? (add-suite! suite))
+             (lp rest)])))]
+     [else
+      (fail "expected directory or suite: ~s" (car specs))])))
 
 (define (harvest from*)
   (let ([ht (make-hashtable string-hash string=?)])
@@ -733,8 +729,7 @@
         [progress (string->symbol (or (opt 'progress) "test"))]
         [report (opt 'report)]
         [coverage (opt 'coverage)]
-        [suites (sort (lambda (s1 s2) (string<? (car s1) (car s2)))
-                  (extract-suites (or (opt 'specs) '())))])
+        [pre-specs (extract-pre-specs (or (opt 'specs) '()))])
     (check-report-format report 'report)
     (cond
      [(and load-prof (not (or save-prof coverage)))
@@ -747,22 +742,21 @@
         (option-named 'coverage)
         (option-named 'load-prof)
         (option-named 'save-prof))]
-     [(and report (not (or (opt 'harvest) (opt 'load-results) (pair? suites))))
+     [(and report (not (or (opt 'harvest) (opt 'load-results) (pair? pre-specs))))
       (fail "~a requires ~a or ~a or a set of tests to run (~a)"
         (option-named 'report)
         (option-named 'harvest)
         (option-named 'load-results)
         (option-named 'files))]
-     [(and (opt 'harvest) (pair? suites))
+     [(and (opt 'harvest) (pair? pre-specs))
       (fail "~a conflicts with ~a"
         (option-named 'harvest)
         (option-named 'files))]
-     [(and (opt 'load-results) (pair? suites))
+     [(and (opt 'load-results) (pair? pre-specs))
       (fail "~a conflicts with ~a"
         (option-named 'load-results)
         (option-named 'files))])
-    (let ([test-files (map car suites)]
-          [test-run
+    (let ([test-run
            (uuid->string ;; normalize to swish's format
             (cond
              [(opt 'test-run) =>
@@ -772,7 +766,36 @@
                    (fail "invalid ~a UUID ~a" (option-named 'test-run) s)]
                   [,uuid uuid]))]
              [else (osi_make_uuid)]))])
-      (define report-files (map ->report-filename test-files))
+      (define (combine-specs pre-specs)
+        (define (flush curr-suite tests specs)
+          (if (not curr-suite)
+              specs
+              (cons
+               (<test-spec> make
+                 [test-file curr-suite]
+                 [test-run test-run]
+                 [report-file (->report-filename curr-suite)]
+                 [tests (and (pair? tests) (map string->symbol (reverse tests)))]
+                 [incl-tags incl-tags]
+                 [excl-tags excl-tags]
+                 [profile save-prof]
+                 [progress progress]
+                 [lib-dirs (library-directories)]
+                 [src-dirs (source-directories)])
+               specs)))
+        (let combine ([ps pre-specs] [curr-suite #f] [tests '()])
+          (match ps
+            [() (flush curr-suite tests '())]
+            [(`(<pre-spec> [suite ,@curr-suite] ,test) . ,rest)
+             (guard test)
+             (combine rest curr-suite (cons test tests))]
+            [(`(<pre-spec> ,suite ,test) . ,rest)
+             (flush curr-suite tests
+               (if test
+                   (combine rest suite (list test))
+                   (flush suite #f
+                     (combine rest #f '()))))])))
+      (define test-specs (combine-specs pre-specs))
       (define status 0)
       (define no-tests '())
       (define full-load-filenames
@@ -789,6 +812,7 @@
            (fail "~a ~a failed (~a)" (option-named 'save-prof) save-prof
              (exit-reason->english reason))]
           [,op (close-port op)]))
+      (define report-files)
       (cond
        [(and load-prof save-prof)
         (let ([add-to-profile
@@ -809,27 +833,21 @@
                        (fail "cannot load profile data from ~a" user-supplied-name)]))))
               (profile:stop))))]
        [save-prof (truncate-profile)])
-      (foreach ([suite/test suites] [report-file report-files])
-        ($init-mat-output-file report-file (car suite/test) test-run))
-      (foreach ([suite/test suites] [report-file report-files])
-        (let ([suite (car suite/test)]
-              [tests (cdr suite/test)])
-          (match (run-test-spec swish
-                   (<test-spec> make
-                     [test-file suite]
-                     [test-run test-run]
-                     [report-file report-file]
-                     [tests (and (pair? tests) tests)]
-                     [incl-tags incl-tags]
-                     [excl-tags excl-tags]
-                     [profile save-prof]
-                     [progress progress]
-                     [lib-dirs (library-directories)]
-                     [src-dirs (source-directories)]))
-            [ran (void)]
-            [fail (set! status 1)]
-            [skip (set! status 1)]
-            [no-tests (set! no-tests (cons suite no-tests))])))
+      (let ([done (make-hashtable string-hash string=?)])
+        (foreach ([spec test-specs])
+          (match spec
+            [`(<test-spec> ,test-file ,report-file ,test-run)
+             (unless (hashtable-contains? done test-file)
+               (hashtable-set! done test-file report-file)
+               ($init-mat-output-file report-file test-file test-run))]))
+        (set! report-files
+          (vector->list (vector-sort string<? (hashtable-values done)))))
+      (foreach ([spec test-specs])
+        (match (run-test-spec swish spec)
+          [ran (void)]
+          [fail (set! status 1)]
+          [skip (set! status 1)]
+          [no-tests (set! no-tests (cons (<test-spec> test-file spec) no-tests))]))
       (let ([summary
              (cond
               [(opt 'load-results) =>

--- a/src/swish/swish-test.ms
+++ b/src/swish/swish-test.ms
@@ -408,14 +408,7 @@
    (swish-test "--progress test " test-file " " common-name)
    (list
     'seek
-    ;; suites appear in sorted order
-    (pregexp-quote common-name-file)
-    "[-]+" " Result * Test name * Message *" "[-]+"
-    " *pass *t1"
-    " *FAIL *t2"
-    "[-]+"
-    "Tests run: 2   Pass: 1   Fail: 1   Skip: 0"
-    'seek
+    ;; suites appear in command-line order
     (pregexp-quote test-file)
     "[-]+" " Result * Test name * Message *" "[-]+"
     (format " *pass *~a" (pregexp-quote (symbol->string common-name)))
@@ -423,7 +416,14 @@
     " *FAIL *a2"
     " *FAIL *a3"
     "[-]+"
-    "Tests run: 4   Pass: 2   Fail: 2   Skip: 0"))
+    "Tests run: 4   Pass: 2   Fail: 2   Skip: 0"
+    'seek
+    (pregexp-quote common-name-file)
+    "[-]+" " Result * Test name * Message *" "[-]+"
+    " *pass *t1"
+    " *FAIL *t2"
+    "[-]+"
+    "Tests run: 2   Pass: 1   Fail: 1   Skip: 0"))
   (zero-exit
    ;; common-name explicitly identified as a test
    ;; zero exit means:
@@ -448,6 +448,275 @@
    '()
    "swish-test: expected directory or suite: \"does-not-exist-as-file-or-directory\"")
   )
+
+(isolate-mat test-order ()
+  (define test-setup
+    (write-test-file "test-setup.ss"
+      (lambda ()
+        (for-each pretty-print
+          '((import (swish mat))
+            ;; side-effect so we can confirm tests ran in specified order vs.
+            ;; results reported in a particular order
+            (define tested
+              (let ([mats '()])
+                (case-lambda
+                 [() (reverse mats)]
+                 [(x) (set! mats (cons x mats))]))))))))
+  (define test-file1
+    (write-test-file "test-file1.ms"
+      (lambda ()
+        (for-each pretty-print
+          `((include ,test-setup)
+            (mat t1 () (tested 't1))
+            (mat t2 () (tested 't2) (assert #f)) ;; failing test shouldn't affect order
+            (mat t3 () (tested 't3))
+            (mat t123 () (match (tested) [(t1 t2 t3) 'ok]))
+            (mat t132 () (match (tested) [(t1 t3 t2) 'ok]))
+            (mat t321 () (match (tested) [(t3 t2 t1) 'ok]))
+            (mat t112233 () (match (tested) [(t1 t1 t2 t2 t3 t3) 'ok]))
+            (mat t312213 () (match (tested) [(t3 t1 t2 t2 t1 t3) 'ok])))))))
+  (define test-file2
+    (write-test-file "test-file2.ms"
+      (lambda ()
+        (for-each pretty-print
+          `((include ,test-setup)
+            (mat a1 () (tested 'a1) (assert #f)) ;; failing test shouldn't affect order
+            (mat a2 () (tested 'a2))
+            (mat a3 () (tested 'a3) (assert #f)) ;; failing test shouldn't affect order
+            (mat a123 () (match (tested) [(a1 a2 a3) 'ok]))
+            (mat a321 () (match (tested) [(a3 a2 a1) 'ok]))
+            (mat a232 () (match (tested) [(a2 a3 a2) 'ok]))
+            (mat a11 () (match (tested) [(a1 a1) 'ok]))
+            (mat a33321 () (match (tested) [(a3 a3 a3 a2 a1) 'ok])))))))
+  ;; suites run in order they appear in file if not specified on command line
+  (nonzero-exit
+   (swish-test "--progress test " test-file1)
+   (list
+    'seek
+    (pregexp-quote test-file1)
+    "[-]+" " Result * Test name * Message *" "[-]+"
+    " *pass *t1"
+    " *FAIL *t2"
+    " *pass *t3"
+    " *pass *t123"
+    " *FAIL *t132"
+    " *FAIL *t321"
+    " *FAIL *t112233"
+    " *FAIL *t312213"
+    "[-]+"
+    "Tests run: 8   Pass: 3   Fail: 5   Skip: 0"))
+  ;; run a subset of the tests in the order they appear within the file
+  (nonzero-exit
+   (swish-test "--progress test " test-file1 " t1 t2 t3 t123")
+   (list
+    'seek
+    (pregexp-quote test-file1)
+    "[-]+" " Result * Test name * Message *" "[-]+"
+    " *pass *t1"
+    " *FAIL *t2"
+    " *pass *t3"
+    " *pass *t123"
+    "[-]+"
+    "Tests run: 4   Pass: 3   Fail: 1   Skip: 0"))
+  ;; run a subset of the tests in an order that differs from that within the file
+  (nonzero-exit
+   (swish-test "--progress test " test-file1 " t1 t3 t2 t132")
+   (list
+    'seek
+    (pregexp-quote test-file1)
+    "[-]+" " Result * Test name * Message *" "[-]+"
+    " *pass *t1"
+    " *pass *t3"
+    " *FAIL *t2"
+    " *pass *t132"
+    "[-]+"
+    "Tests run: 4   Pass: 3   Fail: 1   Skip: 0"))
+  ;; run a subset of the tests with duplicates
+  (nonzero-exit
+   (swish-test "--progress test " test-file1 " t1 t1 t2 t2 t3 t3 t112233")
+   (list
+    'seek
+    (pregexp-quote test-file1)
+    "[-]+" " Result * Test name * Message *" "[-]+"
+    " *pass *t1"
+    " *pass *t1"
+    " *FAIL *t2"
+    " *FAIL *t2"
+    " *pass *t3"
+    " *pass *t3"
+    " *pass *t112233"
+    "[-]+"
+    "Tests run: 7   Pass: 5   Fail: 2   Skip: 0"))
+  ;; run a different subset of the tests with duplicates
+  (nonzero-exit
+   (swish-test "--progress test " test-file1 " t3 t1 t2 t2 t1 t3 t312213")
+   (list
+    'seek
+    (pregexp-quote test-file1)
+    "[-]+" " Result * Test name * Message *" "[-]+"
+    " *pass *t3"
+    " *pass *t1"
+    " *FAIL *t2"
+    " *FAIL *t2"
+    " *pass *t1"
+    " *pass *t3"
+    " *pass *t312213"
+    "[-]+"
+    "Tests run: 7   Pass: 5   Fail: 2   Skip: 0"))
+  ;; run a subset of tests from one suite with all tests from second suite
+  (nonzero-exit
+   (swish-test "--progress test " test-file1 " t321 t3 t2 t1 t321 " test-file2)
+   (list
+    'seek
+    (pregexp-quote test-file1)
+    "[-]+" " Result * Test name * Message *" "[-]+"
+    " *FAIL *t321"
+    " *pass *t3"
+    " *FAIL *t2"
+    " *pass *t1"
+    " *pass *t321"
+    "[-]+"
+    "Tests run: 5   Pass: 3   Fail: 2   Skip: 0"
+    'seek
+    (pregexp-quote test-file2)
+    "[-]+" " Result * Test name * Message *" "[-]+"
+    " *FAIL *a1"
+    " *pass *a2"
+    " *FAIL *a3"
+    " *pass *a123"
+    " *FAIL *a321"
+    " *FAIL *a232"
+    " *FAIL *a11"
+    " *FAIL *a33321"
+    "[-]+"
+    "Tests run: 8   Pass: 2   Fail: 6   Skip: 0"))
+  ;; same as above, but flip order of suites
+  (nonzero-exit
+   (swish-test "--progress test " test-file2 " " test-file1 " t321 t3 t2 t1 t321")
+   (list
+    'seek
+    (pregexp-quote test-file2)
+    "[-]+" " Result * Test name * Message *" "[-]+"
+    " *FAIL *a1"
+    " *pass *a2"
+    " *FAIL *a3"
+    " *pass *a123"
+    " *FAIL *a321"
+    " *FAIL *a232"
+    " *FAIL *a11"
+    " *FAIL *a33321"
+    "[-]+"
+    "Tests run: 8   Pass: 2   Fail: 6   Skip: 0"
+    'seek
+    (pregexp-quote test-file1)
+    "[-]+" " Result * Test name * Message *" "[-]+"
+    " *FAIL *t321"
+    " *pass *t3"
+    " *FAIL *t2"
+    " *pass *t1"
+    " *pass *t321"
+    "[-]+"
+    "Tests run: 5   Pass: 3   Fail: 2   Skip: 0"))
+  ;; run subsets of each suite
+  (nonzero-exit
+   (swish-test "--progress test " test-file2 " a1 a1 a11 " test-file1 " t1 t3 t2 t132")
+   (list
+    'seek
+    (pregexp-quote test-file2)
+    "[-]+" " Result * Test name * Message *" "[-]+"
+    " *FAIL *a1"
+    " *FAIL *a1"
+    " *pass *a11"
+    "[-]+"
+    "Tests run: 3   Pass: 1   Fail: 2   Skip: 0"
+    'seek
+    (pregexp-quote test-file1)
+    "[-]+" " Result * Test name * Message *" "[-]+"
+    " *pass *t1"
+    " *pass *t3"
+    " *FAIL *t2"
+    " *pass *t132"
+    "[-]+"
+    "Tests run: 4   Pass: 3   Fail: 1   Skip: 0"))
+  ;; different subsets of each suite, with suites repeated;
+  ;; also hit case where we run full suite after subset of same suite
+  (nonzero-exit
+   (swish-test "--progress test "
+     test-file2 " a3 a3 a3 a2 a1 a33321 "
+     test-file1 " t1 t3 t2 t132 "
+     test-file1 " "
+     test-file2 " a2 a3 a2 a232 ")
+   (list
+    'seek
+    (pregexp-quote test-file2)
+    "[-]+" " Result * Test name * Message *" "[-]+"
+    " *FAIL *a3"
+    " *FAIL *a3"
+    " *FAIL *a3"
+    " *pass *a2"
+    " *FAIL *a1"
+    " *pass *a33321"
+    "[-]+"
+    "Tests run: 6   Pass: 2   Fail: 4   Skip: 0"
+    'seek
+    (pregexp-quote test-file1)
+    "[-]+" " Result * Test name * Message *" "[-]+"
+    " *pass *t1"
+    " *pass *t3"
+    " *FAIL *t2"
+    " *pass *t132"
+    "[-]+"
+    "Tests run: 4   Pass: 3   Fail: 1   Skip: 0"
+    'seek
+    (pregexp-quote test-file1)
+    "[-]+" " Result * Test name * Message *" "[-]+"
+    " *pass *t1"
+    " *FAIL *t2"
+    " *pass *t3"
+    " *pass *t123"
+    " *FAIL *t132"
+    " *FAIL *t321"
+    " *FAIL *t112233"
+    " *FAIL *t312213"
+    "[-]+"
+    "Tests run: 8   Pass: 3   Fail: 5   Skip: 0"
+    'seek
+    (pregexp-quote test-file2)
+    "[-]+" " Result * Test name * Message *" "[-]+"
+    " *pass *a2"
+    " *FAIL *a3"
+    " *pass *a2"
+    " *pass *a232"
+    "[-]+"
+    "Tests run: 4   Pass: 3   Fail: 1   Skip: 0"))
+  ;; run subset of suite after full suite
+  (nonzero-exit
+   (swish-test "--progress test "
+     test-file2 " "
+     test-file2 " a2 a3 a2 a232 ")
+   (list
+    'seek
+    (pregexp-quote test-file2)
+    "[-]+" " Result * Test name * Message *" "[-]+"
+    " *FAIL *a1"
+    " *pass *a2"
+    " *FAIL *a3"
+    " *pass *a123"
+    " *FAIL *a321"
+    " *FAIL *a232"
+    " *FAIL *a11"
+    " *FAIL *a33321"
+    "[-]+"
+    "Tests run: 8   Pass: 2   Fail: 6   Skip: 0"
+    'seek
+    (pregexp-quote test-file2)
+    "[-]+" " Result * Test name * Message *" "[-]+"
+    " *pass *a2"
+    " *FAIL *a3"
+    " *pass *a2"
+    " *pass *a232"
+    "[-]+"
+    "Tests run: 4   Pass: 3   Fail: 1   Skip: 0")))
 
 (isolate-mat report-results ()
   (define report-file (path-combine (output-dir) "report.html"))


### PR DESCRIPTION
Should we mark this as a breaking change? The original behavior wasn't well documented, though there was a mat checking for sorted order of test results.

Does the mat result format need any changes to better handle duplication?