### PR TITLE
update child view and query for global-process-id

### DIFF
--- a/src/swish/log-db.ss
+++ b/src/swish/log-db.ss
@@ -428,7 +428,7 @@
         (set-session-id! (+ (or id 0) 1)))
 
       (execute "drop view if exists child")
-      (execute "create view child as select T1.pid as id, T1.name, T1.supervisor, T1.restart_type, T1.type, T1.shutdown, T1.timestamp as start, T2.timestamp - T1.timestamp as duration, T2.killed, T2.reason, T2.details from child_start T1 left outer join child_end T2 on T1.pid=T2.pid")
+      (execute "create view child as select T1.rowid as rowid, T1.pid as id, T1.name, T1.supervisor, T1.restart_type, T1.type, T1.shutdown, T1.timestamp as start, T2.timestamp - T1.timestamp as duration, T2.killed, T2.reason, T2.details from child_start T1 left outer join child_end T2 on T1.pid=T2.pid")
 
       (create-prune-on-insert-triggers
        (child_end timestamp)

--- a/web/swish/errors.ss
+++ b/web/swish/errors.ss
@@ -59,7 +59,7 @@
 (define (dispatch)
   (let ([limit (integer-param "limit" 0 params)]
         [offset (integer-param "offset" 0 params)]
-        [child-sql "SELECT id, name, supervisor, restart_type, type, shutdown, datetime(start/1000,'unixepoch','localtime') as start, duration, killed, reason, details as message, NULL as stacks FROM child WHERE message IS NOT NULL ORDER BY id DESC"]
+        [child-sql "SELECT id, name, supervisor, restart_type, type, shutdown, datetime(start/1000,'unixepoch','localtime') as start, duration, killed, reason, details as message, NULL as stacks FROM child WHERE message IS NOT NULL ORDER BY rowid DESC"]
         [gen-sql "SELECT datetime(timestamp/1000,'unixepoch','localtime') as timestamp, pid, name, last_message, state, reason, details as message, NULL as stacks  FROM gen_server_terminating ORDER BY ROWID DESC"]
         [super-sql "SELECT datetime(timestamp/1000,'unixepoch','localtime') as timestamp, supervisor, error_context, reason, child_pid, child_name, details as message, NULL as stacks FROM supervisor_error ORDER BY ROWID DESC"]
         [sql (string-param "sql" params)]


### PR DESCRIPTION
- add an explicit rowid column to the child view, since ordering by pid no longer makes sense
- update errors.ss child query to order by rowid rather than process id

This is a breaking change in the sense that `select * from child` will return more columns than it used to.