### PR TITLE
log os-pid on startup; extend memory statistics

### DIFF
--- a/doc/swish/log-db.tex
+++ b/doc/swish/log-db.tex
@@ -394,6 +394,7 @@ numbers.
   \argrow{software-info}{JSON object from \code{software-info}}
   \argrow{machine-type}{\code{(symbol->string (machine-type))}}
   \argrow{computer-name}{computer name from \code{osi\_get\_hostname}}
+  \argrow{os-pid}{the operating-system process ID for the Swish process}
   \argrow{os-system}{\code{(<uname> system (get-uname))}}
   \argrow{os-release}{\code{(<uname> release (get-uname))}}
   \argrow{os-version}{\code{(<uname> version (get-uname))}}

--- a/doc/swish/statistics.tex
+++ b/doc/swish/statistics.tex
@@ -88,6 +88,11 @@ top-level-value \code{\$suspend}.
   \argrow{reason}{\code{startup}, \code{update}, \code{suspend},
     \code{resume}, or \code{shutdown}}
   \argrow{bytes-allocated}{Scheme heap size from \code{bytes-allocated}}
+  \argrow{current-memory-bytes}{Scheme heap size including overhead,
+    from \code{current-memory-bytes}}
+  \argrow{maximum-memory-bytes}{maximum Scheme heap size including overhead,
+    since startup or since the last \code{<statistics>} event,
+    from \code{maximum-memory-bytes}}
   \argrow{osi-bytes-used}{C heap size from \code{osi\_get\_bytes\_used}}
   \argrow{sqlite-memory}{SQLite memory used from
     \code{osi\_get\_sqlite\_status}}
@@ -104,6 +109,9 @@ top-level-value \code{\$suspend}.
     since last event}
   \argrow{gc-bytes}{Scheme heap bytes reclaimed since last event}
 \end{pubevent}
+
+Each time a \code{<statistics>} event is emitted,
+the maximum memory bytes value is reset via \code{reset-maximum-memory-bytes!}.
 
 The JSON object in the \code{foreign-handles} field contains at least the following entries:
 

--- a/src/swish/events.ss
+++ b/src/swish/events.ss
@@ -82,6 +82,8 @@
     date
     reason            ; startup | update | suspend | resume | shutdown
     bytes-allocated
+    current-memory-bytes
+    maximum-memory-bytes
     osi-bytes-used
     sqlite-memory
     sqlite-memory-highwater
@@ -107,6 +109,7 @@
     software-info
     machine-type
     computer-name
+    os-pid
     os-system
     os-release
     os-version

--- a/src/swish/log-db.ss
+++ b/src/swish/log-db.ss
@@ -115,6 +115,7 @@
                [software-info (software-info)]
                [machine-type (symbol->string (machine-type))]
                [computer-name (osi_get_hostname)]
+               [os-pid (osi_get_pid)]
                [os-system system]
                [os-release release]
                [os-version version]
@@ -387,7 +388,7 @@
 
   (module (make-swish-event-logger swish-event-logger)
     (define schema-name 'swish)
-    (define schema-version "2020-10-01")
+    (define schema-version "2021-09-18")
 
     (define-simple-events create-simple-tables log-simple-event
       (<child-end>
@@ -434,6 +435,8 @@
        (date text)
        (reason text)
        (bytes-allocated integer)
+       (current-memory-bytes integer)
+       (maximum-memory-bytes integer)
        (osi-bytes-used integer)
        (sqlite-memory integer)
        (sqlite-memory-highwater integer)
@@ -459,6 +462,7 @@
        (software-info text)
        (machine-type text)
        (computer-name text)
+       (os-pid integer)
        (os-system text)
        (os-release text)
        (os-version text)
@@ -534,6 +538,12 @@
     (define (upgrade-db)
       (match (log-db:version schema-name)
         [,@schema-version 'ok]
+        ["2020-10-01"
+         (execute "alter table statistics add column current_memory_bytes integer default null")
+         (execute "alter table statistics add column maximum_memory_bytes integer default null")
+         (execute "alter table system_attributes add column os_pid integer default null")
+         (log-db:version schema-name "2021-09-18")
+         (upgrade-db)]
         ["2020-09-01"
          (execute "alter table system_attributes add column os_system text default null")
          (execute "alter table system_attributes add column os_release text default null")

--- a/src/swish/statistics.ss
+++ b/src/swish/statistics.ss
@@ -92,6 +92,11 @@
          [date date]
          [reason reason]
          [bytes-allocated (bytes-allocated)]
+         [current-memory-bytes (current-memory-bytes)]
+         [maximum-memory-bytes
+          (let ([max (maximum-memory-bytes)])
+            (reset-maximum-memory-bytes!)
+            max)]
          [osi-bytes-used (osi_get_bytes_used)]
          [sqlite-memory sqlite-memory]
          [sqlite-memory-highwater sqlite-memory-highwater]

--- a/web/swish/charts.ss
+++ b/web/swish/charts.ss
@@ -94,7 +94,7 @@
         (fill-gaps (sqlite:execute stmt (list limit)))))))
 
 (define standard-charts
-  '(("memory" "bytes_allocated" "osi_bytes_used")
+  '(("memory" "bytes_allocated" "osi_bytes_used" "maximum_memory_bytes")
     ("time" "cpu" "gc_real")
     ("sqlite" "sqlite_memory" "sqlite_memory_highwater")
     ("bytes_allocated" "bytes_allocated")

--- a/web/swish/debug.ss
+++ b/web/swish/debug.ss
@@ -116,7 +116,11 @@
               (quotient (time-nanosecond now) 1000000))))
        (fprintf op "Uptime: ~a\n" (uptime))
        (newline op)
-       (fprintf op "  Scheme bytes: ~15:D\n" (bytes-allocated))
+       (let ([current (current-memory-bytes)]
+             [occupied (bytes-allocated)])
+         (fprintf op "  Scheme bytes: ~15:D / ~:D (~,1f% occupied)\n"
+           occupied current
+           (* 100 (/ occupied current))))
        (fprintf op "       C bytes: ~15:D\n" (osi_get_bytes_used))
        (match (osi_get_sqlite_status* SQLITE_STATUS_MEMORY_USED #f)
          [#(,current ,highwater)


### PR DESCRIPTION
**Fixes**

N/A

**Proposed changes**

* Log the operating-system PID on startup to help correlate Swish logs with other system logs.
* Add current-memory-bytes and maximum-memory-bytes to the statistics we log.

**Question**

* Is it reasonable to call `reset-maximum-memory-bytes!` at each `<statistics>` event?