### PR TITLE
log additional memory information

### DIFF
--- a/doc/swish/log-db.tex
+++ b/doc/swish/log-db.tex
@@ -399,6 +399,7 @@ numbers.
   \argrow{os-release}{\code{(<uname> release (get-uname))}}
   \argrow{os-version}{\code{(<uname> version (get-uname))}}
   \argrow{os-machine}{\code{(<uname> machine (get-uname))}}
+  \argrow{os-total-memory}{\code{(osi\_get\_total\_memory)}}
 \end{pubevent}
 
 The \code{<system-attributes>} event is sent exactly once, when

--- a/doc/swish/osi.tex
+++ b/doc/swish/osi.tex
@@ -289,7 +289,7 @@ See Figure~\ref{fig:service-callbacks} for information on these callbacks.
 \caption{Service callbacks. \label{fig:service-callbacks}}
 \end{figure}
 
-\subsection {System Functions}
+\subsection {System Functions and Procedures}
 
 \defineentry{osi\_get\_argv}
 \begin{function}
@@ -309,6 +309,24 @@ The \code{osi\_get\_bytes\_used} function returns the number of bytes
 used by the C run-time heap. On Linux, it calls the \code{mallinfo}
 function. On macOS, it calls the \code{mstats} function. On Windows,
 it calls the \code{\_heapwalk} function.
+
+\defineentry{osi\_get\_free\_memory}
+\begin{procedure}
+  \code{(osi\_get\_free\_memory)}
+\end{procedure}
+\returns{} an unsigned integer
+
+The \code{osi\_get\_free\_memory} procedure returns the number of bytes of free
+memory as reported by \code{uv\_get\_free\_memory}.
+
+\defineentry{osi\_get\_total\_memory}
+\begin{procedure}
+  \code{(osi\_get\_total\_memory)}
+\end{procedure}
+\returns{} an unsigned integer
+
+The \code{osi\_get\_total\_memory} procedure returns the number of bytes of
+total physical memory as reported by \code{uv\_get\_total\_memory}.
 
 \defineentry{osi\_get\_callbacks}
 \begin{function}

--- a/doc/swish/statistics.tex
+++ b/doc/swish/statistics.tex
@@ -108,6 +108,7 @@ top-level-value \code{\$suspend}.
   \argrow{gc-real}{elapsed time in seconds of garbage collections
     since last event}
   \argrow{gc-bytes}{Scheme heap bytes reclaimed since last event}
+  \argrow{os-free-memory}{current free memory from \code{osi\_get\_free\_memory}}
 \end{pubevent}
 
 Each time a \code{<statistics>} event is emitted,

--- a/src/swish/events.ss
+++ b/src/swish/events.ss
@@ -94,7 +94,8 @@
     gc-count
     gc-cpu
     gc-real
-    gc-bytes)
+    gc-bytes
+    os-free-memory)
   (define-tuple <supervisor-error>
     timestamp
     supervisor
@@ -113,7 +114,8 @@
     os-system
     os-release
     os-version
-    os-machine)
+    os-machine
+    os-total-memory)
   (define-tuple <transaction-retry>
     timestamp
     database

--- a/src/swish/osi.ms
+++ b/src/swish/osi.ms
@@ -96,3 +96,24 @@
         (json:write (current-output-port) (app:config) 0)))
     'replace)
   (script-test test-request '("150") "" '("add-work" "start" "stop" "ok")))
+
+;; test for change in semantics, e.g., units of the underlying uv_get_total_memory
+(isolate-mat sanity-check-memory-info ()
+  ;; test only on Linux; interface should be the same on other platforms
+  (match (get-uname)
+    [`(<uname> [system "Linux"])
+     (let* ([os-total (osi_get_total_memory)] ;; in bytes
+            [os-free (osi_get_free_memory)]   ;; in bytes
+            [ip (open-file-to-read "/proc/meminfo")])
+       (assert (< os-free os-total))
+       (on-exit (close-port ip)
+         (let lp ()
+           (match (get-line ip)
+             [#!eof (throw `reference-memory-info-not-found)]
+             [,line
+              ;; free memory fluctuates too much to check reliably this way
+              (match (pregexp-match (re "^MemTotal: *([0-9]+) kB") line)
+                [(,_ ,total-kb)
+                 (assert (= os-total (* 1024 (string->number total-kb))))]
+                [,_ (lp)])]))))]
+    [,_ 'ok]))

--- a/src/swish/osi.ss
+++ b/src/swish/osi.ss
@@ -53,6 +53,7 @@
    osi_get_executable_path
    osi_get_file_size
    osi_get_file_size*
+   osi_get_free_memory
    osi_get_hostname
    osi_get_hostname*
    osi_get_hrtime
@@ -76,6 +77,7 @@
    osi_get_temp_directory
    osi_get_temp_directory*
    osi_get_time
+   osi_get_total_memory
    osi_get_uname
    osi_interrupt_database
    osi_is_quantum_over
@@ -175,6 +177,10 @@
   (fdefine osi_set_quantum (nanoseconds unsigned-64) void)
   (define-osi osi_start_signal (signum int))
   (define-osi osi_stop_signal (handler uptr))
+  (define osi_get_free_memory
+    (foreign-procedure "uv_get_free_memory" () unsigned-64))
+  (define osi_get_total_memory
+    (foreign-procedure "uv_get_total_memory" () unsigned-64))
 
   ;; Ports
   (define-osi osi_read_port (port uptr) (buffer ptr) (start-index size_t) (size unsigned-32) (offset integer-64) (callback ptr))

--- a/src/swish/run.c
+++ b/src/swish/run.c
@@ -105,6 +105,8 @@ static void swish_init(void) {
   add_foreign(osi_unmarshal_bindings);
   add_foreign(osi_watch_path);
   add_foreign(osi_write_port);
+  add_foreign(uv_get_free_memory);
+  add_foreign(uv_get_total_memory);
   if (g_aux_init) g_aux_init();
 }
 

--- a/src/swish/statistics.ss
+++ b/src/swish/statistics.ss
@@ -107,7 +107,8 @@
          [gc-count (sstats-gc-count delta)]
          [gc-cpu (time-duration (sstats-gc-cpu delta))]
          [gc-real (time-duration (sstats-gc-real delta))]
-         [gc-bytes (sstats-gc-bytes delta)])
+         [gc-bytes (sstats-gc-bytes delta)]
+         [os-free-memory (osi_get_free_memory)])
        stats)))
 
   ;; External entry points are run from the event-loop process.

--- a/web/swish/debug.ss
+++ b/web/swish/debug.ss
@@ -116,6 +116,11 @@
               (quotient (time-nanosecond now) 1000000))))
        (fprintf op "Uptime: ~a\n" (uptime))
        (newline op)
+       (let ([free (osi_get_free_memory)]
+             [total (osi_get_total_memory)])
+         (fprintf op "  Free memory: ~16:D (~,1f%)\n" free (* 100 (/ free total)))
+         (fprintf op "  Phys memory: ~16:D\n" total))
+       (newline op)
        (let ([current (current-memory-bytes)]
              [occupied (bytes-allocated)])
          (fprintf op "  Scheme bytes: ~15:D / ~:D (~,1f% occupied)\n"


### PR DESCRIPTION
**Proposed changes**

* log total physical memory in `<system-attributes>` via `uv_get_total_memory`
* log free memory in `<statistics>` via `uv_get_free_memory`
* add free and total physical memory to the diagnostics debug page

