### PR TITLE
minor updates to documentation and exports

### DIFF
--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -2947,6 +2947,23 @@ any leading or trailing whitespace in \var{s} has been removed.
 Internal whitespace is not affected.
 
 % ----------------------------------------------------------------------------
+\defineentry{wrap-text}
+\begin{procedure}
+  \code{(wrap-text \var{op} \var{width} \var{initial-indent} \var{subsequent-indent} \var{text})}
+\end{procedure}
+\returns{} unspecified
+
+The \code{wrap-text} procedure writes the given \var{text} to the textual output
+port \var{op} after collapsing spaces that separate words. The first line is
+indented by \var{initial-indent} spaces. Subsequent lines are indented by
+\var{subsequent-indent} spaces. If possible, \code{wrap-text} breaks lines that
+would exceed \var{width}. Newlines and tabs are preserved, but tabs are
+treated as if they were the width of a single character.
+
+The \var{text} argument may be a string or a list of strings. If \var{text}
+is a list, it is treated as if it were the string obtained via \code{(join \var{text} \#{\textbackslash}space).}
+
+% ----------------------------------------------------------------------------
 \defineentry{symbol-append}
 \begin{procedure}
   \code{(symbol-append . \var{ls})}

--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -2936,6 +2936,17 @@ string \var{s} starts with string \var{p} using case-insensitive
 comparisons.
 
 % ----------------------------------------------------------------------------
+\defineentry{trim-whitespace}
+\begin{procedure}
+  \code{(trim-whitespace \var{s})}
+\end{procedure}
+\returns{} a string
+
+The \code{trim-whitespace} procedure returns a string in which
+any leading or trailing whitespace in \var{s} has been removed.
+Internal whitespace is not affected.
+
+% ----------------------------------------------------------------------------
 \defineentry{symbol-append}
 \begin{procedure}
   \code{(symbol-append . \var{ls})}

--- a/doc/swish/event-mgr.tex
+++ b/doc/swish/event-mgr.tex
@@ -212,9 +212,6 @@ it prints \var{event} using
 
 \var{event} is any Scheme datum.
 
-Because the gen-server library uses \code{event-mgr:notify}, it is
-implemented there.
-
 \defineentry{event-mgr:set-log-handler}
 \begin{procedure}
   \code{(event-mgr:set-log-handler \var{proc} \var{owner})}

--- a/doc/swish/gen-server.tex
+++ b/doc/swish/gen-server.tex
@@ -231,13 +231,14 @@ ignores all failures. The server will process the request using
   \argrow{reply}{any Scheme datum}
 \end{argtbl}
 
-\code{gen-server:reply} can be used by a server to explicitly send a
-\var{reply} to a \var{client} that called \code{gen-server:call}.
+A server can use \code{gen-server:reply} to send a
+\var{reply} to a \var{client} that called \code{gen-server:call}
+and is blocked awaiting a reply.
 
-In some situations, a server cannot reply immediately to a client. In
-such cases, the \var{from} argument inside \code{handle-call} is
-stored, and \code{no-reply} is returned.  Later,
-\code{gen-server:reply} can be called using that \var{from} value as
+In some situations, a server cannot reply immediately to a client.
+In such cases, \code{handle-call} may store the \var{from} argument
+and return \code{no-reply}. Later, the server can call
+\code{gen-server:reply} using that \var{from} value as
 \var{client}. The \var{reply} is the return value of the
 \code{gen-server:call} in this case.
 
@@ -399,9 +400,9 @@ directly. \code{handle-info} will not be called. The server must use
   \argrow{reason}{any Scheme datum}
 \end{argtbl}
 
-\code{(init \var{arg} \etc)} is called from a new server process and
-must complete before \code{gen-server:start\&link} or
-\code{gen-server:start} returns.
+\code{(init \var{arg} \etc)} is called from a new server process
+started by a call to \code{gen-server:start\&link} or \code{gen-server:start}.
+Calls to those procedures block until \code{init} returns.
 
 A successful \code{init} returns \code{\#(ok \var{state}
   \opt{\var{timeout}})}. The \var{state} is then maintained
@@ -412,7 +413,7 @@ returning \code{\#(stop \var{reason})}. The server will then fail to
 start using this \var{reason}. \code{terminate} will not be called
 as the server has not properly started.
 
-\code{init} may specify \code{ignore}. The server will then exit
+\code{init} may return \code{ignore}. The server will then exit
 with reason \code{normal}, and \code{gen-server:start\&link} will
 return \code{ignore}. This is used to inform a
 supervisor that the server is not necessary

--- a/doc/swish/supervisor.tex
+++ b/doc/swish/supervisor.tex
@@ -85,7 +85,8 @@ itself terminates and is restarted.
 \begin{itemize}
   \item \code{strategy} defines how the supervisor processes a child
     termination: \code{one-for-one} or \code{one-for-all}.
-  \item \code{intensity} is the maximum restart intensity.
+  \item \code{intensity} is the maximum restart intensity for all
+    children within the period.
   \item \code{period} is the maximum restart period in milliseconds.
   \item \code{children} is a list of \code{<child>} tuples with
     the most recently started child first.
@@ -358,6 +359,20 @@ server, \code{\#f} may be specified.
   \prodrow{\var{start-specs}}{(\var{child-spec} \etc)}
 \end{grammar}
 
+\defineentry{supervisor:validate-start-specs}
+\begin{procedure}
+  \code{(supervisor:validate-start-specs \var{specs})}
+\end{procedure}
+\returns{}
+\code{\#f} $|$
+\var{reason}
+
+The \code{supervisor:validate-start-specs} procedure takes a list
+of child specifications and checks them in order. If it encounters
+an invalid child specification, \code{supervisor:validate-start-specs}
+returns a reason suitable as input to \code{exit-reason->english}.
+Otherwise it returns \code{\#f}.
+
 \defineentry{supervisor:start-child}
 \begin{procedure}
   \code{(supervisor:start-child \var{supervisor} \var{child-spec})}
@@ -415,6 +430,7 @@ The \code{supervisor:delete-child} procedure calls
 This procedure terminates the child process identified by
 \var{name}. The child specification must exist, but the child process
 does not need be running.
+Terminating a child does not cause a restart.
 
 The \code{supervisor:terminate-child} procedure calls
 \code{(gen-server:call \var{supervisor} \#(terminate-child

--- a/src/swish/mat.ss
+++ b/src/swish/mat.ss
@@ -33,9 +33,11 @@
    mat-data-results
    mat-data?
    mat-result-message
+   mat-result-sstats
    mat-result-stacks
    mat-result-tags
    mat-result-test
+   mat-result-test-file
    mat-result-type
    mat-result?
    run-mat

--- a/src/swish/string-utils.ms
+++ b/src/swish/string-utils.ms
@@ -173,8 +173,10 @@
     [,@s (wt 0 0 0 s)]
     [,s (join '("This will wrap" "and tab\twill" "fit as single" "character.") #\newline)]
     [,@s (wt 14 0 0 (join (split s #\newline) #\space))]
-    [,s (join '("0 1 2" "3 4 5" "6 7 8" "9") #\newline)]
+    [,ls '("0 1 2" "3 4 5" "6 7 8" "9")]
+    [,s (join ls #\newline)]
     [,@s (wt 5 0 0 "0 1 2 3 4 5 6 7 8 9")]
+    [,@s (wt 5 0 0 ls)]
     [,in "This      string contains    consecutive      spaces."]
     [,s (join '("This string" "contains" "consecutive" "spaces.") #\newline)]
     [,@s (wt 11 0 0 in)]
@@ -186,13 +188,13 @@
     ["" (wt 999 0 0 "                         ")]
     ["\r\na b c \r\n" ;; \r is just another character, not a line marker
      (wt 10 0 0 "\r\n    a    b    c    \r\n")]
-    [,in
-     (join
-      '("This did not need to wrap, since we had plenty of room."
-        "Even more text here that will also go on the same line."
-        "Wow, this is going to be a pretty long line.")
-      #\space)]
+    [,ls
+     '("This did not need to wrap, since we had plenty of room."
+       "Even more text here that will also go on the same line."
+       "Wow, this is going to be a pretty long line.")]
+    [,in (join ls #\space)]
     [,@in (wt 1000 0 0 in)]
+    [,@in (wt 1000 0 0 ls)]
     ["   Hi\nmom" (wt 0 3 0 "Hi mom")]
     ["   Hi\n mom" (wt 0 3 1 "Hi mom")]
     [" Hi\n   mom" (wt 0 1 3 "Hi mom")]
@@ -202,7 +204,11 @@
     ["  Hi\n  mom" (wt 0 2 2 "Hi mom")]
     ["  Hi\n  mom\n  and\n  dad" (wt 0 2 2 "Hi mom and dad")]
     ["     Hi\n  mom\n  and\n  dad\n  just\n  two?"
-     (wt 0 5 2 "Hi mom and\ndad\njust\ntwo?")])
+     (wt 0 5 2 "Hi mom and\ndad\njust\ntwo?")]
+    ["" (wt 10 0 0 "")]
+    ["" (wt 10 0 0 '())]
+    ["" (wt 10 0 0 "    ")]
+    ["" (wt 10 0 0 '("" " " "   " " " ""))])
    'ok))
 
 (mat oxford-comma ()

--- a/src/swish/swish-build
+++ b/src/swish/swish-build
@@ -125,7 +125,7 @@
 
 (define (wrap indent . texts)
   (wrap-text (current-output-port)
-    (- (help-wrap-width) indent) indent indent (join texts #\space)))
+    (- (help-wrap-width) indent) indent indent texts))
 
 (define-syntax example
   (syntax-rules ()
@@ -150,7 +150,7 @@
 
 (define (list-item item . texts)
   (printf "~4@a " item)
-  (wrap-text (current-output-port) (- (help-wrap-width) 6) 0 5 (join texts #\space))
+  (wrap-text (current-output-port) (- (help-wrap-width) 6) 0 5 texts)
   (newline))
 
 (define (usage short? sections ht)

--- a/src/swish/swish-build.ms
+++ b/src/swish/swish-build.ms
@@ -615,7 +615,7 @@
                    [stdout ()]
                    [stderr ,stderr]))
           (match-regexps '(seek "application shutdown due to \\(exit foo\\)") stderr)])]))
-  ;; Attempt to call exit with a non-numeric exit code and is
+  ;; Attempt to call exit with a non-numeric exit code is
   ;; confusing enough that we output a message with the
   ;; console-event-handler.
   (define non-numeric-exit

--- a/src/swish/swish-test
+++ b/src/swish/swish-test
@@ -86,7 +86,7 @@
 
 (define (wrap indent . texts)
   (wrap-text (current-output-port)
-    (- (help-wrap-width) indent) indent indent (join texts #\space)))
+    (- (help-wrap-width) indent) indent indent texts))
 
 (define report-formats '(("json" . json) ("html" . html) ("htm" . html)))
 


### PR DESCRIPTION
* Tried to clarify some gen-server and supervisor text.
* Added some missing documentation identified by check-docs.
* Made a hasty attempt to generalize `wrap-text` to accept either a string or a list of strings. (Not sure if the GitHub UI picked that up or not since I pushed again after opening the UI, but before clicking to create the pull request.)