### PR TITLE
add (response-timeout) to http:options

### DIFF
--- a/doc/swish/http.tex
+++ b/doc/swish/http.tex
@@ -287,6 +287,9 @@ used:
   number of milliseconds to wait to receive an HTTP request after
   initial connection \\
 
+  \code{response-timeout} & 60,000 & a positive fixnum; the maximum
+  number of milliseconds to allow the server to send a response \\
+
   \code{header-limit} & 1,048,576 & a positive fixnum; the maximum
   length in bytes of the HTTP request headers \\
 
@@ -533,7 +536,7 @@ strings. If any of its keys are not strings, exception
 
 \defineentry{http:respond}
 \begin{procedure}
-  \code{(http:respond \var{conn} \var{status} \var{header-alist} \opt{\var{content}})}
+  \code{(http:respond \var{conn} \var{status} \var{header-alist} \opt{\var{content} \opt{\var{timeout}}})}
 \end{procedure}
 \returns{} \code{\#t}
 
@@ -552,9 +555,11 @@ and if \var{content} is a bytevector, it must be empty. Otherwise, the
 \code{Content-Length} header is added with the length of
 \var{content}.
 
+The default value of \var{timeout} is \code{(response-timeout)}.
+
 \defineentry{http:respond-file}
 \begin{procedure}
-  \code{(http:respond-file \var{conn} \var{status} \var{header-alist} \var{filename})}
+  \code{(http:respond-file \var{conn} \var{status} \var{header-alist} \var{filename} \opt{\var{timeout}})}
 \end{procedure}
 \returns{} \code{\#t}
 
@@ -567,6 +572,8 @@ header is added, if it is not already present, with value
 is not already present, by calling the \code{media-type-handler}.  The
 content of the file is streamed to the output port so that the file
 does not need to be loaded into memory. The output port is flushed.
+
+The default value of \var{timeout} is \code{(response-timeout)}.
 
 \defineentry{http:call-with-form}
 \begin{procedure}
@@ -613,6 +620,8 @@ Name/value pairs count against \var{content-limit} while file data
 counts against \var{file-limit}. An exception is raised when either
 limit is exceeded.
 
+The default value of \var{timeout} is \code{(request-timeout)}.
+
 \defineentry{http:call-with-ports}
 \begin{procedure}
   \code{(http:call-with-ports \var{conn} \var{f} \opt{\var{timeout}})}
@@ -624,6 +633,8 @@ connection state and calls \var{f} in the connection process with the
 connection's input and output ports.  Running \var{f} in the
 connection process allows the caller to timeout when input is
 unavailable. The return value of \var{f} is returned to the caller.
+
+The default value of \var{timeout} is 5000 milliseconds.
 
 \defineentry{http:switch-protocol}
 \begin{procedure}

--- a/src/swish/http.ms
+++ b/src/swish/http.ms
@@ -695,6 +695,10 @@
      (catch ((http:options [request-timeout 'a])))]
     [#(EXIT #(bad-arg request-timeout 0))
      (catch ((http:options [request-timeout 0])))]
+    [#(EXIT #(bad-arg response-timeout a))
+     (catch ((http:options [response-timeout 'a])))]
+    [#(EXIT #(bad-arg response-timeout 0))
+     (catch ((http:options [response-timeout 0])))]
     [#(EXIT #(bad-arg header-limit a))
      (catch ((http:options [header-limit 'a])))]
     [#(EXIT #(bad-arg header-limit 0))
@@ -1123,6 +1127,25 @@
      (discard-events)
      (gc)
      (assert (output-port? (g))))))
+
+(http-mat response-timeout ()
+  (define bytes (make-bytevector (- (expt 2 29) 1)))
+  (supervisor:start&link 'http-sup 'one-for-all 0 1
+    (http:configure-server #f 0
+      (http:url-handler
+       (http:respond conn 200 '() bytes))
+      (http:options
+       [response-timeout 15])))
+  (capture-events)
+  (let-values ([(ip op) (connect-tcp "127.0.0.1" (get-http-port))])
+    (put-bytevector op (string->utf8 "GET / HTTP/1.1\r\n\r\n"))
+    (flush-output-port op)
+    ;; grab a few bytes, but otherwise don't read. This will cause the
+    ;; server to fill up the network queue and eventually wait. This
+    ;; causes the response-timeout to trigger.
+    (do ([i 0 (+ i 1)]) ((= i 10)) (get-u8 ip))
+    (receive (after 2000 (throw 'failed-to-timeout))
+      [`(<child-end> [reason #(timeout ,_)]) 'ok])))
 
 (http-mat content-length ()
   (define (test s)


### PR DESCRIPTION
`http:respond` and `http:respond-file` use the default 5 second gen-server
timeout which is not enough for slow networks or large amounts of data.

Adding an optional timeout argument to each of these functions helps,
but does not cover the static file handler buried in the http-cache server.

Adding (response-timeout) allows Swish applications to override this
behavior when configuring the server. Using a default of 60 seconds
should allow a 50 MB file over a 10 Mbit/sec connection, or 500 MB
file over a 100 Mbit/sec connection with overhead.
