### PR TITLE
add record-type-hash-procedure for pcb and for mon

### DIFF
--- a/src/swish/erlang.ms
+++ b/src/swish/erlang.ms
@@ -3753,6 +3753,28 @@
        ,@stack-info)
      (split (get-output-string os) #\newline))))
 
+(isolate-mat record-hash ()
+  ;; mon
+  (match-let*
+   ([,me self]
+    [,pid1 (spawn&link (lambda () (send me (monitor me))))]
+    [,m1 (monitor pid1)]
+    [,m2 (receive [,x x])]
+    [#t (monitor? m2)]
+    [#f (eq? m1 m2)]
+    [#f (= (equal-hash m1) (equal-hash m2))] ;; collision unlikely
+    [#t (= (equal-hash m1) (equal-hash m1))]
+    [#t (= (equal-hash m2) (equal-hash m2))])
+   'ok)
+  ;; pcb
+  (match-let*
+   ([,pid1 (spawn&link values)]
+    [#f (eq? pid1 self)]
+    [#f (= (equal-hash pid1) (equal-hash self))] ;; no collision
+    [#t (= (equal-hash pid1) (equal-hash pid1))]
+    [#t (= (equal-hash self) (equal-hash self))])
+   'ok))
+
 (isolate-mat cyclic-event ()
   ;; Handle cyclic structures in console-event-handler.
   (script-test #f '()

--- a/src/swish/erlang.ss
+++ b/src/swish/erlang.ss
@@ -1668,6 +1668,18 @@
           (wr name p)))
       (write-char #\> p)))
 
+  ;; support equal-hash on mon and pcb records so folks don't get burned
+  ;; by the default record-hash-procedure when using functional hash tables
+  (record-type-hash-procedure (record-type-descriptor mon)
+    (lambda (m hash)
+      (match-define `(mon ,origin ,target) m)
+      (+ (pcb-id origin)
+         (ash (pcb-id target) (quotient (fixnum-width) 2)))))
+
+  (record-type-hash-procedure (record-type-descriptor pcb)
+    (lambda (pcb hash)
+      (pcb-id pcb)))
+
   (record-writer (csv7:record-type-descriptor
                   (condition (make-error) (make-warning)))
     (lambda (x p wr)


### PR DESCRIPTION
**Fixes**

O(n) lookup when `equal-hash` is used (with default `record-hash-procedure`) for a functional hash table storing processes or monitors.

**Proposed changes**

Add record-type-hash-procedure for pcb and mon records to support the
use of equal-hash for functional hash tables that hold processes and
monitors. This helps developers avoid poor hashing behavior from the
default record-hash-procedure.
