### PR TITLE
Fortify db and log-db gen-servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ is not thread safe and should be used from the main thread only.
 Swish follows the [semantic versioning](http://semver.org/)
 scheme, starting with 2.0.0 to avoid confusion with internal projects.
 
+Odd minor-version numbers are used for development. As such,
+we are extremely unlikely to use a patch number other than 0 during
+development.
+
+Even minor-version numbers are used for official tagged
+releases.
+
+The first commit after an official tagged release should increment
+either the minor-version or patch-version number so that the version
+number for an official tagged release corresponds to a unique commit
+hash.
+
 # Notes
 
 1. install the prerequisites (see Build System Requirements)

--- a/doc/swish/db.tex
+++ b/doc/swish/db.tex
@@ -39,7 +39,7 @@ Definitive Guide to SQLite~\cite{sqlite-guide}.
 
 The \code{db} gen-server serializes internal requests to the
 database.  For storage and retrieval of data, each transaction is
-processed in turn by a separate linked \var{worker} process.  The gen-server does
+processed in turn by a separate monitored \var{worker} process.  The gen-server does
 not block waiting for this process to finish so that it can maintain
 linear performance by keeping its inbox short. The return value of the
 transaction is returned to the caller or an error is generated without
@@ -213,14 +213,20 @@ processes messages matching the following patterns:
 
 \antipar\begin{itemize}
 
-\item \code{timeout}: Remove old entries from the statement cache.
+\item \code{timeout}: If the request queue is empty, remove old
+  entries from the statement cache. Process the queue.
 
-\item \code{`(EXIT \var{worker-pid} normal)}: The worker finished
-  the previous request successfully. Process the queue.
+\item \code{`(DOWN \_ \var{worker-pid} \var{reason} \var{e})}: The
+  worker finished the previous request. If successful, process the
+  queue. Otherwise, flush the queue and stop with the fault \var{e}.
 
-\item \code{`(EXIT \var{worker-pid} \var{reason})}: The worker
-  failed to process the previous request. Flush the queue and stop
-  with \var{reason}.
+\item \code{`(DOWN \_ \_ \_)}: Ignore the unexpected \code{DOWN}
+  message. Process the queue.
+
+\item \code{`(EXIT \var{pid} \_ \var{e})}: If the \var{pid} is the
+  worker, ignore the message. Do not update the state. A follow-up
+  \code{DOWN} message will process the queue. Otherwise, flush the
+  queue, and stop with the fault \var{e}.
 
 \end{itemize}
 

--- a/doc/swish/db.tex
+++ b/doc/swish/db.tex
@@ -51,6 +51,8 @@ executes them by opening a transaction lazily when an explicit transaction is
 enqueued, when a \var{worker} process exits normally, or when the \code{db}
 message queue is empty.
 To maintain responsiveness, each lazy transaction commits at most 10,000 queued \code{db:log} requests.
+To maintain responsiveness, each lazy transaction commits at most \code{commit-limit} \code{db:log} requests.
+See \code{db:options} on page~\pageref{db:options} for details.
 By default, each database is created with write-ahead logging enabled
 to prevent write operations from blocking on queries made from another
 connection.
@@ -244,7 +246,8 @@ messages.
 
 \defineentry{db:start\&link}
 \begin{procedure}
-  \code{(db:start\&link \var{name} \var{filename} \var{mode} \opt{\var{db-init}})}
+  \code{(db:start\&link \var{name} \var{filename} \var{mode} \opt{\var{db-init}})}\\
+  \code{(db:start\&link \var{name} \var{filename} \var{mode} \opt{\var{db-options}})}
 \end{procedure}
 \returns{}
 \code{\#(ok \var{pid})} $|$
@@ -282,7 +285,32 @@ record instance. The return value is ignored. When the \var{mode} is
 default procedure sets \code{journal\_mode} to ``wal''; otherwise, no
 additional initialization occurs.
 
-This procedure may return an \var{error} of \code{\#(db-error open
+\var{db-options} can be defined using
+\code{(db:options [\var{option} \var{value}] \etc)}.
+The following options may be used:
+\defineentry{db:options}
+\phantomsection % make pageref go to correct page for this label
+\label{db:options}
+
+\begin{tabular}{lp{5em}p{.65\textwidth}}
+  option & default & description \\ \hline
+
+  \code{init}
+  & see right
+  & a procedure, \code{(lambda (filename mode db) \etc)},
+  called when initializing the gen-server,
+  where \var{db} is a database record instance;
+  the default \code{init} procedure is equivalent to
+  the default \var{db-init} procedure described above \\
+
+  \code{commit-limit}
+  & 10,000
+  & a positive fixnum; the maximum number of \code{db:log}
+  entries to include when opening a lazy transaction \\
+\end{tabular}
+
+The \code{db:start\&link} procedure may return an \var{error} of
+\code{\#(db-error open
   \var{error} \var{filename})}, where \var{error} is a SQLite error
 pair.
 

--- a/doc/swish/db.tex
+++ b/doc/swish/db.tex
@@ -356,6 +356,17 @@ exiting.  This is a suitable alternative to starting a
 SQLite connection, and you do not need to cache prepared SQL
 statements.
 
+\defineentry{db:expire-cache}
+\begin{procedure}
+  \code{(db:expire-cache \var{who})}
+\end{procedure}
+\returns{} unspecified
+
+The \code{db:expire-cache} procedure enqueues a request to remove
+entries from the statement cache regardless of their expiration
+time. \code{BEGIN IMMEDIATE} and \code{COMMIT} remain in the cache
+because they are used frequently.
+
 \defineentry{db:filename}
 \begin{procedure}
   \code{(db:filename \var{who})}

--- a/doc/swish/db.tex
+++ b/doc/swish/db.tex
@@ -779,11 +779,12 @@ or \code{\#f} if the record has been unmarshaled by
 \begin{procedure}
   \code{(sqlite:interrupt \var{db})}
 \end{procedure}
-\returns{} unspecified
+\returns{} a boolean
 
 The \code{sqlite:interrupt} procedure interrupts any pending
 operations on the database associated with database record instance
-\var{db}.
+\var{db}. It returns \code{\#t} when the database is busy and
+\code{\#f} otherwise.
 
 \defineentry{sqlite:last-insert-rowid}
 \begin{procedure}

--- a/doc/swish/db.tex
+++ b/doc/swish/db.tex
@@ -273,14 +273,14 @@ to \code{osi\_open\_database}:
   SQLITE\_OPEN\_READWRITE \code{SQLITE\_OPEN\_CREATE})}.
 \end{itemize}
 
+The SQLite constants can be found in \texttt{sqlite3.h} or
+online~\cite{sqlite}.
+
 \var{db-init} is a procedure that takes one argument, a database
 record instance. The return value is ignored. When the \var{mode} is
 \code{create} and \var{filename} is not a special SQLite filename, the
 default procedure sets \code{journal\_mode} to ``wal''; otherwise, no
 additional initialization occurs.
-
-The SQLite constants can be found in \texttt{sqlite3.h} or
-online~\cite{sqlite}.
 
 This procedure may return an \var{error} of \code{\#(db-error open
   \var{error} \var{filename})}, where \var{error} is a SQLite error

--- a/doc/swish/db.tex
+++ b/doc/swish/db.tex
@@ -118,9 +118,14 @@ guardian via \code{make-foreign-handle-guardian}.
 (define-record-type cache
   (fields
    (immutable ht)
+   (immutable expire-timeout)
    (mutable waketime)
    (mutable lazy-objects)))
   \end{alltt}\antipar
+  The \code{expire-timeout} is the duration in milliseconds that
+  entries live in the cache. This is configurable using the
+  \code{cache-timeout} option.
+
   The \code{waketime} is the next time the cache will attempt to
   remove dead entries.
 
@@ -302,6 +307,11 @@ The following options may be used:
   where \var{db} is a database record instance;
   the default \code{init} procedure is equivalent to
   the default \var{db-init} procedure described above \\
+
+  \code{cache-timeout}
+  & 5 minutes
+  & a nonnegative fixnum; the number of milliseconds before
+  unreferenced statements expire from the statement cache \\
 
   \code{commit-delay}
   & 0

--- a/doc/swish/db.tex
+++ b/doc/swish/db.tex
@@ -49,8 +49,8 @@ To facilitate logging, the \code{db} gen-server can execute SQL statements
 asynchronously. It enqueues SQL statements submitted via \code{db:log} and
 executes them by opening a transaction lazily when an explicit transaction is
 enqueued, when a \var{worker} process exits normally, or when the \code{db}
-message queue is empty.
-To maintain responsiveness, each lazy transaction commits at most 10,000 queued \code{db:log} requests.
+message queue is empty and \code{commit-delay} has elapsed since enqueuing
+a \code{db:log} request in an empty queue.
 To maintain responsiveness, each lazy transaction commits at most \code{commit-limit} \code{db:log} requests.
 See \code{db:options} on page~\pageref{db:options} for details.
 By default, each database is created with write-ahead logging enabled
@@ -302,6 +302,11 @@ The following options may be used:
   where \var{db} is a database record instance;
   the default \code{init} procedure is equivalent to
   the default \var{db-init} procedure described above \\
+
+  \code{commit-delay}
+  & 0
+  & a nonnegative fixnum; the number of milliseconds
+  to wait before opening a lazy transaction \\
 
   \code{commit-limit}
   & 10,000

--- a/doc/swish/db.tex
+++ b/doc/swish/db.tex
@@ -39,18 +39,18 @@ Definitive Guide to SQLite~\cite{sqlite-guide}.
 
 The \code{db} gen-server serializes internal requests to the
 database.  For storage and retrieval of data, each transaction is
-processed in turn by a separate linked process.  The gen-server does
+processed in turn by a separate linked \var{worker} process.  The gen-server does
 not block waiting for this process to finish so that it can maintain
 linear performance by keeping its inbox short. The return value of the
 transaction is returned to the caller or an error is generated without
 tearing down the gen-server.
 
-To facilitate logging, the \code{db} gen-server can lazily open a
-transaction. In order to allow other processes access to the database,
-lazy transactions should be closed occasionally. To support this, it
-tracks a count of entries in the current transaction. A transaction is
-committed when the threshold of 10,000 is reached, the message queue
-of the \code{db} is empty, or when a direct transaction is requested.
+To facilitate logging, the \code{db} gen-server can execute SQL statements
+asynchronously. It enqueues SQL statements submitted via \code{db:log} and
+executes them by opening a transaction lazily when an explicit transaction is
+enqueued, when a \var{worker} process exits normally, or when the \code{db}
+message queue is empty.
+To maintain responsiveness, each lazy transaction commits at most 10,000 queued \code{db:log} requests.
 By default, each database is created with write-ahead logging enabled
 to prevent write operations from blocking on queries made from another
 connection.

--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -2851,6 +2851,31 @@ reason from Swish into an English string.
 
 The string utilities below are found in the \code{(swish
   string-utils)} library.
+% ----------------------------------------------------------------------------
+
+\defineentry{ct:join}
+\begin{syntax}
+  \code{(ct:join \var{sep} \var{s} \etc{})}
+\end{syntax}
+\expandsto{} a string or a call to \code{string-append}
+
+The \code{ct:join} macro uses \code{ct:string-append} to join adjacent string
+literals into a literal string or a call to \code{string-append} where adjacent
+string literals are combined.
+The \var{sep}, which must be a literal string or character, is inserted
+between adjacent elements of \var{s}~\etc{}.
+
+% ----------------------------------------------------------------------------
+\defineentry{ct:string-append}
+\begin{syntax}
+  \code{(ct:string-append \var{s} \etc{})}
+\end{syntax}
+\expandsto{} a string or a call to \code{string-append}
+
+The \code{ct:string-append} macro appends adjacent string literals
+at compile time and expands into the resulting literal string or a
+call to \code{string-append} where adjacent string literals are
+combined.
 
 % ----------------------------------------------------------------------------
 \defineentry{ends-with?}

--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -1656,6 +1656,15 @@ checks the tuple type only once:
 The \code{is?} form determines whether or not the datum \var{x} is
 an instance of tuple type \var{name}.
 
+\index{tuple!is?@\code{is?}}
+\begin{syntax}
+  \code{(\var{name} is?)}
+\end{syntax}
+\expandsto{} a predicate that returns true if and only if its argument
+is an instance of tuple type \var{name}
+
+The \code{(\var{name} is?)} form expands to \code{(lambda (x) (\var{name} is? x))}.
+
 % ----------------------------------------------------------------------------
 \subsection {I/O}
 

--- a/doc/swish/event-mgr.tex
+++ b/doc/swish/event-mgr.tex
@@ -104,7 +104,7 @@ processes the following messages:
 \item \code{flush-buffer}: Process the events in the buffer using
   \code{do-notify}, turn off buffering, and return \code{ok}.
 
-\item \code{\#(set-log-handler \var{proc} \var{owner})}: Link to the
+\item \code{\#(set-log-handler \var{proc} \var{owner} \var{endure?})}: Link to the
   \var{owner} process, set the log handler of the state, and return
   \code{ok}.
 
@@ -214,19 +214,26 @@ it prints \var{event} using
 
 \defineentry{event-mgr:set-log-handler}
 \begin{procedure}
-  \code{(event-mgr:set-log-handler \var{proc} \var{owner})}
+  \code{(event-mgr:set-log-handler \var{proc} \var{owner} \opt{\var{endure?}})}
 \end{procedure}
 \returns{} \code{ok} $|$ \code{\#(error \var{reason})}
 
 The \code{event-mgr:set-log-handler} procedure calls
 \code{(gen-server:call event-mgr \#(set-log-handler \var{proc}
-  \var{owner}))}.
+  \var{owner} \var{endure?}))}.
 
-\var{proc} is a procedure of one argument, the event. Failure in
-\var{proc} results in the event manager killing the \var{owner}
-process with the same failure reason. The log handler is removed when
-\var{proc} fails or the event manager receives an \code{EXIT}
-message from \var{owner}.
+\var{proc} and \var{endure?} are procedures of one argument, the event.
+If \var{proc} fails and \var{endure?} returns false, the event is logged
+to the console and the event manager kills the \var{owner}
+process with the same failure reason.
+This is the default behavior since the default \var{endure?} procedure always
+returns false.
+However, if \var{proc} fails and \var{endure?} returns true, the event is
+logged to the console followed by the fault in \var{proc}, and the fault is
+tolerated.
+The log handler is removed when
+\var{proc} fails and \var{endure?} returns true or when the event manager
+receives an \code{EXIT} message from \var{owner}.
 
 \var{owner} is a process.
 

--- a/doc/swish/log-db.tex
+++ b/doc/swish/log-db.tex
@@ -74,7 +74,8 @@ Swish events are logged. The \code{log-db} design allows for this
 type of extension.
 
 The \code{log-db:setup} procedure takes a list of
-\code{<event-logger>} tuples. Each logger represents an extension
+\code{<event-logger>} tuples or \code{log-db:event-logger} objects.
+Each logger represents an extension
 to the log database schema and contains two procedures, \code{setup}
 and \code{log}. The \code{log-db:setup} procedure calls the
 \code{setup} procedure of logger to make sure that its portion of
@@ -133,7 +134,8 @@ The optional \var{db-options} must be an object created by
 \code{\#(error \var{error})}
 
 The argument \var{loggers} is a list of \code{<event-logger>}
-tuples. The \code{log-db:setup} makes sure the \code{log-db} is
+tuples or objects constructed by \code{log-db:event-logger}.
+The \code{log-db:setup} makes sure the \code{log-db} is
 setup to run by doing the following in order.
 
 \begin{enumerate}
@@ -153,6 +155,24 @@ If everything succeeds, the procedure returns \code{ignore}. If
 either the \code{db:transaction} or
 \code{event-mgr:set-log-handler} indicate an error, the procedure
 returns that error.
+
+A logger may be configured via
+\code{(log-db:event-logger [\var{option} \var{value}] \etc)}, which
+supports the following options:
+\defineentry{log-db:event-logger}
+
+\begin{tabular}{llp{.5\textwidth}}
+  option & default & description \\ \hline
+
+  \code{setup} & \emph{required} &
+  a procedure of no arguments that makes sure this
+  portion of the schema is created and up-to-date \\
+
+  \code{log} & \emph{required} &
+  a procedure of one argument, an event, that logs the
+  event if it recognizes it and otherwise ignores it \\
+
+\end{tabular}
 
 \defineentry{log-db:version}
 \begin{procedure}

--- a/doc/swish/log-db.tex
+++ b/doc/swish/log-db.tex
@@ -263,6 +263,21 @@ The argument \var{x} is a Scheme object mapped to a SQLite value.
 interprets as NULL.  Other values are converted to string using
 \code{write}.
 
+\defineentry{create-prune-on-insert-trigger}
+\begin{procedure}
+  \code{(create-prune-on-insert-trigger \var{table} \var{column} \var{max-days} \var{limit})}
+\end{procedure}
+\returns{} unspecified
+
+The \code{create-prune-on-insert-trigger} procedure should be called
+only within a thunk \var{f} provided to \code{db:transaction}.
+It creates a temporary trigger that prunes, after an insert, up to
+\var{limit} rows of the specified \var{table} where the \code{erlang:now}
+timestamp in \var{column} is older than \var{max-days}.
+\var{max-days} must be a nonnegative fixnum, and
+\var{limit} must be a positive fixnum.
+To keep insert operations fast, \var{column} should be indexed.
+
 \defineentry{stack->json}
 \begin{procedure}
   \code{(stack->json \var{k} \opt{\var{max-depth}})}

--- a/doc/swish/log-db.tex
+++ b/doc/swish/log-db.tex
@@ -63,6 +63,7 @@ not recognize are ignored.
 The tables are pruned using insert triggers to hold 90 days of
 information. To keep the insert operations fast, the timestamp columns
 are indexed, and the pruning deletes no more than 10 rows per insert.
+See \hyperref[make-swish-event-logger]{\code{make-swish-event-logger}}.
 
 \subsection {Extensions}
 
@@ -179,14 +180,31 @@ associated with \var{name} in the database.
 database file. The \code{log-db:get-instance-id} function caches and
 returns that identifier.
 
+\defineentry{make-swish-event-logger}
+\begin{property}
+  \code{(make-swish-event-logger \opt{\var{prune-max-days} \var{prune-limit}})}
+  \label{make-swish-event-logger}
+\end{property}
+
+The \code{make-swish-event-logger} procedure returns
+an \code{<event-logger>} tuple that defines the schema
+for Swish events.
+It uses the name \code{swish} to store its schema version.
+The optional \var{prune-max-days} and \var{prune-limit} arguments are passed to
+\code{create-prune-on-insert-trigger} when initializing the Swish event log
+tables.
+The default \var{prune-max-days} is 90.
+The default \var{prune-limit} is 10.
+
 \defineentry{swish-event-logger}
 \begin{property}
   \code{swish-event-logger}
 \end{property}
 
 The \code{swish-event-logger} is an \code{<event-logger>} tuple
-that defines the schema for Swish events. It uses the name
-\code{swish} to store its schema version.
+created by calling \code{(make-swish-event-logger)}.
+
+% TODO deprecate swish-event-logger binding?
 
 \defineentry{create-table}
 \begin{syntax}\begin{alltt}

--- a/doc/swish/log-db.tex
+++ b/doc/swish/log-db.tex
@@ -111,7 +111,7 @@ respect to changes in the Swish implementation.
 
 \defineentry{log-db:start\&link}
 \begin{procedure}
-  \code{(log-db:start\&link)}
+  \code{(log-db:start\&link \opt{\var{db-options}})}
 \end{procedure}
 \returns{}
 \code{\#(ok \var{pid})} $|$
@@ -121,6 +121,8 @@ The \code{log-db:start\&link} procedure creates a new \code{db}
 gen-server named \code{log-db} using \code{db:start\&link}. It
 uses the value of the \code{(log-file)} parameter as the path to the
 SQLite database and specifies \code{create} mode.
+The optional \var{db-options} must be an object created by
+\hyperref[db:options]{\code{db:options}}.
 
 \defineentry{log-db:setup}
 \begin{procedure}

--- a/doc/swish/log-db.tex
+++ b/doc/swish/log-db.tex
@@ -172,6 +172,13 @@ supports the following options:
   a procedure of one argument, an event, that logs the
   event if it recognizes it and otherwise ignores it \\
 
+  \code{tolerate-fault?}
+  & \code{(lambda (\var{event}) \#f)}
+  & a procedure of one argument, an event,
+  that returns true if \code{event-mgr} should tolerate
+  the fault in \code{log} for that event
+  or false if \code{event-mgr} should kill \code{log-db} \\
+
 \end{tabular}
 
 \defineentry{log-db:version}

--- a/doc/swish/log-db.tex
+++ b/doc/swish/log-db.tex
@@ -52,8 +52,9 @@ also calls \code{event-mgr:flush-buffer}. This causes the event
 manager to stop buffering startup events and the \code{log-db} to
 log the events that were buffered.
 
-Finally, setup sends a \code{<system-attributes>} event so that
-\code{log-db} receives and logs it.
+Setup sends a \code{<system-attributes>} event so that \code{log-db}
+receives and logs it. Finally, setup calls \code{db:expire-cache} to
+release the schema definition queries.
 
 Once the \code{log-db} gen-server has been setup, it continues to
 receive events from the system event manager. It converts events that

--- a/doc/swish/osi.tex
+++ b/doc/swish/osi.tex
@@ -1129,12 +1129,13 @@ Scheme. Otherwise, the callback list \code{(\var{callback}
 
 \defineentry{osi\_interrupt\_database}
 \begin{function}
-  \code{void osi\_interrupt\_database(uptr \var{database});}
+  \code{ptr osi\_interrupt\_database(uptr \var{database});}
 \end{function}
 
 The \code{osi\_interrupt\_database} function calls the
 \code{sqlite3\_interrupt} function to interrupt the current operation
-of the \var{database}.
+of the \var{database}. It returns \code{\#t} when the database is busy
+and \code{\#f} otherwise.
 
 \defineentry{osi\_get\_sqlite\_status}
 \begin{function}

--- a/src/swish/db.ms
+++ b/src/swish/db.ms
@@ -880,3 +880,18 @@
     ["#<bindings>" (format "~s" mbindings)]
     )
    'ok))
+
+(db-mat expire-cache ()
+  (match-let*
+   ([#(ok ,db) (db:start&link #f ":memory:" 'create)]
+    [,stmts-before (statement-count)])
+   (transaction db
+     (execute "CREATE TABLE table1 (col1, col2, col3)")
+     (execute "INSERT INTO table1 (col1, col2, col3) VALUES(?,?,?)" 1 2 3)
+     (execute "INSERT INTO table1 (col1, col2, col3) VALUES(?,?,?)" 4 5 6))
+   ;; BEGIN IMMEDIATE, COMMIT, CREATE, INSERT
+   (assert (= (statement-count) (+ stmts-before 4)))
+   (db:expire-cache db)
+   ;; Only BEGIN IMMEDIATE, COMMIT remain.
+   (assert (= (statement-count) (+ stmts-before 2)))
+   (db:stop db)))

--- a/src/swish/db.ms
+++ b/src/swish/db.ms
@@ -407,6 +407,8 @@
            (assert (= (statement-count) (+ stmts-before 1)))
            (catch (sqlite:bind s (list too-large))))))]
     [,@stmts-before (statement-count)]
+    [#(EXIT #(bad-arg db:start&link "options"))
+     (catch (db:start&link #f ":memory:" 'open "options"))]
     [,name (gensym)]
     [,_
      (db:start&link name ":memory:" 'open
@@ -743,6 +745,17 @@
              (pregexp-quote ")")))
           output)))
       data))))
+
+(db-mat check-options ()
+  (match-let*
+   ([,wrong-arity (lambda (x) x)]
+    [`(catch #(bad-arg init ,@wrong-arity))
+     (try (db:options [init wrong-arity]))]
+    [`(catch #(bad-arg init bogus))
+     (try (db:options [init 'bogus]))]
+    [`(catch #(bad-arg commit-limit 3.4))
+     (try (db:options [commit-limit 3.4]))])
+   'ok))
 
 (db-mat record-writers ()
   ;; database, statement, and bindings

--- a/src/swish/db.ms
+++ b/src/swish/db.ms
@@ -753,6 +753,10 @@
      (try (db:options [init wrong-arity]))]
     [`(catch #(bad-arg init bogus))
      (try (db:options [init 'bogus]))]
+    [`(catch #(bad-arg cache-timeout -1))
+     (try (db:options [cache-timeout -1]))]
+    [`(catch #(bad-arg cache-timeout whenever))
+     (try (db:options [cache-timeout 'whenever]))]
     [`(catch #(bad-arg commit-delay -3))
      (try (db:options [commit-delay -3]))]
     [`(catch #(bad-arg commit-delay none))
@@ -827,6 +831,32 @@
              (print-row id ts1 ts2 (- ts2 ts1))
              (assert (<= delay-ms (- ts2 ts1) (* 2 delay-ms))))]))
       (execute "select id, queued, actual from log order by rowid asc")))))
+
+(db-mat cache-timeout ()
+  (match-let*
+   ([,op (open-output-string)]
+    [,_ (console-error-port op)]
+    [,_ (console-output-port op)]
+    [#(ok ,db)
+     (db:start&link #f ":memory:" 'create
+       (db:options
+        [cache-timeout 0]))]
+    [,stmts-before (statement-count)]
+    [ok
+     (transaction db
+       (execute "create table data(x)")
+       (execute "insert into data(x) values(?)" 1)
+       (execute "insert into data(x) values(?)" 2)
+       (execute "insert into data(x) values(?)" 3)
+       'ok)]
+    [ok (db:log db "insert into data(x) values(4)")]
+    [ok (db:log db "insert into data(x) values(?)" 5)]
+    [(#(1) #(2) #(3) #(4) #(5))
+     (transaction db
+       (execute "select x from data order by rowid asc"))]
+    [ok (receive (after 10 'ok))]
+    [,@stmts-before (statement-count)])
+   'ok))
 
 (db-mat record-writers ()
   ;; database, statement, and bindings

--- a/src/swish/db.ms
+++ b/src/swish/db.ms
@@ -753,9 +753,80 @@
      (try (db:options [init wrong-arity]))]
     [`(catch #(bad-arg init bogus))
      (try (db:options [init 'bogus]))]
+    [`(catch #(bad-arg commit-delay -3))
+     (try (db:options [commit-delay -3]))]
+    [`(catch #(bad-arg commit-delay none))
+     (try (db:options [commit-delay 'none]))]
     [`(catch #(bad-arg commit-limit 3.4))
      (try (db:options [commit-limit 3.4]))])
    'ok))
+
+(define (julian->timestamp j)
+  ;; based on example at https://sqlite.org/lang_datefunc.html
+  (exact (round (* (- j 2440587.5) 86400 1000))))
+
+(db-mat commit-delay ()
+  (match-let*
+   ([,op (open-output-string)]
+    [,_ (console-error-port op)]
+    [,_ (console-output-port op)]
+    [,delay-ms 250]
+    [,expected '(1 3 7 25)]
+    [#(ok ,db)
+     (db:start&link #f ":memory:" 'create
+       (db:options
+        [commit-delay delay-ms]
+        [commit-limit 10000]))]
+    [ok
+     (transaction db
+       (execute "create table log(id,queued,actual)")
+       'ok)]
+    [,sql "insert into log(id,queued,actual) values(?,?,julianday('now'))"]
+    [,_ (gen-server:debug db '(message) '())]
+    [,rev-actual '()]
+    [,me self]
+    [,_ (event-mgr:add-handler
+         (let ([log 0])
+           (define-tuple <log> sql mbindings)
+           (lambda (x)
+             (match x
+               [`(<gen-server-debug> [type 2] [message `(<log>)])
+                (set! log (+ log 1))]
+               [`(<gen-server-debug> [type 3] [message `(EXIT ,worker ,r)])
+                (set! rev-actual (cons log rev-actual))
+                (set! log 0)
+                (send me 'worker-finished)]
+               [#(,@me waiting) (send me 'in-sync)]
+               [,_ (void)]))))]
+    [ok
+     (let insert ([i 0] [rows expected])
+       (match rows
+         [() 'ok]
+         [(,n . ,rows)
+          (do ([j 0 (fx+ j 1)]) ((fx= j n))
+            (db:log db sql (fx+ i j) (erlang:now)))
+          ;; wait for the commit-delay
+          (receive (after delay-ms 'ok))
+          ;; now wait for the worker to complete
+          (receive (after 2000 (throw 'timeout-waiting-for-worker))
+            [worker-finished 'ok])
+          (insert (fx+ i n) rows)]))]
+    [,_ (event-mgr:notify `#(,self waiting))]
+    [ok (receive [in-sync 'ok])]
+    [,@expected (reverse rev-actual)])
+   (define (print-row id ts1 ts2 delta)
+     (when (getenv "DEBUG")
+       (printf "~3a ~13a ~13a ~5a\n" id ts1 ts2 delta)))
+   (transaction db
+     (print-row "id" "queued" "actual" "delta")
+     (for-each
+      (lambda (v)
+        (match v
+          [#(,id ,ts1 ,julian)
+           (let ([ts2 (julian->timestamp julian)])
+             (print-row id ts1 ts2 (- ts2 ts1))
+             (assert (<= delay-ms (- ts2 ts1) (* 2 delay-ms))))]))
+      (execute "select id, queued, actual from log order by rowid asc")))))
 
 (db-mat record-writers ()
   ;; database, statement, and bindings

--- a/src/swish/db.ms
+++ b/src/swish/db.ms
@@ -156,6 +156,13 @@
           (populate bv 0)
           (loop (- n 1) (cons bv ls))))))
 
+(define (assert-stmt-counts before)
+  (let ([after (statement-count)])
+    (unless (= before after)
+      (errorf 'assert-stmt-counts
+        "statement counts didn't match, before ~a and after ~a\n"
+        before after))))
+
 (print-unicode #f)
 
 (db-mat marshal ()
@@ -404,7 +411,7 @@
        (execute-sql db "create table data(x)")
        (let ([s (sqlite:prepare db "insert into data(x) values(?)")])
          (on-exit (sqlite:finalize s)
-           (assert (= (statement-count) (+ stmts-before 1)))
+           (assert-stmt-counts (+ stmts-before 1))
            (catch (sqlite:bind s (list too-large))))))]
     [,@stmts-before (statement-count)]
     [#(EXIT #(bad-arg db:start&link "options"))
@@ -699,6 +706,218 @@
       (guard (> count 0))
       'ok])))
 
+(define (do-transaction trans-proc)
+  (match-let*
+   ([,me self]
+    [,stmts-before (statement-count)]
+    [#(ok ,db) (db:start&link #f ":memory:" 'create)])
+   (spawn
+    (lambda ()
+      ;; Fire up a transaction that may not complete, with a live
+      ;; statement.
+      (transaction db
+        (trans-proc (lambda () (send me 'ready))))))
+   (receive [ready 'ok])
+   ;; Give the transaction some time to start executing
+   (receive (after 10 'ok))
+   (unlink db)
+   (db:stop db)
+   (assert-stmt-counts stmts-before)))
+
+(db-mat terminate-live-statement ()
+  (do-transaction
+   (lambda (ready)
+     (ready)
+     (execute "SELECT 1")
+     (receive))))
+
+(db-mat terminate-live-statement-trap-exit ()
+  (do-transaction
+   (lambda (ready)
+     (process-trap-exit #t)
+     (ready)
+     (execute "SELECT 1")
+     (receive))))
+
+(db-mat transaction-link ()
+  (do-transaction
+   (lambda (ready)
+     (link (process-parent))
+     (ready)
+     (execute "SELECT 1")
+     (receive))))
+
+(db-mat transaction-link-error ()
+  (do-transaction
+   (lambda (ready)
+     (link (process-parent))
+     (ready)
+     (execute "SELECT 1")
+     (throw 'boom!))))
+
+(db-mat transaction-unlink ()
+  (do-transaction
+   (lambda (ready)
+     (unlink (process-parent))
+     (ready)
+     (execute "SELECT 1")
+     (receive))))
+
+(db-mat transaction-unlink-trap-exit ()
+  (do-transaction
+   (lambda (ready)
+     (process-trap-exit #t)
+     (unlink (process-parent))
+     (ready)
+     (execute "SELECT 1")
+     (receive))))
+
+(db-mat trap-exit-succeed-after-shutdown ()
+  (do-transaction
+   (lambda (ready)
+     (process-trap-exit #t)
+     (ready)
+     (execute "SELECT 1")
+     (receive [`(EXIT ,_ shutdown) 'done]))))
+
+(db-mat trap-exit-succeed-after-shutdown-with-busy ()
+  (do-transaction
+   (lambda (ready)
+     (process-trap-exit #t)
+     (ready)
+     (try
+      (execute
+       (string-append
+        "with recursive ints(n) as\n"
+        " ( select 1 union all select n + 1 from ints )\n"
+        "select max(n) from ints")))
+     (receive [`(EXIT ,_ shutdown) 'done]))))
+
+(db-mat terminate-live-trap-exit-alternate-error ()
+  (match-let*
+   ([,me self]
+    [,stmts-before (statement-count)]
+    [#(ok ,db) (db:start&link #f ":memory:" 'create)])
+   (spawn
+    (lambda ()
+      (transaction db
+        (process-trap-exit #t)
+        (send me 'ready)
+        (execute "SELECT 1")
+        (receive [`(EXIT ,_ shutdown) (execute "ROLLBACK")]))))
+   (receive [ready 'ok])
+   (spawn
+    (lambda ()
+      (transaction db
+        (execute "SELECT 1"))
+      (send me 'second-transaction-completed)))
+   (receive (after 10 'ok))
+
+   (unlink db)
+   (db:stop db)
+   (receive (after 10 'ok)
+     [second-transaction-completed
+      (throw 'transaction-should-not-have-completed)])
+   (assert-stmt-counts stmts-before)))
+
+(db-mat terminate-while-busy ()
+  (do-transaction
+   (lambda (ready)
+     (ready)
+     (execute
+      (string-append
+       "with recursive ints(n) as\n"
+       " ( select 1 union all select n + 1 from ints )\n"
+       "select max(n) from ints")))))
+
+(db-mat terminate-while-busy-extended ()
+  ;; Query runs forever. Gets interrupted. Foolishly, someone caught
+  ;; the error and tried to rollback the transaction and causes a
+  ;; failure outside of user-code.
+  (do-transaction
+   (lambda (ready)
+     (ready)
+     (try
+      (execute
+       (string-append
+        "with recursive ints(n) as\n"
+        " ( select 1 union all select n + 1 from ints )\n"
+        "select max(n) from ints")))
+     (execute "ROLLBACK"))))
+
+(db-mat terminate-bad-transaction ()
+  (match-let*
+   ([,me self]
+    [,stmts-before (statement-count)]
+    [#(ok ,db) (db:start&link #f ":memory:" 'create)]
+    [,_ (process-trap-exit #t)]
+    [,pid (spawn&link
+           (lambda ()
+             ;; Fire up a transaction that jumps the gun by doing the
+             ;; rollback that the gen-server will do when the transaction
+             ;; crashes.
+             (transaction db
+               (execute "ROLLBACK")
+               (send me 'crashing)
+               (throw 'crashed))))])
+   (receive [crashing 'ok])
+   (receive
+    [`(EXIT ,@db #(db-error step (sqlite3_step ,_ . ,_) "ROLLBACK")) 'ok])
+   (receive
+    [`(EXIT ,@pid #(#(db-error step (sqlite3_step ,_ . ,_) "ROLLBACK")
+                    #(gen-server call ,_)))
+     'ok])
+   (assert-stmt-counts stmts-before)))
+
+(db-mat errant-messages ()
+  (match-let*
+   ([#(ok ,db) (db:start&link #f ":memory:" 'create)]
+    ;; This is more for coverage than an actual test. It is unlikely
+    ;; that we get an errant DOWN message, but if we do, the db
+    ;; gen-server should survive.
+    [,m (monitor (spawn (lambda () (throw 'boom!))))]
+    [,msg (receive [,(msg <= `(DOWN ,@m ,_ ,_ ,_)) msg])]
+    [,_ (send db msg)]
+    [(#(1)) (transaction db (execute "SELECT 1"))]
+    [,m (monitor (spawn (lambda () 'done)))]
+    [,msg (receive [,(msg <= `(DOWN ,@m ,_ ,_ ,_)) msg])]
+    [,_ (send db msg)]
+    [(#(1)) (transaction db (execute "SELECT 1"))]
+    ;; The db gen-server should ignore EXIT message from worker.
+    [#t (transaction db (kill db 'howdy))]
+    [(#(1)) (transaction db (execute "SELECT 1"))]
+    ;; If the db gen-server receives an EXIT message from a process
+    ;; other than worker, it should terminate.
+    [,me self]
+    [,_ (unlink db)]
+    [,_ (spawn (lambda () (kill db 'bye) (send me 'ready)))]
+    [ok (receive [ready 'ok])]
+    [,m (monitor db)])
+   (receive (after 100 (throw 'timeout))
+     [`(DOWN ,@m ,@db bye) 'ok])))
+
+(db-mat flush-queue ()
+  ;; check that we flush lazy transactions on terminate
+  (match-let*
+   ([,op (open-output-string)]
+    [,_ (console-error-port op)]
+    [,_ (console-output-port op)]
+    [#(ok ,db1)
+     (db:start&link #f "file::memory:?cache=shared" 'create
+       (db:options
+        [commit-delay 5000]))]
+    [#(ok ,db2)
+     (db:start&link #f "file::memory:?cache=shared" 'open)]
+    [ok
+     (transaction db1
+       (execute "create table data(x)")
+       'ok)]
+    [ok (db:log db1 "insert into data(x) values(?)" 1)]
+    [() (transaction db2 (execute "select * from data"))]
+    [stopped (db:stop db1)]
+    [(#(1)) (transaction db2 (execute "select * from data"))])
+   'ok))
+
 (isolate-mat crash ()
   ;; Explicitly not using db-mat form because we want to build an
   ;; event-mgr that dumps output to the console.
@@ -796,7 +1015,7 @@
              (match x
                [`(<gen-server-debug> [type 2] [message `(<log>)])
                 (set! log (+ log 1))]
-               [`(<gen-server-debug> [type 3] [message `(EXIT ,worker ,r)])
+               [`(<gen-server-debug> [type 3] [message `(DOWN ,_ ,worker ,r)])
                 (set! rev-actual (cons log rev-actual))
                 (set! log 0)
                 (send me 'worker-finished)]
@@ -890,8 +1109,8 @@
      (execute "INSERT INTO table1 (col1, col2, col3) VALUES(?,?,?)" 1 2 3)
      (execute "INSERT INTO table1 (col1, col2, col3) VALUES(?,?,?)" 4 5 6))
    ;; BEGIN IMMEDIATE, COMMIT, CREATE, INSERT
-   (assert (= (statement-count) (+ stmts-before 4)))
+   (assert-stmt-counts (+ stmts-before 4))
    (db:expire-cache db)
    ;; Only BEGIN IMMEDIATE, COMMIT remain.
-   (assert (= (statement-count) (+ stmts-before 2)))
+   (assert-stmt-counts (+ stmts-before 2))
    (db:stop db)))

--- a/src/swish/db.ms
+++ b/src/swish/db.ms
@@ -644,7 +644,9 @@
 
 (db-mat db-open ()
   (match-let*
-   ([,filename (path-combine (data-dir) "test-db.db3")]
+   ([,filename
+     (make-directory-path
+      (path-combine (data-dir) "test-db.db3"))]
     [#(ok ,file) (db:start&link #f filename 'create)]
     [#(ok ,tmp) (db:start&link #f "" 'create)]
     [#(ok ,mem) (db:start&link #f ":memory:" 'create)]

--- a/src/swish/db.ss
+++ b/src/swish/db.ss
@@ -143,7 +143,7 @@
       [#(ok ,result) result]
       [#(error ,reason) (throw reason)]))
 
-  (define commit-threshold 10000)
+  (define commit-limit 10000)
 
   (define-state-tuple <db-state> filename db cache queue worker)
 
@@ -236,7 +236,7 @@
   (define (get-related-logs queue count)
     (let ([queue (queue:drop queue)]
           [count (+ count 1)])
-      (if (or (queue:empty? queue) (>= count commit-threshold))
+      (if (or (queue:empty? queue) (>= count commit-limit))
           (values '() queue count)
           (let ([head (queue:get queue)])
             (if (<log> is? head)

--- a/src/swish/erlang.ms
+++ b/src/swish/erlang.ms
@@ -1264,7 +1264,7 @@
        (lambda () (eval (read (open-input-string "(match 3 [#[foo] 4])"))))
        (lambda () (record-reader 'foo orig))))
    "invalid match pattern #[foo]")
-  (assert-syntax-error (define-tuple <point> (x y)) "invalid syntax")
+  (assert-syntax-error (define-tuple <point> (x y)) "invalid field")
   (assert-syntax-error (define-tuple <point> make) "invalid field")
   (assert-syntax-error (define-tuple <point> copy) "invalid field")
   (assert-syntax-error (define-tuple <point> copy*) "invalid field")
@@ -1359,7 +1359,7 @@
      (define-tuple <point> x y)
      (<point> open p [51 mustang])
      p)
-   "invalid syntax")
+   "invalid field")
   )
 
 (mat t9 ()

--- a/src/swish/erlang.ms
+++ b/src/swish/erlang.ms
@@ -1691,6 +1691,19 @@
 (mat native-record ()
   (with-cp0-disabled
    ;; define-record-type
+   (assert-syntax-error
+    (let ()
+      ;; match needs the rtd at expand time, but define-record-type does not
+      ;; construct the rtd at expand time because the record type is generative,
+      ;; i.e., it lacks the (nongenerative) clause; for details, see
+      ;; Chez Scheme's s/syntax.ss.
+      (define-record-type foo (fields a))
+      (match 123 [`(foo) #f]))
+    "unknown type foo in `(foo)")
+   (let ()
+     ;; define-record-type creates rtd at expand time; match finds it
+     (define-record-type foo (nongenerative) (fields a))
+     (match (make-foo 1) [`(foo) #t]))
    (let ()
      (define-record-type foo
        (nongenerative)

--- a/src/swish/erlang.ms
+++ b/src/swish/erlang.ms
@@ -1273,6 +1273,11 @@
   (assert-syntax-error
    (let ()
      (define-tuple <point> x y)
+     (<point> is? "sharp" "end"))
+   "invalid syntax")
+  (assert-syntax-error
+   (let ()
+     (define-tuple <point> x y)
      (<point> make))
    "missing field x in")
   (assert-syntax-error
@@ -1628,13 +1633,13 @@
       (define-tuple <box> content)
       (<box> copy* 27)))
                                         ; is?
-  (assert
-   (equal?
-    '(#t #f #f #f #f #f #f #f #f #f #f)
-    (let ()
-      (define-tuple <point> x y)
-      (map (lambda (p) (<point> is? p))
-        (list (<point> make [x 1] [y 2]) #f #t 27 #\a "point" 'point '(point) '#(<point>) '#(<point> 1) '#(<point> 1 2 3))))))
+  (let ()
+    (define-tuple <point> x y)
+    (define expected '(#t #f #f #f #f #f #f #f #f #f #f))
+    (define inputs
+      (list (<point> make [x 1] [y 2]) #f #t 27 #\a "point" 'point '(point) '#(<point>) '#(<point> 1) '#(<point> 1 2 3)))
+    (assert (equal? expected (map (lambda (p) (<point> is? p)) inputs)))
+    (assert (equal? expected (map (<point> is?) inputs))))
                                         ; open
   (assert
    (equal?

--- a/src/swish/erlang.ss
+++ b/src/swish/erlang.ss
@@ -1556,12 +1556,17 @@
                [(name open expr field-names)
                 (eq? (datum open) 'open)
                 (handle-open x #'expr #f #'field-names)]
-               [(name is? e)
+               [(name is? . args)
                 (eq? (datum is?) 'is?)
-                #'(let ([x e])
-                    (and (vector? x)
-                         (#3%fx= (#3%vector-length x) (length '(name field ...)))
-                         (eq? (#3%vector-ref x 0) 'name)))]
+                (let ([is?
+                       #'(lambda (x)
+                           (and (vector? x)
+                                (#3%fx= (#3%vector-length x) (length '(name field ...)))
+                                (eq? (#3%vector-ref x 0) 'name)))])
+                  (syntax-case #'args ()
+                    [() is?]
+                    [(e) #`(#,is? e)]
+                    [else (syntax-case x ())]))]
                [(name fn e)
                 (syntax-datum-eq? #'fn #'field)
                 (with-syntax ([getter (replace-source x #'(name fn))])

--- a/src/swish/erlang.ss
+++ b/src/swish/erlang.ss
@@ -1439,22 +1439,6 @@
              #,(match-help lookup
                  #'(v pattern fail (begin)) #f))])))
 
-  (meta define (valid-fields? x f* known-fields forbidden)
-    (let valid? ([f* f*] [seen '()])
-      (syntax-case f* ()
-        [(fn . rest)
-         (identifier? #'fn)
-         (let ([f (datum fn)])
-           (when (memq f seen)
-             (syntax-violation #f "duplicate field" x #'fn))
-           (when (memq f forbidden)
-             (syntax-violation #f "invalid field" x #'fn))
-           (unless (or (not known-fields) (memq f known-fields))
-             (syntax-violation #f "unknown field" x #'fn))
-           (valid? #'rest (cons f seen)))]
-        [() #t]
-        [_ #f])))
-
   (meta define (generate-name prefix fn)
     (if (not prefix) fn (compound-id fn prefix fn)))
 

--- a/src/swish/event-mgr.ms
+++ b/src/swish/event-mgr.ms
@@ -230,6 +230,7 @@
       [#(error #(invalid-owner bar)) (event-mgr:add-handler (lambda (x) x) 'bar)]
       [#(error #(invalid-procedure foo)) (event-mgr:set-log-handler 'foo self)]
       [#(error #(invalid-owner bar)) (event-mgr:set-log-handler (lambda (x) x) 'bar)]
+      [#(error #(invalid-procedure baz)) (event-mgr:set-log-handler values self 'baz)]
       [,pid (spawn&link (lambda () (receive)))]
       [ok (event-mgr:set-log-handler (lambda (x) (raise x)) pid)]
       [#(error log-handler-already-set) (event-mgr:set-log-handler (lambda (x) x) self)])
@@ -238,7 +239,76 @@
        [`(EXIT ,@pid crash) 'ok])
      (match-regexps '(seek "^Date: " "^Timestamp: " "^Event: crash")
        (split (get-output-string op) #\newline))
-     'ok)))
+     (assert (process? (whereis 'event-mgr))))))
+
+;; log handler fails for certain events, but is configured to endure
+(event-mgr-mat log-handler-endures ()
+  (define op (open-output-string))
+  (parameterize ([console-error-port op])
+    (stop-event-mgr)
+    (event-mgr:start&link)
+    (event-mgr:flush-buffer)
+    ;; do not trap exit: crash the test if event-mgr kills pid with the raised
+    ;; condition
+    (match-let*
+     ([,pid (spawn&link (lambda () (receive)))]
+      [,me self]
+      [ok (event-mgr:set-log-handler
+           (lambda (x)
+             (unless (number? x)
+               (raise `#(unhandled-event ,x)))
+             (send me x))
+           pid
+           (lambda (e) #t))])
+     (for-each event-mgr:notify '(1 2 3 crash 4 5 6))
+     (for-each
+      (lambda (x)
+        (match (receive [,x x])
+          [,@x 'ok]))
+      '(1 2 3 4 5 6))
+     (match-regexps
+      '(seek
+        "^Date: " "^Timestamp: " "^Event: crash"
+        seek
+        "^Date: " "^Timestamp: " "^Event: #\\(unhandled-event crash\\)")
+      (split (get-output-string op) #\newline))
+     (assert (process? (whereis 'event-mgr))))))
+
+;; log handler endure? predicate fails
+(event-mgr-mat log-handler-shield-fails ()
+  (define op (open-output-string))
+  (parameterize ([console-error-port op])
+    (stop-event-mgr)
+    (event-mgr:start&link)
+    (event-mgr:flush-buffer)
+    (process-trap-exit #t)
+    (match-let*
+     ([,pid (spawn&link (lambda () (receive)))]
+      [,me self]
+      [ok (event-mgr:set-log-handler
+           (lambda (x)
+             (unless (number? x)
+               (raise `#(unhandled-event ,x)))
+             (send me x))
+           pid
+           (lambda (e)
+             (send me 'saving-throw)
+             (raise 'shield-failed)))])
+     (for-each event-mgr:notify '(1 2 3 crash 4 5 6))
+     (for-each
+      (lambda (x)
+        (match (receive [,x x])
+          [,@x 'ok]))
+      '(1 2 3 saving-throw))
+     (receive (after 1000 (throw 'timeout))
+      [`(EXIT ,@pid #(unhandled-event crash)) 'ok])
+     (match-regexps
+      '(seek "^Date: " "^Timestamp: " "^Event: crash"
+        seek "^Date: " "^Timestamp: " "^Event: 4"
+        seek "^Date: " "^Timestamp: " "^Event: 5"
+        seek "^Date: " "^Timestamp: " "^Event: 6")
+      (split (get-output-string op) #\newline))
+     (assert (process? (whereis 'event-mgr))))))
 
 (event-mgr-mat exit-reason ()
   (match-let*

--- a/src/swish/http.ms
+++ b/src/swish/http.ms
@@ -688,33 +688,33 @@
      [val "1"]))
   (match-let*
    ([#(EXIT #(bad-arg request-limit a))
-     (catch ((http:options [request-limit 'a])))]
+     (catch (http:options [request-limit 'a]))]
     [#(EXIT #(bad-arg request-limit 0))
-     (catch ((http:options [request-limit 0])))]
+     (catch (http:options [request-limit 0]))]
     [#(EXIT #(bad-arg request-timeout a))
-     (catch ((http:options [request-timeout 'a])))]
+     (catch (http:options [request-timeout 'a]))]
     [#(EXIT #(bad-arg request-timeout 0))
-     (catch ((http:options [request-timeout 0])))]
+     (catch (http:options [request-timeout 0]))]
     [#(EXIT #(bad-arg response-timeout a))
-     (catch ((http:options [response-timeout 'a])))]
+     (catch (http:options [response-timeout 'a]))]
     [#(EXIT #(bad-arg response-timeout 0))
-     (catch ((http:options [response-timeout 0])))]
+     (catch (http:options [response-timeout 0]))]
     [#(EXIT #(bad-arg header-limit a))
-     (catch ((http:options [header-limit 'a])))]
+     (catch (http:options [header-limit 'a]))]
     [#(EXIT #(bad-arg header-limit 0))
-     (catch ((http:options [header-limit 0])))]
+     (catch (http:options [header-limit 0]))]
     [#(EXIT #(bad-arg media-type-handler a))
-     (catch ((http:options [media-type-handler 'a])))]
+     (catch (http:options [media-type-handler 'a]))]
     [#(EXIT #(bad-arg media-type-handler 0))
-     (catch ((http:options [media-type-handler 0])))]
+     (catch (http:options [media-type-handler 0]))]
     [#(EXIT #(bad-arg file-transform a))
-     (catch ((http:options [file-transform 'a])))]
+     (catch (http:options [file-transform 'a]))]
     [#(EXIT #(bad-arg file-transform 0))
-     (catch ((http:options [file-transform 0])))]
+     (catch (http:options [file-transform 0]))]
     [#(EXIT #(bad-arg file-search-extensions a))
-     (catch ((http:options [file-search-extensions 'a])))]
+     (catch (http:options [file-search-extensions 'a]))]
     [#(EXIT #(bad-arg file-search-extensions 0))
-     (catch ((http:options [file-search-extensions 0])))]
+     (catch (http:options [file-search-extensions 0]))]
     [#f (http:find-header "None" header)]
     [#f (http:find-header 'None header)]
     [#(EXIT #(bad-arg http:find-header 0))
@@ -1299,21 +1299,21 @@
 (http-mat websocket-bad-args ()
   (match-let*
    ([#(EXIT #(bad-arg fragmentation-size a))
-     (catch ((ws:options [fragmentation-size 'a])))]
+     (catch (ws:options [fragmentation-size 'a]))]
     [#(EXIT #(bad-arg fragmentation-size 0))
-     (catch ((ws:options [fragmentation-size 0])))]
+     (catch (ws:options [fragmentation-size 0]))]
     [#(EXIT #(bad-arg maximum-message-size a))
-     (catch ((ws:options [maximum-message-size 'a])))]
+     (catch (ws:options [maximum-message-size 'a]))]
     [#(EXIT #(bad-arg maximum-message-size 0))
-     (catch ((ws:options [maximum-message-size 0])))]
+     (catch (ws:options [maximum-message-size 0]))]
     [#(EXIT #(bad-arg ping-frequency a))
-     (catch ((ws:options [ping-frequency 'a])))]
+     (catch (ws:options [ping-frequency 'a]))]
     [#(EXIT #(bad-arg ping-frequency 0))
-     (catch ((ws:options [ping-frequency 0])))]
+     (catch (ws:options [ping-frequency 0]))]
     [#(EXIT #(bad-arg pong-timeout a))
-     (catch ((ws:options [pong-timeout 'a])))]
+     (catch (ws:options [pong-timeout 'a]))]
     [#(EXIT #(bad-arg pong-timeout 0))
-     (catch ((ws:options [pong-timeout 0])))]
+     (catch (ws:options [pong-timeout 0]))]
     [#(EXIT #(bad-arg ws:upgrade a))
      (catch (ws:upgrade 'a 'b 'c))]
     [#(EXIT #(bad-arg ws:upgrade a))

--- a/src/swish/imports.ss
+++ b/src/swish/imports.ss
@@ -47,6 +47,7 @@
     (swish json)
     (swish log-db)
     (swish meta)
+    (swish options)
     (swish osi)
     (swish pregexp)
     (swish queue)

--- a/src/swish/log-db.ms
+++ b/src/swish/log-db.ms
@@ -333,5 +333,10 @@
     [`(catch #(bad-arg json-stack->string ,@op))
      (try (json-stack->string op empty-stack))]
     [`(catch #(bad-arg json-stack->string 123))
-     (try (json-stack->string (open-output-string) 123))])
+     (try (json-stack->string (open-output-string) 123))]
+    [`(catch #(bad-arg create-prune-on-insert-trigger -1))
+     (try (create-prune-on-insert-trigger 'table 'column -1 10))]
+    [`(catch #(bad-arg create-prune-on-insert-trigger 0))
+     (try (create-prune-on-insert-trigger 'table 'column 44 0))]
+    )
    'ok))

--- a/src/swish/log-db.ms
+++ b/src/swish/log-db.ms
@@ -378,5 +378,11 @@
      (try (make-swish-event-logger -1 10))]
     [`(catch #(bad-arg make-swish-event-logger 0))
      (try (make-swish-event-logger 44 0))]
+    [`(catch #(bad-arg setup "xyz"))
+     (try (log-db:event-logger [setup "xyz"] [log values]))]
+    [`(catch #(bad-arg setup "xyz"))
+     (try (log-db:event-logger [setup "xyz"] [log values]))]
+    [`(catch #(bad-arg log "rhythm"))
+     (try (log-db:event-logger [setup void] [log "rhythm"]))]
     )
    'ok))

--- a/src/swish/log-db.ms
+++ b/src/swish/log-db.ms
@@ -171,6 +171,73 @@
         [#(error log-handler-already-set) (log-db:setup '())])
        'ok))))
 
+(isolate-mat log-handler-endures ()
+  (define me self)
+  (define strikes 0)
+  (define (make-logger who)
+    (lambda (x)
+      (match x
+        [(crash ,@who) (raise `(fail ,who))]
+        [,_ (send me (cons who x))])))
+  (process-trap-exit #t)
+  (parameterize ([console-error-port (open-output-string)])
+    (on-exit (for-each stop '(log-db event-mgr))
+      (match-let*
+       ([#(ok ,log-db)
+         (parameterize ([log-file ":memory:"])
+           (start-event-mgr)
+           (log-db:start&link))]
+        [ignore
+         (log-db:setup
+          (list
+           (log-db:event-logger
+            [setup void]
+            [log (make-logger 'logger-1)]
+            [tolerate-fault? (lambda (e) #t)])
+           ;; legacy logger
+           (<event-logger> make
+             [setup void]
+             [log (make-logger 'logger-2)])
+           (log-db:event-logger
+            [setup void]
+            [log (make-logger 'logger-3)]
+            [tolerate-fault?
+             (lambda (e)
+               (set! strikes (+ strikes 1))
+               (< strikes 3))])))]
+        [(logger-1 . `(<system-attributes>)) (receive [,x x])]
+        [(logger-2 . `(<system-attributes>)) (receive [,x x])]
+        [(logger-3 . `(<system-attributes>)) (receive [,x x])]
+        [nothing (receive (until 0 'nothing) [,x x])]
+        [ok (event-mgr:notify 'safe)]
+        [(logger-1 . safe) (receive [,x x])]
+        [(logger-2 . safe) (receive [,x x])]
+        [(logger-3 . safe) (receive [,x x])]
+        [nothing (receive (until 0 'nothing) [,x x])]
+        ;; logger-1 shielded from error, so log-db survives
+        [ok (event-mgr:notify '(crash logger-1))]
+        ;; crash in logger-1 so we never get to logger-2 or logger-3
+        [nothing (receive (until 0 'nothing) [,x x])]
+        ;; logger-3 tolerates strike 1, so log-db survives
+        [ok (event-mgr:notify '(crash logger-3))]
+        [(logger-1 crash logger-3) (receive [,x x])]
+        [(logger-2 crash logger-3) (receive [,x x])]
+        [nothing (receive (until 0 'nothing) [,x x])]
+        [1 strikes]
+        ;; logger-3 tolerates strike 2, so log-db survives
+        [ok (event-mgr:notify '(crash logger-3))]
+        [(logger-1 crash logger-3) (receive [,x x])]
+        [(logger-2 crash logger-3) (receive [,x x])]
+        [nothing (receive (until 0 'nothing) [,x x])]
+        [2 strikes]
+        ;; logger-2 is NOT shielded from error, so log goes down
+        [ok (event-mgr:notify '(crash logger-2))]
+        [(logger-1 crash logger-2) (receive [,x x])]
+        [`(EXIT ,@log-db (fail logger-2)) (receive [,x x])]
+        [nothing (receive (until 0 'nothing) [,x x])]
+        [2 strikes])
+       'ok))))
+
 (isolate-mat prune-trigger ()
   (process-trap-exit #t)
   (on-exit (for-each stop '(log-db event-mgr))
@@ -384,5 +451,10 @@
      (try (log-db:event-logger [setup "xyz"] [log values]))]
     [`(catch #(bad-arg log "rhythm"))
      (try (log-db:event-logger [setup void] [log "rhythm"]))]
+    [`(catch #(bad-arg tolerate-fault? "andreas"))
+     (try (log-db:event-logger
+           [setup void]
+           [log values]
+           [tolerate-fault? "andreas"]))]
     )
    'ok))

--- a/src/swish/log-db.ms
+++ b/src/swish/log-db.ms
@@ -171,6 +171,40 @@
         [#(error log-handler-already-set) (log-db:setup '())])
        'ok))))
 
+(isolate-mat prune-trigger ()
+  (process-trap-exit #t)
+  (on-exit (for-each stop '(log-db event-mgr))
+    (match-let*
+     ([#(ok ,log-db)
+       (parameterize ([log-file ":memory:"])
+         (start-event-mgr)
+         (log-db:start&link))]
+      [,max-days 1]
+      [,logger (make-swish-event-logger max-days 10)]
+      [`(<event-logger> ,setup ,log) logger]
+      [ignore (log-db:setup (list logger))]
+      [,now (erlang:now)]
+      [,msg (<child-end> make
+              [timestamp now]
+              [pid self]
+              [killed 0]
+              [reason "arbitrary"]
+              [details #f])]
+      [,_ (log msg)]
+      [,_ (log (<child-end> copy* msg
+                 [timestamp (- now (* max-days 24 60 60 1000) 1)]
+                 [reason "ancient"]))]
+      [(#("ancient") #("arbitrary"))
+       (transaction log-db
+         (execute "select reason from child_end order by timestamp asc"))]
+      [,_ (log (<child-end> copy* msg
+                 [timestamp (+ now 1000)]
+                 [reason "future"]))]
+      [(#("arbitrary") #("future"))
+       (transaction log-db
+         (execute "select reason from child_end order by timestamp asc"))])
+     'ok)))
+
 (isolate-mat create ()
   (define db-file (path-combine (output-dir) (uuid->string (osi_make_uuid))))
   (process-trap-exit #t)
@@ -338,5 +372,9 @@
      (try (create-prune-on-insert-trigger 'table 'column -1 10))]
     [`(catch #(bad-arg create-prune-on-insert-trigger 0))
      (try (create-prune-on-insert-trigger 'table 'column 44 0))]
+    [`(catch #(bad-arg make-swish-event-logger -1))
+     (try (make-swish-event-logger -1 10))]
+    [`(catch #(bad-arg make-swish-event-logger 0))
+     (try (make-swish-event-logger 44 0))]
     )
    'ok))

--- a/src/swish/log-db.ms
+++ b/src/swish/log-db.ms
@@ -368,6 +368,8 @@
      (try (json-stack->string op empty-stack))]
     [`(catch #(bad-arg json-stack->string 123))
      (try (json-stack->string (open-output-string) 123))]
+    [`(catch #(bad-arg log-db:start&link "bad options"))
+     (try (log-db:start&link "bad options"))]
     [`(catch #(bad-arg create-prune-on-insert-trigger -1))
      (try (create-prune-on-insert-trigger 'table 'column -1 10))]
     [`(catch #(bad-arg create-prune-on-insert-trigger 0))

--- a/src/swish/log-db.ms
+++ b/src/swish/log-db.ms
@@ -158,6 +158,19 @@
          [`(EXIT ,@log-db bad-logger)
           'ok])))))
 
+(isolate-mat handler-already-set ()
+  (process-trap-exit #t)
+  (parameterize ([console-error-port (open-output-string)])
+    (on-exit (for-each stop '(log-db event-mgr))
+      (match-let*
+       ([#(ok ,log-db)
+         (parameterize ([log-file ":memory:"])
+           (start-event-mgr)
+           (log-db:start&link))]
+        [ok (event-mgr:set-log-handler (lambda (event) (void)) self)]
+        [#(error log-handler-already-set) (log-db:setup '())])
+       'ok))))
+
 (isolate-mat create ()
   (define db-file (path-combine (output-dir) (uuid->string (osi_make_uuid))))
   (process-trap-exit #t)

--- a/src/swish/log-db.ss
+++ b/src/swish/log-db.ss
@@ -80,6 +80,7 @@
                [os-release release]
                [os-version version]
                [os-machine machine])])
+          (db:expire-cache 'log-db)
           'ignore]
          [,error error])]
       [,error error]))

--- a/src/swish/log-db.ss
+++ b/src/swish/log-db.ss
@@ -56,10 +56,15 @@
 
   (define-tuple <event-logger> setup log)
 
-  (define (log-db:start&link)
-    (db:start&link 'log-db
-      (make-directory-path (log-file))
-      'create))
+  (define log-db:start&link
+    (case-lambda
+     [() (log-db:start&link (db:options))]
+     [(options)
+      (arg-check 'log-db:start&link [options (db:options is?)])
+      (db:start&link 'log-db
+        (make-directory-path (log-file))
+        'create
+        options)]))
 
   (define (log-db:setup loggers)
     (match (db:transaction 'log-db (lambda () (setup-db loggers)))

--- a/src/swish/log-db.ss
+++ b/src/swish/log-db.ss
@@ -66,20 +66,19 @@
                (lambda (event) (log-event loggers event))
                (whereis 'log-db))
          [ok
-          (let ([now (current-date)])
-            (event-mgr:flush-buffer)
-            (match (get-uname)
-              [`(<uname> ,system ,release ,version ,machine)
-               (system-detail <system-attributes>
-                 [date (current-date)]
-                 [software-info (software-info)]
-                 [machine-type (symbol->string (machine-type))]
-                 [computer-name (osi_get_hostname)]
-                 [os-system system]
-                 [os-release release]
-                 [os-version version]
-                 [os-machine machine])])
-            'ignore)]
+          (event-mgr:flush-buffer)
+          (match (get-uname)
+            [`(<uname> ,system ,release ,version ,machine)
+             (system-detail <system-attributes>
+               [date (current-date)]
+               [software-info (software-info)]
+               [machine-type (symbol->string (machine-type))]
+               [computer-name (osi_get_hostname)]
+               [os-system system]
+               [os-release release]
+               [os-version version]
+               [os-machine machine])])
+          'ignore]
          [,error error])]
       [,error error]))
 

--- a/src/swish/meta.ss
+++ b/src/swish/meta.ss
@@ -26,7 +26,6 @@
    add-if-absent
    collect-clauses
    compound-id
-   define-options
    find-clause
    find-source
    get-clause
@@ -227,31 +226,6 @@
                   (display " " os)
                   (pretty (syntax->datum form) os))
                 (get-output-string os))))))))]))
-
-  (define-syntax (make-options x)
-    (syntax-case x ()
-      [(_ [param-expr val-expr] ...)
-       (with-syntax ([(param ...) (generate-temporaries #'(param-expr ...))]
-                     [(val ...) (generate-temporaries #'(val-expr ...))])
-         #'(let ([param param-expr] ... [val val-expr] ...)
-             (lambda () (param val) ... (void))))]))
-
-  (define-syntax (define-options x)
-    (syntax-case x ()
-      [(_ name option ...)
-       #`(define-syntax name
-           (let ()
-             (define (expose k)
-               (case k [(option) #'option] ...))
-             (lambda (x)
-               (syntax-case x ()
-                 [(_ [opt val] (... ...))
-                  (begin
-                    (collect-clauses x #'([opt val] (... ...))
-                      (datum (option ...)))
-                    (with-syntax ([(actual-opt (... ...))
-                                   (map expose (datum (opt (... ...))))])
-                      #'(make-options (actual-opt val) (... ...))))]))))]))
 
   (define (valid-fields? x f* known-fields forbidden)
     (let valid? ([f* f*] [seen '()])

--- a/src/swish/meta.ss
+++ b/src/swish/meta.ss
@@ -39,6 +39,7 @@
    scdr
    snull?
    syntax-datum-eq?
+   valid-fields?
    windows?
    with-temporaries
    )
@@ -251,4 +252,20 @@
                     (with-syntax ([(actual-opt (... ...))
                                    (map expose (datum (opt (... ...))))])
                       #'(make-options (actual-opt val) (... ...))))]))))]))
+
+  (define (valid-fields? x f* known-fields forbidden)
+    (let valid? ([f* f*] [seen '()])
+      (syntax-case f* ()
+        [(fn . rest)
+         (let ([f (datum fn)])
+           (when (or (not (identifier? #'fn)) (memq f forbidden))
+             (syntax-violation #f "invalid field" x #'fn))
+           (when (memq f seen)
+             (syntax-violation #f "duplicate field" x #'fn))
+           (unless (or (not known-fields) (memq f known-fields))
+             (syntax-violation #f "unknown field" x #'fn))
+           (valid? #'rest (cons f seen)))]
+        [() #t]
+        [_ #f])))
+
   )

--- a/src/swish/options.ms
+++ b/src/swish/options.ms
@@ -1,0 +1,415 @@
+;;; Copyright 2021 Beckman Coulter, Inc.
+;;;
+;;; Permission is hereby granted, free of charge, to any person
+;;; obtaining a copy of this software and associated documentation
+;;; files (the "Software"), to deal in the Software without
+;;; restriction, including without limitation the rights to use, copy,
+;;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;;; of the Software, and to permit persons to whom the Software is
+;;; furnished to do so, subject to the following conditions:
+;;;
+;;; The above copyright notice and this permission notice shall be
+;;; included in all copies or substantial portions of the Software.
+;;;
+;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;;; DEALINGS IN THE SOFTWARE.
+
+#!chezscheme
+(import
+ (chezscheme)
+ (swish erlang)
+ (swish mat)
+ (swish options)
+ (swish testing)
+ )
+
+(mat syntax ()
+  (assert-syntax-error
+   (define-options my:options (required signature))
+   "invalid syntax")
+  (assert-syntax-error
+   (define-options my:options (optional signature))
+   "invalid syntax")
+  (assert-syntax-error
+   (define-options (my:options) (required))
+   "invalid syntax")
+  (assert-syntax-error
+   (define-options my:options (required [(my-key)]))
+   "invalid field")
+  (assert-syntax-error
+   (define-options my:options (optional [(my-key)]))
+   "invalid field")
+  (assert-syntax-error
+   (define-options my:options (optional [copy]))
+   "invalid field")
+  (assert-syntax-error
+   (define-options my:options (required [a]) (optional [a]))
+   "duplicate field")
+  (assert-syntax-error
+   (define-options my:options (required [a] [a]))
+   "duplicate field")
+  (assert-syntax-error
+   (define-options my:options (optional [a] [a]))
+   "duplicate field")
+  ;; no default clause for required options
+  (assert-syntax-error
+   (define-options my:options (required [xyz (default 9)]))
+   "invalid clause")
+  (assert-syntax-error
+   (define-options my:options (required [xyz (unknown 9)]))
+   "invalid clause")
+  (assert-syntax-error
+   (define-options my:options (optional [xyz (unknown 9)]))
+   "invalid clause")
+  (assert-syntax-error
+   (define-options my:options (optional [xyz (default 1 2 3)]))
+   "invalid syntax")
+  (assert-syntax-error
+   (define-options my:options (optional [xyz (filter 1 2 3)]))
+   "invalid syntax")
+  (assert-syntax-error
+   (define-options my:options (optional [xyz (must-be)]))
+   "invalid syntax")
+  (assert-syntax-error
+   (define-options my:options (optional [xyz (filter)]))
+   "invalid syntax")
+  ;; must specify required options
+  (assert-syntax-error
+   (let ()
+     (define-options my:options (required [key1]))
+     (my:options))
+   "missing key1 clause in")
+  (assert-syntax-error
+   (let ()
+     (define-options my:options (required [key1] [key2]) (optional [key3]))
+     (my:options [key1 1] [key3 3]))
+   "missing key2 clause in")
+  (assert-syntax-error
+   (let ()
+     (define-options my:options (required [x]))
+     (my:options [x 1] [x 2]))
+   "duplicate clause")
+  (assert-syntax-error
+   (let ()
+     (define-options my:options (required [x]))
+     (my:options [x]))
+   "invalid syntax")
+  (assert-syntax-error
+   (let ()
+     (define-options my:options (required [x]))
+     (my:options [x 1 2 3]))
+   "invalid syntax")
+  (assert-syntax-error
+   (let ()
+     (define-options my:options (required [x]))
+     (my:options [y not]))
+   "invalid clause")
+  (assert-syntax-error
+   (let ()
+     (define-options my:options (required [x]))
+     (my:options y))
+   "unknown field")
+  (assert-syntax-error
+   (let ()
+     (define-options my:options (required [x]))
+     (my:options y 123))
+   "unknown field")
+  (assert-syntax-error
+   (let ()
+     (define-options my:options (required [x]))
+     (my:options copy 123 [y not]))
+   "unknown field")
+  (assert-syntax-error
+   (let ()
+     (define-options my:options (required [x]))
+     (my:options copy* 123 [y not]))
+   "unknown field")
+  (assert-syntax-error
+   (let ()
+     (define-options my:options (required [x]))
+     (my:options copy 123 [x 4 5 6]))
+   "invalid syntax")
+  (assert-syntax-error
+   (let ()
+     (define-options my:options (required [x]))
+     (my:options copy* 123 [x 4 5 6]))
+   "invalid syntax")
+  ;; optional means optional
+  (match-let*
+   ([#t
+     (let ()
+       (define-options my:options (optional [key1]))
+       (my:options is? (my:options)))])
+   'ok)
+  ;; no namespace pollution
+  (assert
+   (eval ;; delay expand-time error, if any, til now
+    '(let ()
+       (define-options foo (optional [x]))
+       (define-options bar (optional [y]))
+       (define make-record)
+       (define make-<foo>)
+       (define make-<bar>)
+       (match-let*
+        ([`(<foo> [x 1]) (foo [x 1])]
+         [`(<bar> [y 2]) (bar [y 2])])
+        'ok))))
+  ;; field accessor syntax error
+  (assert-syntax-error
+   (let ()
+     (define-options foo (optional [x]))
+     (foo x 1 2))
+   "invalid syntax")
+
+  )
+
+(mat operation ()
+  (let ()
+    (define-options my:options
+      (required [any])
+      (optional [num (must-be number?) (default 0)]))
+    (define-options other:opts
+      (optional [a] [b] [c]))
+    (match-let*
+     ([,x (my:options [any 3])]
+      [,y (my:options [any "seven"] [num 11])]
+      ;; direct field accessors
+      [3 (my:options any x)]
+      ["seven" (my:options any y)]
+      [0 (my:options num x)]
+      [11 (my:options num y)]
+      ;; curried field accessors
+      [(3 "seven") (map (my:options any) (list x y))]
+      [(0 11) (map (my:options num) (list x y))]
+      [(4 101)
+       (map (my:options num)
+         (list
+          (my:options [any #f] [num 4])
+          (my:options [any #t] [num 101])))]
+      [`(<my:options> [any #(outer)])
+       (let ([any 'outer])
+         (my:options copy x [any (vector any)]))]
+      [`(<my:options> [any #(3)])
+       (let ([any 'outer])
+         (my:options copy* x [any (vector any)]))]
+      [`(<my:options> [any #(3)])
+       (let ([any 'outer])
+         (my:options copy* x [any (vector any)]))]
+      [`(<my:options> [any 0] [num 3])
+       (let ([any 'outer] [num 'ber])
+         ;; copy* clause bindings shadow the local bindings
+         (my:options copy* x [any num] [num any]))]
+      [`(<my:options> [any ber] [num 0])
+       (let ([any 14] [num 'ber])
+         ;; we see local binding for num since no clause for num here
+         (my:options copy* x [any num]))]
+      [`(<my:options> [any 3] [num 14])
+       (let ([any 14] [num 'ber])
+         ;; we see local binding for any since no clause for any here
+         (my:options copy* x [num any]))]
+      [`(<my:options> [any 14] [num 15])
+       (let ([any 14] [num 15])
+         (my:options copy x [any any] [num num]))]
+      ;; option types are distinct
+      [,other (other:opts)]
+      [#f (my:options is? other)]
+      [#t (other:opts is? other)]
+      [#t (my:options is? x)]
+      [#f (other:opts is? x)]
+      ;; field order does not matter
+      [`(<other:opts> [a 1] [b 2] [c 3])
+       (other:opts [a 1] [b 2] [c 3])]
+      [`(<other:opts> [a 1] [b 2] [c 3])
+       (other:opts [b 2] [a 1] [c 3])]
+      [`(<other:opts> [a 1] [b 2] [c 3])
+       (other:opts [b 2] [c 3] [a 1])]
+      [`(<other:opts> [a 1] [b 2] [c 3])
+       (other:opts [c 3] [b 2] [a 1])])
+     'ok))
+  (let ()
+    (define-options alt:opts
+      (optional
+       [int (default 0) (must-be integer?)]
+       [->ls (filter list)]
+       [str->sym
+        (default "none")
+        (must-be string?)
+        (filter string->symbol)]
+       [multi
+        (default 0)
+        (must-be fixnum? even? fxnonnegative?)
+        (filter (lambda (n) (* n n)))]))
+    (match-let*
+     ([,x (alt:opts)]
+      ;; single predicate must-be
+      [`(catch #(bad-arg int "zero")) (try (alt:opts [int "zero"]))]
+      ;; multi-predicate must-be
+      [`(catch #(bad-arg multi -8)) (try (alt:opts [multi -8]))]
+      ;; apply must-be before filter (no error from string->symbol)
+      [`(catch #(bad-arg str->sym 7)) (try (alt:opts [str->sym 7]))]
+      ;; apply filters when making options
+      [`(<alt:opts> [int 3] [->ls (wrapped)] [str->sym ok] [multi 16])
+       (alt:opts [int 3] [->ls 'wrapped] [str->sym "ok"] [multi 4])]
+      ;; reminder of filtered result to explain catch that follows
+      [none (alt:opts str->sym x)]
+      ;; apply must-be on copy
+      [`(catch #(bad-arg str->sym none))
+       (try (alt:opts copy x))]
+      ;; apply filters on copy
+      [`(<alt:opts> [int 0] [->ls ((#f))] [str->sym okay] [multi 4])
+       (alt:opts copy x [str->sym "okay"] [multi 2])]
+      ;; apply must-be on copy*
+      [`(catch #(bad-arg str->sym none))
+       (try (alt:opts copy* x))]
+      ;; apply filter on copy*
+      [`(<alt:opts> [int 0] [->ls ((#f))] [str->sym okay] [multi 64])
+       (alt:opts copy* x [str->sym "okay"] [multi 8])])
+     'ok))
+  (let ()
+    ;; default is #f if not specified
+    ;; no filter or predicate if not specified
+    (define-options new:opts (optional [x]))
+    (match (new:opts)
+      [`(<new:opts> [x #f]) 'ok]
+      [`(<new:opts> [x list?]) (new:opts [x list?])]
+      [`(<new:opts> [x #!eof]) (new:opts [x #!eof])])
+    'ok)
+  (let ()
+    ;; default expression evaluated iff n is not supplied
+    (define count 0)
+    (define (next!) (set! count (+ count 1)) count)
+    (define-options new:opts
+      (optional
+       [n (default (next!))]))
+    (match-let*
+     ([0 count]
+      [,x (new:opts [n 1000])]
+      [0 count]
+      [,y (new:opts)]
+      [1 count]
+      [,z (new:opts)]
+      [2 count]
+      [(1000 1 2) (map (new:opts n) (list x y z))]
+      ;; copy and copy* supply value, so default not invoked
+      [,a (new:opts copy x)]
+      [2 count]
+      [,a (new:opts copy* x)]
+      [2 count])
+     'ok))
+  ;; check that (foo x) and (foo x obj) can see <foo>-x field
+  ;; accessor at top-level
+  (match-let*
+   ([,env (environment '(scheme) '(swish imports))]
+    [ok
+     (eval
+      '(begin
+         (define-options foo (optional [x]))
+         (define y (foo [x 1]))
+         (and (= 1 ((foo x) y) (foo x y)) 'ok))
+      (copy-environment env #t))]
+    [ok
+     (eval
+      '(let ()
+         (define-options foo (optional [x]))
+         (define y (foo [x 1]))
+         (and (= 1 ((foo x) y) (foo x y)) 'ok))
+      (copy-environment env #f))]
+    [ok
+     (eval
+      '(begin
+         (define-options foo (optional [x]))
+         (define x (foo [x 1]))
+         (and (= 1 ((foo x) x) (foo x x)) 'ok))
+      (copy-environment env #t))]
+    [ok
+     (eval
+      '(let ()
+         (define-options foo (optional [x]))
+         (define x (foo [x 1]))
+         (and (= 1 ((foo x) x) (foo x x)) 'ok))
+      (copy-environment env #f))])
+   'ok)
+  ;; safely reject bad input
+  (let ()
+    (define-options foo (optional [x]))
+    (define-options bar (optional [x]))
+    (match-let*
+     ([`(catch #(bad-match 3 ,_)) (try (foo x 3))]
+      [,ba (bar [x 'elephant])]
+      [`(catch #(bad-match ,@ba ,_)) (try (foo x ba))]
+      [,z (foo [x 11])]
+      [`(catch #(bad-match ,@z ,_)) (try (bar x z))]
+      [elephant (bar x ba)]
+      [11 (foo x z)])
+     'ok))
+  )
+
+(mat procedure/arity ()
+  (define (take-any . x) x)
+  (define (take-one x) x)
+  (define (take-five a b c d e) a)
+  (define take-one-or-four
+    (case-lambda
+     [(x) x]
+     [(a b c d) a]))
+  (define port (open-input-string "port in a storm"))
+  ;; curried cases
+  (match-let*
+   ([,any (procedure/arity? -1)]
+    [#t (any take-any)]
+    [#t (any take-one)]
+    [#t (any take-five)]
+    [#t (any take-one-or-four)]
+    [#f (any port)]
+    [,two+ (procedure/arity? -4)]
+    [#t (two+ take-any)]
+    [#f (two+ take-one)]
+    [#t (two+ take-five)]
+    [#t (two+ take-one-or-four)]
+    [#f (two+ port)]
+    [,one-or-four (procedure/arity? #b10010)]
+    [#t (one-or-four take-any)]
+    [#t (one-or-four take-one)]
+    [#f (one-or-four take-five)]
+    [#t (one-or-four take-one-or-four)]
+    [#f (one-or-four port)])
+   'ok)
+  ;; direct case
+   (match-let*
+   ([#t (procedure/arity? -1 take-any)]
+    [#t (procedure/arity? -1 take-one)]
+    [#t (procedure/arity? -1 take-five)]
+    [#t (procedure/arity? -1 take-one-or-four)]
+    [#f (procedure/arity? -1 port)]
+    [#t (procedure/arity? -4 take-any)]
+    [#f (procedure/arity? -4 take-one)]
+    [#t (procedure/arity? -4 take-five)]
+    [#t (procedure/arity? -4 take-one-or-four)]
+    [#f (procedure/arity? -4 port)]
+    [#t (procedure/arity? #b10010 take-any)]
+    [#t (procedure/arity? #b10010 take-one)]
+    [#f (procedure/arity? #b10010 take-five)]
+    [#t (procedure/arity? #b10010 take-one-or-four)]
+    [#f (procedure/arity? #b10010 port)])
+   'ok)
+  )
+
+(mat record-writer ()
+  (define-options my:opts (required))
+  (define-options other:options (optional [x] [y]))
+  (define-options more:options (required [a]) (optional [b]))
+  (match-let*
+   (["#<my:opts>" (format "~s" (my:opts))]
+    ["#<other:options>" (format "~s" (other:options))]
+    ["#<other:options>" (format "~s" (other:options [x 11]))]
+    ["#<other:options>" (format "~s" (other:options [y not]))]
+    ["#<other:options>" (format "~s" (other:options [x 11] [y not]))]
+    ["#<more:options>" (format "~s" (more:options [a 'ok]))]
+    ["#<more:options>" (format "~s" (more:options [a 'ok] [b "line"]))])
+   'ok))

--- a/src/swish/options.ss
+++ b/src/swish/options.ss
@@ -1,0 +1,218 @@
+;;; Copyright 2021 Beckman Coulter, Inc.
+;;;
+;;; Permission is hereby granted, free of charge, to any person
+;;; obtaining a copy of this software and associated documentation
+;;; files (the "Software"), to deal in the Software without
+;;; restriction, including without limitation the rights to use, copy,
+;;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;;; of the Software, and to permit persons to whom the Software is
+;;; furnished to do so, subject to the following conditions:
+;;;
+;;; The above copyright notice and this permission notice shall be
+;;; included in all copies or substantial portions of the Software.
+;;;
+;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;;; DEALINGS IN THE SOFTWARE.
+
+(library (swish options)
+  (export
+   define-options
+   procedure/arity?
+   )
+  (import
+   (scheme)
+   (swish erlang)
+   (swish meta))
+
+  (meta define (get-rhs key clauses form)
+    (syntax-case (get-clause key clauses form) ()
+      [(_ val) #'val]))
+
+  (meta define (get-rhs/default key clauses default-var)
+    (syntax-case (find-clause key clauses) ()
+      [(_ val) #'val]
+      [_ default-var]))
+
+  (meta define (find-rhs key clauses multiple?)
+    (cond
+     [(find-clause key clauses) =>
+      (lambda (present)
+        (syntax-case present ()
+          [(key rhs0 rhs1 ...) multiple? #'(rhs0 rhs1 ...)]
+          [(key rhs1) #'rhs1]))]
+     [else #f]))
+
+  (meta define (choose-refs copy-vars all-keys)
+    (let ([als (map cons (syntax->datum copy-vars) copy-vars)])
+      (map (lambda (key)
+             (syntax-case (assq (syntax->datum key) als) ()
+               [(copy-name . copy-var) #'copy-var]
+               [else key]))
+        (syntax->list all-keys))))
+
+  ;; (define-options opt-name
+  ;;   (required [key req-spec ...] ...)
+  ;;   (optional [key opt-spec ...] ...))
+  ;;
+  ;; opt-name is an identifier
+  ;; required, optional, must-be, filter, and default are keywords
+  ;; key ... are distinct identifiers
+  ;;
+  ;; req-spec -> (must-be pred? ...)
+  ;;           | (filter filter-expr)
+  ;;
+  ;; opt-spec -> req-spec
+  ;;           | (default default-expr)
+  ;;
+  ;; The pred? and filter-expr expressions are evaluated once, when defining the
+  ;; internal make-record procedure generated for my:options. The default-expr
+  ;; is evaluated whenever the corresponding optional key is not specified in a
+  ;; call to the internal make-record procedure. This lets us have generative
+  ;; default expressions. We can bind default-expr to a variable where this is
+  ;; not desirable.
+  ;;
+  ;; The define-options form defines:
+  ;;  - a macro opt-name that supports
+  ;;    - record construction and copying
+  ;;      (opt-name [key val] ...)
+  ;;      (opt-name copy obj [key val] ...)
+  ;;      (opt-name copy* obj [key val] ...)
+  ;;    - record field access
+  ;;      ((opt-name key) obj)
+  ;;      (opt-name key obj)
+  ;;    - record predicate
+  ;;      ((opt-name is?) obj)
+  ;;      (opt-name is? obj)
+  ;;  - a native record type called <opt-name> for use in:
+  ;;    (match obj [`(<opt-name> ,key ...) ...])
+
+  (define-syntax (define-options input)
+    (define (parse-optional opt-field) (parse-spec opt-field '(default)))
+    (define (parse-required opt-field) (parse-spec opt-field '()))
+    (define (parse-spec field extra-specs)
+      (define valid-specs (append extra-specs '(must-be filter)))
+      (syntax-case field ()
+        [(key kv ...)
+         (let ([kv* (collect-clauses field #'(kv ...) valid-specs)])
+           (with-syntax ([(check) (generate-temporaries '(check))]
+                         [dflt-expr (find-rhs 'default kv* #f)]
+                         [(pred? ...) (or (find-rhs 'must-be kv* #t) '())]
+                         [filter (or (find-rhs 'filter kv* #f) #'values)])
+             #`(key
+                dflt-expr
+                [check
+                 (lambda (val)
+                   (unless (and (pred? val) ...)
+                     (bad-arg 'key val))
+                   (filter val))])))]))
+    (let f ([x input])
+      (syntax-case x ()
+        [(_ name (optional opt-field ...))
+         (eq? (datum optional) 'optional)
+         (f #'(define-options name (required) (optional opt-field ...)))]
+        [(_ name (required req-field ...))
+         (eq? (datum required) 'required)
+         (f #'(define-options name (required req-field ...) (optional)))]
+        [(_ name (required req-field ...) (optional opt-field ...))
+         (and (identifier? #'name)
+              (equal? (datum (required optional)) '(required optional)))
+         (with-syntax
+          ([<name> (compound-id #'name "<" #'name ">")]
+           [<name>? (compound-id #'name "<" #'name ">?")]
+           [make-<name> (compound-id #'name "make-<" #'name ">")]
+           [((req-key #f [req-check req-check-expr]) ...)
+            (map parse-required #'(req-field ...))]
+           [((opt-key opt-dflt-expr [opt-check opt-check-expr]) ...)
+            (map parse-optional #'(opt-field ...))]
+           [:... #'(... ...)])
+          (assert (valid-fields? input #'(req-key ... opt-key ...) #f '(copy copy* is?)))
+          #'(module (<name> (name make-record))
+              (define-record-type <name>
+                (nongenerative)
+                (parent <options>)
+                (fields
+                 (immutable req-key) ...
+                 (immutable opt-key) ...))
+              (define make-record
+                (let ([req-check req-check-expr] ...
+                      [opt-check opt-check-expr] ...
+                      [omitted (record-type-descriptor <options>)])
+                  (lambda (req-key ... opt-key ...)
+                    (make-<name>
+                     (req-check req-key) ...
+                     (opt-check (if (eq? opt-key omitted) opt-dflt-expr opt-key))
+                     ...))))
+              (define-syntax (name x)
+                (define fields '(req-key ... opt-key ...))
+                force-library-init ;; insert reference to force library init
+                (syntax-case x ()
+                  [(_ copy obj [key val] :...)
+                   (memq (datum copy) '(copy copy*))
+                   (begin
+                     (valid-fields? x #'(key :...) fields '())
+                     (with-syntax ([(ref :...)
+                                    (choose-refs #'(key :...) #'(req-key ... opt-key ...))])
+                       (case (datum copy)
+                         [copy
+                          #'(match obj
+                              [`(<name> ,req-key ... ,opt-key ...)
+                               (let ([key val] :...)
+                                 (make-record ref :...))])]
+                         [copy*
+                          #'(match obj
+                              [`(<name> ,req-key ... ,opt-key ...)
+                               ((lambda (ref :...)
+                                  (let ([key val] :...)
+                                    (make-record ref :...)))
+                                req-key ... opt-key ...)])])))]
+                  [(_ copy . _)
+                   (memq (datum copy) '(copy copy*))
+                   (syntax-case x ())]
+                  [(_ field arg :...)
+                   (or (memq (datum field) fields) (eq? (datum field) 'is?))
+                   (let ([proc
+                          (if (eq? (datum field) 'is?)
+                              #'(lambda (x) (match x [`(<name>) #t] [,_ #f]))
+                              #'(lambda (x) (match x [`(<name> ,field) field])))])
+                     (syntax-case #'(arg :...) ()
+                       [() proc]
+                       [(obj) #`(#,proc obj)]
+                       [else (syntax-case x ())]))]
+                  [(_ field . _)
+                   (identifier? #'field)
+                   (syntax-violation #f "unknown field" x #'field)]
+                  [(_ clause :...)
+                   (let ([clauses (collect-clauses x #'(clause :...) fields)])
+                     (with-syntax
+                      ([(req-val :...) (list (get-rhs 'req-key clauses x) ...)]
+                       [(opt-val :...) (list (get-rhs/default 'opt-key clauses #'omitted) ...)])
+                      #`(let ([omitted (record-type-descriptor <options>)])
+                          (make-record req-val :... opt-val :...))))]))))]
+        ;; report syntax error using source for the *original* input,
+        ;; not the source from recursive calls to f above
+        [else (syntax-case input ())])))
+
+  (define procedure/arity?
+    (case-lambda
+     [(mask) (lambda (p) (procedure/arity? mask p))]
+     [(mask p)
+      (and (procedure? p)
+           (not (zero? (logand (procedure-arity-mask p) mask))))]))
+
+  (define force-library-init)
+
+  (define-record-type <options> (nongenerative))
+
+  ;; install record-writer for base type that handles children
+  (record-writer (record-type-descriptor <options>)
+    (lambda (r p wr)
+      (display-string "#" p)
+      (wr (record-type-name (record-rtd r)) p)))
+
+  )

--- a/src/swish/osi.h
+++ b/src/swish/osi.h
@@ -126,7 +126,7 @@ EXPORT ptr osi_get_statement_columns(uptr statement);
 EXPORT ptr osi_get_statement_expanded_sql(uptr statement);
 EXPORT ptr osi_reset_statement(uptr statement);
 EXPORT ptr osi_step_statement(uptr statement, ptr callback);
-EXPORT void osi_interrupt_database(uptr database);
+EXPORT ptr osi_interrupt_database(uptr database);
 EXPORT ptr osi_get_sqlite_status(int operation, int resetp);
 EXPORT ptr osi_bulk_execute(ptr statements, ptr mbindings, ptr callback);
 EXPORT ptr osi_marshal_bindings(ptr bindings);

--- a/src/swish/osi.ss
+++ b/src/swish/osi.ss
@@ -269,7 +269,7 @@
   (define-osi osi_get_statement_expanded_sql (statement uptr))
   (define-osi osi_reset_statement (statement uptr))
   (define-osi osi_step_statement (statement uptr) (callback ptr))
-  (fdefine osi_interrupt_database (database uptr) void)
+  (fdefine osi_interrupt_database (database uptr) ptr)
   (define-osi osi_get_sqlite_status (operation int) (reset? boolean))
   (define-osi osi_bulk_execute (statements ptr) (mbindings ptr) (callback ptr))
   (define-osi osi_marshal_bindings (ls ptr))

--- a/src/swish/sqlite.c
+++ b/src/swish/sqlite.c
@@ -711,8 +711,9 @@ ptr osi_step_statement(uptr statement, ptr callback) {
   return Strue;
 }
 
-void osi_interrupt_database(uptr database) {
+ptr osi_interrupt_database(uptr database) {
   sqlite3_interrupt(((database_t*)database)->db);
+  return ((database_t*)database)->busy ? Strue : Sfalse;
 }
 
 ptr osi_get_sqlite_status(int operation, int resetp) {

--- a/src/swish/string-utils.ms
+++ b/src/swish/string-utils.ms
@@ -266,3 +266,65 @@
        (oxford-comma "~@{" "~a" " and " "~}") '(control alt delete))])
    'ok)
   )
+
+(mat ct:join ()
+  (match-let*
+   (["combined" (expand '(ct:join "" "comb" "in" "e" "d"))]
+    ["comb--in--e--d" (expand '(ct:join "--" "comb" "in" "e" "d"))]
+    ["nu_cle_ar" (expand '(ct:join #\_ "nu" "cle" "ar"))]
+    ["okay" (expand '(ct:join #\! "okay"))]
+    ["someday-maybe" (expand '(ct:join #\- "someday" "maybe"))]
+    ["" (expand '(ct:join "xyz"))]
+    ["" (expand '(ct:join "" "" ""))]
+    [(#2%string-append "join-ed-" x "-o-the-r-" y)
+     (expand '(ct:join "-" "join" "ed" x "o" "the" "r" y))]
+    [(#2%string-append x "---ceptional")
+     (expand '(ct:join "---" x "ceptional"))]
+    ;; residualize call to string-append in case y evaluates to non-string
+    [(#2%string-append y)
+     (expand '(ct:join "phone" y))]
+    [(#2%string-append x "\nbr\nok\nen\n" y)
+     (expand '(ct:join #\newline x "br" "ok" "en" y))]
+    [(#2%string-append x "\nbr\nok\nen\n" y "\nzap")
+     (expand '(ct:join #\newline x "br" "ok" "en" y "zap"))])
+   'ok))
+
+(mat ct:string-append ()
+  (match-let*
+   (["combined" (expand '(ct:string-append "comb" "in" "e" "d"))]
+    ["xyz" (expand '(ct:string-append "xyz"))]
+    ["" (expand '(ct:string-append "" "" ""))]
+    [(#2%string-append "joined" x "other" y)
+     (expand '(ct:string-append "join" "ed" x "o" "the" "r" y))]
+    [(#2%string-append x "ceptional")
+     (expand '(ct:string-append x "ceptional"))]
+    [(#2%string-append "phone" y)
+     (expand '(ct:string-append "phone" y))]
+    [(#2%string-append 123 "broken" 777)
+     (expand '(ct:string-append 123 "br" "ok" "en" 777))]
+    [(#2%string-append 123 "broken" 777 "zap")
+     (expand '(ct:string-append 123 "br" "ok" "en" 777 "zap"))]
+    [(#2%string-append "abc" 123 "broken" 777 "zap")
+     (expand '(ct:string-append "abc" 123 "br" "ok" "en" 777 "zap"))]
+    [(#2%string-append "abc" 123 "broken" 777 "zap")
+     (expand '(ct:string-append "a" "" "bc" 123 "br" "ok" "en" 777 "za" "p" "" ""))]
+    [(#2%string-append "abc" (#2%string #\newline) "broken" (#2%string #\newline) "zap")
+     (expand
+      '(ct:string-append
+        "a" "bc" (string #\newline)
+        "br" "ok" "en" (string #\newline)
+        "za" "p" ""))]
+    [(#2%string-append "abc\nbr" ok "en\nzap")
+     (expand
+      '(ct:string-append
+        "a" "bc" "\n"
+        "br" ok "en" "\n"
+        "za" "p" ""))]
+    ["abc\nbroken\nzap"
+     (expand
+      '(ct:string-append
+        "a" "bc" "\n"
+        "br" "ok" "en" "\n"
+        "za" "p" ""))])
+   'ok)
+  )


### PR DESCRIPTION
**Fixes**

* Let applications selectively tolerate `log-handler` faults.
* Make `db` more robust in shutdown and in its handling of transactions.
* Expose options for tuning database parameters.
* Document lazy transactions more accurately.

**Proposed changes**

Summarize changes here. Note any breaking changes.

* Recast `define-options` using native records in place of parameter-setting.
* Add compile-time string concatenation utilities.
* Add `make-swish-event-logger` to permit control over `prune-max-days` and `prune-limit` for the Swish event tables.
* Expose `create-prune-on-insert-trigger`.
* Expose `commit-limit`, `commit-delay`, and `cache-timeout` database parameters.
* Add `db:expire-cache` for explicit control over statement cache.
* Allow `db:options` argument to `log-db` to permit tuning the log database.
* Add `log-db:event-logger` interface so we can extend logger interface without breaking `<event-logger>`.
* Add optional `endure?` predicate to `event-mgr:set-log-handler` so applications have the option of tolerating log-handler faults, without paying the extra `try` / `catch` overhead.
* Add optional `tolerate-fault` (hmm, should that be `tolerate-fault?`) to `log-db:event-logger` to take advantage of `event-mgr:set-log-handler`'s `endure?` option.
* Make `db` gen-server `flush` its work queue on `shutdown`.
* Handle failure while finalizing statements when database is busy at `shutdown`.
* Overhaul `db` gen-server to use `monitor` in place of `link` to make it more robust to misbehaving transactions.
* Adapt the `supervisor` shutdown protocol in `db` gen-server's `terminate` path.