### PR TITLE
update for glibc 2.33

### DIFF
--- a/src/swish/Mf-a6le
+++ b/src/swish/Mf-a6le
@@ -1,10 +1,10 @@
-ifneq (,$(shell "${CC}" --help=warnings 2> /dev/null | grep implicit-fallthrough))
+ifneq (,$(shell ${CC} --help=warnings 2> /dev/null | grep Wimplicit-fallthrough))
   HUSH:=-Wimplicit-fallthrough=0
 endif
-ifneq (,$(shell "${CC}" --help=warnings 2> /dev/null | grep cast-function-type))
+ifneq (,$(shell ${CC} --help=warnings 2> /dev/null | grep Wcast-function-type))
   HUSH:=${HUSH} -Wno-cast-function-type
 endif
-ifneq (,$(shell "${CC}" --help=warnings 2> /dev/null | grep return-local-addr))
+ifneq (,$(shell ${CC} --help=warnings 2> /dev/null | grep Wreturn-local-addr))
   HUSH:=${HUSH} -Wno-return-local-addr
 endif
 C = ${CC} -m64 -msse2 -fPIC -Wall -Wextra -Werror -O2 ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}

--- a/src/swish/Mf-a6le
+++ b/src/swish/Mf-a6le
@@ -7,6 +7,9 @@ endif
 ifneq (,$(shell ${CC} --help=warnings 2> /dev/null | grep Wreturn-local-addr))
   HUSH:=${HUSH} -Wno-return-local-addr
 endif
+ifneq (,$(shell ${CC} --help=warnings 2> /dev/null | grep Wmisleading-indentation))
+  HUSH:=${HUSH} -Wno-misleading-indentation
+endif
 C = ${CC} -m64 -msse2 -fPIC -Wall -Wextra -Werror -O2 ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}
 OsiObj=osi.o sha1.o sqlite.o sqlite3.o
 SystemLibs=-lm -ldl -lncurses -luuid -lpthread -lsystemd

--- a/src/swish/Mf-i3le
+++ b/src/swish/Mf-i3le
@@ -1,10 +1,10 @@
-ifneq (,$(shell "${CC}" --help=warnings 2> /dev/null | grep implicit-fallthrough))
+ifneq (,$(shell ${CC} --help=warnings 2> /dev/null | grep Wimplicit-fallthrough))
   HUSH:=-Wimplicit-fallthrough=0
 endif
-ifneq (,$(shell "${CC}" --help=warnings 2> /dev/null | grep cast-function-type))
+ifneq (,$(shell ${CC} --help=warnings 2> /dev/null | grep Wcast-function-type))
   HUSH:=${HUSH} -Wno-cast-function-type
 endif
-ifneq (,$(shell "${CC}" --help=warnings 2> /dev/null | grep return-local-addr))
+ifneq (,$(shell ${CC} --help=warnings 2> /dev/null | grep Wreturn-local-addr))
   HUSH:=${HUSH} -Wno-return-local-addr
 endif
 C = ${CC} -m32 -fPIC -Wall -Wextra -Werror -O2 ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}

--- a/src/swish/Mf-i3le
+++ b/src/swish/Mf-i3le
@@ -7,6 +7,9 @@ endif
 ifneq (,$(shell ${CC} --help=warnings 2> /dev/null | grep Wreturn-local-addr))
   HUSH:=${HUSH} -Wno-return-local-addr
 endif
+ifneq (,$(shell ${CC} --help=warnings 2> /dev/null | grep Wmisleading-indentation))
+  HUSH:=${HUSH} -Wno-misleading-indentation
+endif
 C = ${CC} -m32 -fPIC -Wall -Wextra -Werror -O2 ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}
 OsiObj=osi.o sha1.o sqlite.o sqlite3.o
 SystemLibs=-lm -ldl -lncurses -luuid -lpthread -lsystemd

--- a/src/swish/osi.c
+++ b/src/swish/osi.c
@@ -650,7 +650,11 @@ size_t osi_get_bytes_used(void) {
   struct mstats ms = mstats();
   return ms.bytes_used;
 #elif defined(__GLIBC__)
+#if (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 33)
+  struct mallinfo2 hinfo = mallinfo2();
+#else
   struct mallinfo hinfo = mallinfo();
+#endif
   return hinfo.hblkhd + hinfo.uordblks;
 #elif defined(_WIN32)
   size_t used = 0;


### PR DESCRIPTION
**Fixes**

* Fix build error "`mallinfo` is deprecated" with glibc 2.33.
* Fix sqlite3.c compiler warning with gcc 11.1.1 on a6le.
* Fix sqlite3.c warnings are not disarmed when `CC='ccache gcc'`.

**Proposed changes**

Summarize changes here. Note any breaking changes.

* Use `mallinfo2` if glibc version >= 2.33.
* Add `-Wmisleading-indentation` to the set of warnings we mute for sqlite3.c.
* Unquote `"${CC}"` in x86* Linux makefiles so we still tame sqlite3.c warnings when `CC='ccache gcc'`.
