### PR TITLE
extend db integer tests

### DIFF
--- a/src/swish/db.ms
+++ b/src/swish/db.ms
@@ -52,7 +52,7 @@
             (let ([x (bitwise-ior
                       (bitwise-arithmetic-shift 1 i)
                       (bitwise-arithmetic-shift 1 j))])
-              (cons* x (bitwise-not x) ls))
+              (cons* x (bitwise-not x) (twos i (+ j 1) ls)))
             (twos (+ i 1) 0 ls))
         ls))
   (twos 1 0 (ones 0 '(0 -1))))


### PR DESCRIPTION
I noticed that the 2-bit integer tests in db.ms didn't work as I originally planned. This change fixes it.