### PR TITLE
swish-test updates and tilde-expansion for filesystem operations

### DIFF
--- a/doc/swish/osi.tex
+++ b/doc/swish/osi.tex
@@ -715,6 +715,15 @@ finishes, it enqueues the callback list \code{(\var{callback}
   \var{result})}, where \var{result} is the string path when
 successful and a negative error code otherwise.
 
+\defineentry{osi\_get\_home\_directory}
+\begin{function}
+  \code{ptr osi\_get\_home\_directory(void);}
+\end{function}
+
+The \code{osi\_get\_home\_directory} function uses the
+\code{uv\_os\_homedir} function to return the string path of the
+current user's home directory and an error pair otherwise.
+
 \defineentry{osi\_get\_temp\_directory}
 \begin{function}
   \code{ptr osi\_get\_temp\_directory(void);}

--- a/src/swish/http.ms
+++ b/src/swish/http.ms
@@ -1138,14 +1138,15 @@
        [response-timeout 15])))
   (capture-events)
   (let-values ([(ip op) (connect-tcp "127.0.0.1" (get-http-port))])
-    (put-bytevector op (string->utf8 "GET / HTTP/1.1\r\n\r\n"))
-    (flush-output-port op)
-    ;; grab a few bytes, but otherwise don't read. This will cause the
-    ;; server to fill up the network queue and eventually wait. This
-    ;; causes the response-timeout to trigger.
-    (do ([i 0 (+ i 1)]) ((= i 10)) (get-u8 ip))
-    (receive (after 2000 (throw 'failed-to-timeout))
-      [`(<child-end> [reason #(timeout ,_)]) 'ok])))
+    (on-exit (close-port op) ; tidy up, but also prevent premature gc of op
+      (put-bytevector op (string->utf8 "GET / HTTP/1.1\r\n\r\n"))
+      (flush-output-port op)
+      ;; grab a few bytes, but otherwise don't read. This will cause the
+      ;; server to fill up the network queue and eventually wait. This
+      ;; causes the response-timeout to trigger.
+      (do ([i 0 (+ i 1)]) ((= i 10)) (get-u8 ip))
+      (receive (after 2000 (throw 'failed-to-timeout))
+        [`(<child-end> [reason #(timeout ,_)]) 'ok]))))
 
 (http-mat content-length ()
   (define (test s)
@@ -1437,22 +1438,23 @@
           [ping-frequency 10]
           [pong-timeout 1])))))
   (let-values ([(ip op) (connect-tcp "127.0.0.1" (get-http-port))])
-    (for-each
-     (lambda (str)
-       (put-bytevector op (string->utf8 str))
-       (put-bytevector op (string->utf8 "\r\n")))
-     '("GET / HTTP/1.1"
-       "Connection: Upgrade"
-       "Host: 127.0.0.1"
-       "Upgrade: websocket"
-       "Sec-Websocket-Version: 13"
-       "Sec-Websocket-Key: dGhlIHNhbXBsZSBub25jZQ=="))
-    (put-bytevector op (string->utf8 "\r\n"))
-    (flush-output-port op)
-    (receive (after 1000 (throw 'no-ws:init))
-      [#(ws:init ,s)
-       (receive (after 1000 (throw 'no-server-close))
-         [#(ws:closed ,@s 1002 "no response from ping") 'ok])])))
+    (on-exit (close-port op) ; tidy up, but also prevent premature gc of op
+      (for-each
+       (lambda (str)
+         (put-bytevector op (string->utf8 str))
+         (put-bytevector op (string->utf8 "\r\n")))
+       '("GET / HTTP/1.1"
+         "Connection: Upgrade"
+         "Host: 127.0.0.1"
+         "Upgrade: websocket"
+         "Sec-Websocket-Version: 13"
+         "Sec-Websocket-Key: dGhlIHNhbXBsZSBub25jZQ=="))
+      (put-bytevector op (string->utf8 "\r\n"))
+      (flush-output-port op)
+      (receive (after 1000 (throw 'no-ws:init))
+        [#(ws:init ,s)
+         (receive (after 1000 (throw 'no-server-close))
+           [#(ws:closed ,@s 1002 "no response from ping") 'ok])]))))
 
 (http-mat websocket-client-connect-errors ()
   (define (do-test req)

--- a/src/swish/io.ms
+++ b/src/swish/io.ms
@@ -967,5 +967,23 @@
          (split (receive [,x x]) #\newline)))])
    'ok))
 
+(isolate-mat bad-args ()
+  (define-syntax assert-bad-args
+    (syntax-rules ()
+      [(_ [bad (fn arg ...)] ...)
+       (match-let*
+        ([`(catch #(bad-arg fn bad)) (try (fn arg ...))] ...)
+        'ok)]))
+  (assert-bad-args
+   [123 (open-file-port 123 O_RDONLY S_IFREG)]
+   [123 (get-real-path 123)]
+   [123 (get-stat 123)]
+   [123 (list-directory 123)]
+   [123 (read-file 123)]
+   [123 (spawn-os-process 123 '() self)]
+   [(oops) (spawn-os-process "nosuchfile" '(oops) self)]
+   [due (spawn-os-process "nosuchfile" '() 'due)]
+   [123 (spawn-os-process-detached 123 '())]
+   [(oops) (spawn-os-process-detached"nosuchfile" '(oops))]))
 
 (hook-console-input)

--- a/src/swish/io.ms
+++ b/src/swish/io.ms
@@ -263,7 +263,8 @@
     ["end of file" (osi_get_error_text UV_EOF)]
     ["SQLITE_ERROR" (osi_get_error_text -6000001)]
     ["Error code 0" (osi_get_error_text 0)]
-    [#t (directory? (osi_get_temp_directory))])
+    [#t (directory? (osi_get_temp_directory))]
+    [#t (directory? (osi_get_home_directory))])
    'ok)
   (delete-tree test-dir)
   (make-directory-path test-dir)

--- a/src/swish/io.ss
+++ b/src/swish/io.ss
@@ -446,7 +446,7 @@
     (unless (process? process)
       (bad-arg 'watch-path process))
     (with-interrupts-disabled
-     (match (osi_watch_path* path
+     (match (osi_watch_path* (tilde-expand path)
               (case-lambda
                [(filename events)
                 (send process
@@ -576,7 +576,7 @@
      [(path mode)
       (define result)
       (with-interrupts-disabled
-       (match (osi_make_directory* path mode
+       (match (osi_make_directory* (tilde-expand path) mode
                 (let ([p self])
                   (lambda (r)
                     (set! result r)
@@ -591,7 +591,7 @@
   (define make-directory-path
     (case-lambda
      [(path mode)
-      (let loop ([path path])
+      (let loop ([path (tilde-expand path)])
         (let ([dir (path-parent path)])
           (unless (or (string=? dir path) (string=? dir ""))
             (unless (directory? dir)
@@ -619,7 +619,7 @@
   (define (remove-directory path)
     (define result)
     (with-interrupts-disabled
-     (match (osi_remove_directory* path
+     (match (osi_remove_directory* (tilde-expand path)
               (let ([p self])
                 (lambda (r)
                   (set! result r)
@@ -633,7 +633,7 @@
   (define (remove-file path)
     (define result)
     (with-interrupts-disabled
-     (match (osi_unlink* path
+     (match (osi_unlink* (tilde-expand path)
               (let ([p self])
                 (lambda (r)
                   (set! result r)
@@ -647,7 +647,7 @@
   (define (rename-path path new-path)
     (define result)
     (with-interrupts-disabled
-     (match (osi_rename* path new-path
+     (match (osi_rename* (tilde-expand path) (tilde-expand new-path)
               (let ([p self])
                 (lambda (r)
                   (set! result r)
@@ -661,7 +661,7 @@
   (define (set-file-mode path mode)
     (define result)
     (with-interrupts-disabled
-     (match (osi_chmod* path mode
+     (match (osi_chmod* (tilde-expand path) mode
               (let ([p self])
                 (lambda (r)
                   (set! result r)
@@ -682,10 +682,17 @@
        [(,who . ,errno) (io-error name who errno)]
        [,handle (@make-osi-port name handle)])))
 
+  (define (tilde-expand path)
+    (if (and (> (string-length path) 0)
+             (char=? #\~ (string-ref path 0))
+             (string=? "~" (path-first path)))
+        (path-combine (osi_get_home_directory) (path-rest path))
+        path))
+
   (define (open-file-port name flags mode)
     (define result)
     (with-interrupts-disabled
-     (match (osi_open_file* name flags mode
+     (match (osi_open_file* (tilde-expand name) flags mode
               (let ([p self])
                 (lambda (r)
                   (if (pair? r)
@@ -718,7 +725,7 @@
   (define (get-real-path path)
     (define result)
     (with-interrupts-disabled
-     (match (osi_get_real_path* path
+     (match (osi_get_real_path* (tilde-expand path)
               (let ([p self])
                 (lambda (r)
                   (set! result r)
@@ -735,7 +742,7 @@
      [(path follow?)
       (define result)
       (with-interrupts-disabled
-       (match (osi_get_stat* path follow?
+       (match (osi_get_stat* (tilde-expand path) follow?
                 (let ([p self])
                   (lambda (r)
                     (set! result r)
@@ -749,7 +756,7 @@
   (define (list-directory path)
     (define result)
     (with-interrupts-disabled
-     (match (osi_list_directory* path
+     (match (osi_list_directory* (tilde-expand path)
               (let ([p self])
                 (lambda (r)
                   (set! result r)
@@ -841,7 +848,7 @@
     (unless (process? process)
       (bad-arg 'spawn-os-process process))
     (with-interrupts-disabled
-     (match (osi_spawn* path args
+     (match (osi_spawn* (tilde-expand path) args
               (lambda (os-pid exit-status term-signal)
                 (send process
                   `#(process-terminated ,os-pid ,exit-status ,term-signal))))
@@ -859,7 +866,7 @@
   (define (spawn-os-process-detached path args)
     (unless (and (list? args) (for-all string? args))
       (bad-arg 'spawn-os-process-detached args))
-    (match (osi_spawn_detached* path args)
+    (match (osi_spawn_detached* (tilde-expand path) args)
       [(,who . ,errno) (io-error path who errno)]
       [,os-pid os-pid]))
 

--- a/src/swish/io.ss
+++ b/src/swish/io.ss
@@ -691,6 +691,7 @@
 
   (define (open-file-port name flags mode)
     (define result)
+    (arg-check 'open-file-port [name string?])
     (with-interrupts-disabled
      (match (osi_open_file* (tilde-expand name) flags mode
               (let ([p self])
@@ -724,6 +725,7 @@
 
   (define (get-real-path path)
     (define result)
+    (arg-check 'get-real-path [path string?])
     (with-interrupts-disabled
      (match (osi_get_real_path* (tilde-expand path)
               (let ([p self])
@@ -741,6 +743,7 @@
     (case-lambda
      [(path follow?)
       (define result)
+      (arg-check 'get-stat [path string?])
       (with-interrupts-disabled
        (match (osi_get_stat* (tilde-expand path) follow?
                 (let ([p self])
@@ -755,6 +758,7 @@
 
   (define (list-directory path)
     (define result)
+    (arg-check 'list-directory [path string?])
     (with-interrupts-disabled
      (match (osi_list_directory* (tilde-expand path)
               (let ([p self])
@@ -829,6 +833,7 @@
     (open-file name (+ O_WRONLY O_CREAT O_TRUNC) #o666 'binary-output))
 
   (define (read-file name)
+    (arg-check 'read-file [name string?])
     (let ([port (open-file-port name O_RDONLY 0)])
       (on-exit (close-osi-port port)
         (let ([n (get-file-size port)])
@@ -842,11 +847,13 @@
 
   ;; Process Ports
 
+  (define (list-of-strings? ls) (and (list? ls) (for-all string? ls)))
+
   (define (spawn-os-process path args process)
-    (unless (and (list? args) (for-all string? args))
-      (bad-arg 'spawn-os-process args))
-    (unless (process? process)
-      (bad-arg 'spawn-os-process process))
+    (arg-check 'spawn-os-process
+      [path string?]
+      [args list-of-strings?]
+      [process process?])
     (with-interrupts-disabled
      (match (osi_spawn* (tilde-expand path) args
               (lambda (os-pid exit-status term-signal)
@@ -864,8 +871,9 @@
        [(,who . ,errno) (io-error path who errno)])))
 
   (define (spawn-os-process-detached path args)
-    (unless (and (list? args) (for-all string? args))
-      (bad-arg 'spawn-os-process-detached args))
+    (arg-check 'spawn-os-process-detached
+      [path string?]
+      [args list-of-strings?])
     (match (osi_spawn_detached* (tilde-expand path) args)
       [(,who . ,errno) (io-error path who errno)]
       [,os-pid os-pid]))

--- a/src/swish/mat.ss
+++ b/src/swish/mat.ss
@@ -371,6 +371,7 @@
               ["meta-kv"
                (json:set! meta-data (string->symbol (meta-kv-key r)) (meta-kv-value r))])
             (rd)))))
+    (json:set! obj 'results (reverse (json:ref obj 'results '())))
     obj)
 
   (define (summarize-results results*)

--- a/src/swish/osi.c
+++ b/src/swish/osi.c
@@ -1234,6 +1234,15 @@ ptr osi_rename(const char* path, const char* new_path, ptr callback) {
   return Strue;
 }
 
+ptr osi_get_home_directory(void) {
+  static char buffer[32768];
+  size_t len = sizeof(buffer);
+  int rc = uv_os_homedir(buffer, &len);
+  if (rc < 0)
+    return osi_make_error_pair("uv_os_homedir", rc);
+  return Sstring_utf8(buffer, len);
+}
+
 ptr osi_get_temp_directory(void) {
   static char buffer[32768];
   size_t len = sizeof(buffer);

--- a/src/swish/osi.h
+++ b/src/swish/osi.h
@@ -88,6 +88,7 @@ EXPORT ptr osi_open_file(const char* path, int flags, int mode, ptr callback);
 EXPORT ptr osi_get_executable_path(void);
 EXPORT ptr osi_get_file_size(uptr port, ptr callback);
 EXPORT ptr osi_get_real_path(const char* path, ptr callback);
+EXPORT ptr osi_get_home_directory(void);
 EXPORT ptr osi_get_temp_directory(void);
 EXPORT ptr osi_chmod(const char* path, int mode, ptr callback);
 EXPORT ptr osi_make_directory(const char* path, int mode, ptr callback);

--- a/src/swish/osi.ss
+++ b/src/swish/osi.ss
@@ -54,6 +54,8 @@
    osi_get_file_size
    osi_get_file_size*
    osi_get_free_memory
+   osi_get_home_directory
+   osi_get_home_directory*
    osi_get_hostname
    osi_get_hostname*
    osi_get_hrtime
@@ -199,6 +201,7 @@
   (define-osi osi_get_executable_path)
   (define-osi osi_get_file_size (port uptr) (callback ptr))
   (define-osi osi_get_real_path (path string) (callback ptr))
+  (define-osi osi_get_home_directory)
   (define-osi osi_get_temp_directory)
   (define-osi osi_chmod (path string) (mode int) (callback ptr))
   (define-osi osi_make_directory (path string) (mode int) (callback ptr))

--- a/src/swish/profile.ss
+++ b/src/swish/profile.ss
@@ -37,6 +37,7 @@
    (chezscheme)
    (swish app-io)
    (swish erlang)
+   (swish errors)
    (swish gen-server)
    (swish html)
    (swish io)
@@ -336,7 +337,8 @@
          (lambda (profile-fn)
            (match (catch ($profile-load profile-fn (make-insert-filedata table)))
              [#(EXIT ,reason)
-              (errorf 'profile:dump-html "cannot load profile data from ~a" profile-fn)]
+              (errorf 'profile:dump-html "cannot load profile data from ~a: ~a" profile-fn
+                (exit-reason->english reason))]
              [,_ (void)]))
          inputs))
       (let-values ([(keys vals) (hashtable-entries table)])

--- a/src/swish/run.c
+++ b/src/swish/run.c
@@ -61,6 +61,7 @@ static void swish_init(void) {
   add_foreign(osi_get_error_text);
   add_foreign(osi_get_executable_path);
   add_foreign(osi_get_file_size);
+  add_foreign(osi_get_home_directory);
   add_foreign(osi_get_hostname);
   add_foreign(osi_get_hrtime);
   add_foreign(osi_get_ip_address);

--- a/src/swish/swish-test
+++ b/src/swish/swish-test
@@ -944,11 +944,17 @@
           (if (profile:dump-html (or save-prof load-prof) coverage include exclude)
               (printf "see ~a\n" (path->file-uri (get-real-path coverage)))
               (printf "no profile to dump\n")))
-        (summarize-results summary
-          (cond
-           [(or (opt 'harvest) (opt 'load-results)) (or progress 'summary)]
-           [(or report coverage) 'summary]
-           [else 'none]))
+        (call-with-values
+          (lambda ()
+            (summarize-results summary
+              (cond
+               [(or (opt 'harvest) (opt 'load-results)) (or progress 'summary)]
+               [(or report coverage) 'summary]
+               [else 'none])))
+          (lambda (pass fail skip completed attempted)
+            (when (or (opt 'harvest) (opt 'load-results))
+              (unless (and (> pass 0) (= fail 0) (= skip 0) (= completed attempted))
+                (set! status 1)))))
         (when (opt 'info)
           (let ([ht (make-eq-hashtable)])
             (define (sym<? a b) (string<? (symbol->string a) (symbol->string b)))

--- a/src/swish/swish-test
+++ b/src/swish/swish-test
@@ -41,13 +41,13 @@
   (cli-specs
    [incl-tags --tag (list "<tag>") "run only the tests with this tag"]
    [excl-tags --not (list "<tag>") "exclude tests with this tag"]
-   [progress --progress (string "<mode>") "<mode>={test|suite|none}"]
    [test-run --test-run (string "<UUID>")
     "use the specified <UUID> to identify the test run instead of generating one"]
    [specs (list . "<spec>") "directory | suite [{test | -t test} ...]"]))
 
 (define test-and-report-cli
   (cli-specs
+   [progress --progress (string "<mode>") "<mode>={test|suite|none}"]
    [load-prof --load-profile (list "<file>" "<file>" ...)
     "load the specified profile(s)"]
    [save-prof --save-profile (string "<file>")
@@ -592,15 +592,6 @@
             (div (@ (class "vscroll"))
               (table (@ (id "content"))))))))))
 
-(define (console-summary mat-data* reporting?)
-  (let-values ([(pass fail skip completed attempted) (summarize-results mat-data*)])
-    (when reporting?
-      (printf "Tests run: ~s   Pass: ~s   Fail: ~s   Skip: ~s\n\n"
-        (+ pass fail) pass fail skip))
-    (let ([incomplete (- attempted completed)])
-      (unless (zero? incomplete)
-        (printf "*** Some test suite~p did not complete ***\n\n" incomplete)))))
-
 (define (if-exists fn) (and (regular-file? fn) fn))
 
 (define (get-test-files x)
@@ -743,11 +734,13 @@
         [include (or (opt 'include) '())]
         [save-prof (opt 'save-prof)]
         [load-prof (opt 'load-prof)]
-        [progress (string->symbol (or (opt 'progress) "test"))]
+        [progress (cond [(opt 'progress) => string->symbol] [else #f])]
         [report (opt 'report)]
         [coverage (opt 'coverage)]
         [pre-specs (extract-pre-specs (or (opt 'specs) '()))])
     (check-report-format report 'report)
+    (unless (memq progress '(#f test suite none))
+      (fail "invalid ~a ~s" (option-named 'progress) progress))
     (cond
      [(and load-prof (not (or save-prof coverage)))
       (fail "~a requires ~a or ~a"
@@ -796,7 +789,7 @@
                  [incl-tags incl-tags]
                  [excl-tags excl-tags]
                  [profile save-prof]
-                 [progress progress]
+                 [progress (or progress 'test)]
                  [lib-dirs (library-directories)]
                  [src-dirs (source-directories)])
                specs)))
@@ -889,7 +882,11 @@
           (if (profile:dump-html (or save-prof load-prof) coverage include exclude)
               (printf "see ~a\n" (path->file-uri (get-real-path coverage)))
               (printf "no profile to dump\n")))
-        (console-summary summary (or report coverage (opt 'load-results) (opt 'harvest)))
+        (summarize-results summary
+          (cond
+           [(or (opt 'harvest) (opt 'load-results)) (or progress 'summary)]
+           [(or report coverage) 'summary]
+           [else 'none]))
         (when (opt 'info)
           (let ([ht (make-eq-hashtable)])
             (define (sym<? a b) (string<? (symbol->string a) (symbol->string b)))

--- a/src/swish/swish-test
+++ b/src/swish/swish-test
@@ -173,8 +173,11 @@
     [(all details)
      (wrap 0
        "By default, " who " runs all tests in the specified test suites."
-       "To run a limited set of tests, specify a suite or a suite and test"
-       "or use --tag or --not to filter tests based on tags.\n"
+       "To run a limited set of tests, use --tag or --not to select or exclude"
+       "tests based on the tags present in the mat or isolate-mat forms."
+       "To run particular tests, specify a suite followed by names of one"
+       "or more tests in the suite. Use -t to disambiguate where a test name"
+       "happens to match the name of an existing suite.\n"
        "\n"
        "Test suites are files with a \".ms\" or \".ss\" extension listed"
        "explicitly on the command line or found by recursively searching"
@@ -607,9 +610,6 @@
 (define (get-test-files x)
   (and (directory? x) (find-files x ".ms" ".ss")))
 
-(define (get-test-suite x)
-  (or (if-exists x) (if-exists (string-append x ".ms"))))
-
 (define (path->file-uri path)
   (define (sanitize path)
     (join (map http:percent-encode (pregexp-split (re "[\\\\/]") path)) "/"))
@@ -683,7 +683,7 @@
       (lambda (files)
         (for-each add-suite! files)
         (lp (cdr specs)))]
-     [(get-test-suite (car specs)) =>
+     [(if-exists (car specs)) =>
       (lambda (suite)
         (let lp2 ([added? #f] [ls (cdr specs)])
           (match ls
@@ -692,7 +692,7 @@
              (add-test! suite test)
              (lp2 #t rest)]
             [(,test . ,rest)
-             (guard (not (or (directory? test) (get-test-suite test))))
+             (guard (not (or (directory? test) (if-exists test))))
              (add-test! suite test)
              (lp2 #t rest)]
             [,rest

--- a/src/swish/swish-test
+++ b/src/swish/swish-test
@@ -43,6 +43,11 @@
    [excl-tags --not (list "<tag>") "exclude tests with this tag"]
    [test-run --test-run (string "<UUID>")
     "use the specified <UUID> to identify the test run instead of generating one"]
+   [rerun --rerun (string "<type>")
+     (ct:join #\space
+       "rerun tests whose result type matches <type>, where <type> is"
+       "one of {pass|fail|skip} or a parenthesized Scheme list of those types;"
+       "here <spec> specifies test results in .ms.mo or .ss.mo files")]
    [specs (list . "<spec>") "directory | suite [{test | -t test} ...]"]))
 
 (define test-and-report-cli
@@ -220,7 +225,12 @@
        "run tests t1, t2, and t3 from ./src/foo.ms and all tests from src/bar.ms\n")
      (example (who " --tag fast --not regression src web")
        "run only the tests under src and web whose mat tags include fast,"
-       "but not regression.")])
+       "but not regression.\n")
+     (example (who " --rerun fail --not long src web/alt.ms.mo")
+       "rerun failed tests under src or in web/alt.ms"
+       "whose tags do not include long.\n")
+     (example (who " --rerun '(skip fail)' .")
+       "rerun tests under . that failed or were skipped.")])
   (let ([invalid (fold-right remq sections help-sections)])
     (unless (null? invalid)
       (fail "unrecognized help section~p:~{ ~a~}" (length invalid) invalid)))
@@ -241,7 +251,7 @@
           (match entry
             [(,fn . ,@DIRENT_DIR) (search (combine path fn) hits)]
             [(,fn . ,@DIRENT_FILE)
-             (if (member (path-extension fn) extensions)
+             (if (ormap (lambda (ext) (ends-with-ci? fn ext)) extensions)
                  (cons (combine path fn) hits)
                  hits)]
             [,_ hits])) ;; not following symlinks
@@ -595,7 +605,7 @@
 (define (if-exists fn) (and (regular-file? fn) fn))
 
 (define (get-test-files x)
-  (and (directory? x) (find-files x "ms" "ss")))
+  (and (directory? x) (find-files x ".ms" ".ss")))
 
 (define (get-test-suite x)
   (or (if-exists x) (if-exists (string-append x ".ms"))))
@@ -612,15 +622,52 @@
 
 (define-tuple <pre-spec> suite test)
 
+(define (get-rerun types x)
+  (cond
+   [(not types) #f]
+   [(null? types) '()]
+   [(directory? x) (extract-reruns types (find-files x ".ms.mo" ".ss.mo"))]
+   [(if-exists x) (extract-reruns types (list x))]
+   [else #f]))
+
+(define (extract-reruns types ls)
+  (define (add-pre-spec ls mr)
+    (if (not (memq (mat-result-type mr) types))
+        ls
+        (cons (<pre-spec> make
+                [suite (mat-result-test-file mr)]
+                [test (symbol->string (mat-result-test mr))])
+          ls)))
+  (let lp ([ls ls] [pre-specs '()])
+    (if (null? ls)
+        (reverse pre-specs)
+        (let ([results (get-results (car ls))])
+          (unless (json:ref results '(meta-data completed) #f)
+            (printf "Warning: ~a found incomplete results in ~a.\n"
+              (option-named 'rerun) (car ls)))
+          (lp (cdr ls)
+            (fold-left add-pre-spec pre-specs
+              (mat-data-results results)))))))
+
+(define (parse-rerun-type s)
+  (let* ([x (read (open-input-string s))]
+         [ls (if (list? x) x (list x))])
+    (cond
+     [(ormap (lambda (x) (and (not (memq x '(pass fail skip))) x)) ls) =>
+        (lambda (type)
+          (fail "invalid ~a type ~s" (option-named 'rerun) type))]
+     [else ls])))
+
 (define (extract-pre-specs specs)
   (define out (make-hashtable values =))
+  (define (add-pre-spec! pre-spec)
+    (hashtable-set! out (hashtable-size out) pre-spec))
   (define (add-suite! suite)
     (when (may-have-mats? suite)
-      (hashtable-set! out (hashtable-size out)
-        (<pre-spec> make [suite suite] [test #f]))))
+      (add-pre-spec! (<pre-spec> make [suite suite] [test #f]))))
   (define (add-test! suite test)
-    (hashtable-set! out (hashtable-size out)
-      (<pre-spec> make [suite suite] [test test])))
+    (add-pre-spec! (<pre-spec> make [suite suite] [test test])))
+  (define types (cond [(opt 'rerun) => parse-rerun-type] [else #f]))
   (let lp ([specs specs])
     (cond
      [(null? specs)
@@ -628,6 +675,10 @@
        (vector-map cdr
          (vector-sort (lambda (a b) (< (car a) (car b)))
            (hashtable-cells out))))]
+     [(get-rerun types (car specs)) =>
+      (lambda (pre-specs)
+        (for-each add-pre-spec! pre-specs)
+        (lp (cdr specs)))]
      [(get-test-files (car specs)) =>
       (lambda (files)
         (for-each add-suite! files)
@@ -650,17 +701,18 @@
      [else
       (fail "expected directory or suite: ~s" (car specs))])))
 
+(define (get-results from)
+  (match (catch (load-results from))
+    [#(EXIT ,reason)
+     (fail "cannot load mat results from ~a: ~a" from
+       (exit-reason->english reason))]
+    [,results results]))
+
 (define (harvest from*)
   (let ([ht (make-hashtable string-hash string=?)])
-    (define (get-results from)
-      (match (catch (load-results from))
-        [#(EXIT ,reason)
-         (fail "cannot load mat results from ~a: ~a" from
-           (exit-reason->english reason))]
-        [,results results]))
     (define (add! from)
       (if (directory? from)
-          (for-each add! (find-files from "mo"))
+          (for-each add! (find-files from ".ms.mo" ".ss.mo"))
           (hashtable-set! ht from (hashtable-size ht))))
     (for-each add! from*)
     (vector->list
@@ -732,6 +784,7 @@
         [excl-tags (map string->symbol (or (opt 'excl-tags) '()))]
         [exclude (or (opt 'exclude) '())]
         [include (or (opt 'include) '())]
+        [rerun (opt 'rerun)]
         [save-prof (opt 'save-prof)]
         [load-prof (opt 'load-prof)]
         [progress (cond [(opt 'progress) => string->symbol] [else #f])]
@@ -758,6 +811,14 @@
         (option-named 'harvest)
         (option-named 'load-results)
         (option-named 'files))]
+     [(and (opt 'rerun) (opt 'harvest))
+      (fail "~a conflicts with ~a"
+        (option-named 'rerun)
+        (option-named 'harvest))]
+     [(and (opt 'rerun) (opt 'load-results))
+      (fail "~a conflicts with ~a"
+        (option-named 'rerun)
+        (option-named 'load-results))]
      [(and (opt 'harvest) (pair? pre-specs))
       (fail "~a conflicts with ~a"
         (option-named 'harvest)

--- a/src/swish/swish-test
+++ b/src/swish/swish-test
@@ -901,7 +901,8 @@
                     (match (catch (profile:merge full-name))
                       [ok (void)]
                       [#(EXIT ,reason)
-                       (fail "cannot load profile data from ~a" user-supplied-name)]))))
+                       (fail "cannot load profile data from ~a: ~a" user-supplied-name
+                         (exit-reason->english reason))]))))
               (profile:stop))))]
        [save-prof (truncate-profile)])
       (let ([done (make-hashtable string-hash string=?)])

--- a/src/swish/swish-test
+++ b/src/swish/swish-test
@@ -670,9 +670,14 @@
     (define (add! from)
       (if (directory? from)
           (for-each add! (find-files from "mo"))
-          (hashtable-set! ht from #t)))
+          (hashtable-set! ht from (hashtable-size ht))))
     (for-each add! from*)
-    (vector->list (vector-map get-results (hashtable-keys ht)))))
+    (vector->list
+     (vector-map get-results
+       (vector-sort
+        (lambda (k1 k2)
+          (< (hashtable-ref ht k1 #f) (hashtable-ref ht k2 #f)))
+        (hashtable-keys ht))))))
 
 (define (option-named name)
   (format-spec

--- a/src/swish/swish-test.ms
+++ b/src/swish/swish-test.ms
@@ -434,7 +434,7 @@
     (format "~a *fail$" (pregexp-quote file3))))
   ;; test --harvest directory processing
   (let ([combined.json (path-combine (output-dir) "combined.json")])
-    (zero-exit
+    (nonzero-exit
      (swish-test "--report " combined.json " --harvest "
        (path-combine (output-dir) test-dir0))
      '("Tests run: 7   Pass: 6   Fail: 1   Skip: 0"))))
@@ -826,6 +826,13 @@
             (mat hangry () (throw 'tantrum))
             (mat deep () (flub 100 'deep))
             (mat shallow () (flub 1 "a fit")))))))
+  (define all-pass
+    (write-test-file "all-pass.ms"
+      (lambda ()
+        (for-each pretty-print
+          `((import (swish mat))
+            (mat one () (assert #t))
+            (mat two () (assert 'yes)))))))
   (define (check data test-name type tags message check-stack)
     (match-let*
      ([,results (mat-data-results data)]
@@ -847,6 +854,7 @@
   (define mo-path2 (string-append test-file2 ".mo"))
   (define mo-path3 (string-append test-file3 ".mo"))
   (define mo-path4 (string-append test-file4 ".mo"))
+  (define mo-all-pass (string-append all-pass ".mo"))
   (define (get-data content)
     (match-let* ([(,_ ,data) (pregexp-match "<script>var data = (.*);</script><script>\n  function escapeHtml" content)])
       (json:string->object data)))
@@ -856,6 +864,10 @@
   (define (find-test name obj)
     (find (lambda (r) (eq? name (mat-result-test r)))
       (mat-data-results obj)))
+  ;; case where all tests pass
+  (zero-exit (swish-test "--progress none " all-pass) '())
+  (zero-exit (swish-test "--progress none --harvest " mo-all-pass) '())
+  ;; case where some tests fail
   (nonzero-exit
    (swish-test "--progress none --report " report-file " " test-file)
    '())
@@ -996,6 +1008,8 @@
   (nonzero-exit
    (swish-test "--progress none --tag good --report " report-file1 " " test-file)
    '())
+  ;; same exit status when we harvest those results
+  (nonzero-exit (swish-test "--progress none --harvest " mo-path1) '())
   ;; check HTML report output
   (match-let*
    ([#t (file-exists? report-file1)]
@@ -1009,6 +1023,8 @@
   (zero-exit
    (swish-test "--progress none --tag good --report " report-file2 " " test-file " TEST1")
    '())
+  ;; same exit code when we --harvest those results [questionable but consistent]
+  (zero-exit (swish-test "--progress none --harvest " mo-path1) '())
   ;; check HTML report output
   (match-let*
    ([#t (file-exists? report-file2)]
@@ -1075,17 +1091,17 @@
      (swish-test "--progress none --not tag1 " test-file)
      '())
     ;; --harvest alone prints summary and incomplete notice
-    (zero-exit
+    (nonzero-exit
      (swish-test "--harvest " mo-path1 " " mo-path2 " " mo-path3 " " incomplete)
      summary-output)
     ;; --harvest for report also prints summary and incomplete notice
-    (zero-exit
+    (nonzero-exit
      (swish-test
       "--harvest " mo-path1 " " mo-path2 " " mo-path3 " " incomplete
       " --report " aggregate.json)
      summary-output)
     ;; --load-results alone prints summary and incomplete notice
-    (zero-exit
+    (nonzero-exit
      (swish-test "--load-results " aggregate.json)
      summary-output)
     (let ([expected
@@ -1095,13 +1111,13 @@
              ,(string-append (pregexp-quote "incomplete.ms") ".* no tests")
              ,@summary-output)])
       ;; --progress suite with --harvest
-      (zero-exit
+      (nonzero-exit
        (swish-test
         "--harvest " mo-path1 " " mo-path2 " " mo-path3 " " incomplete " "
         "--progress " "suite")
        expected)
       ;; --progress suite with --load-results
-      (zero-exit
+      (nonzero-exit
        (swish-test
         "--progress " "suite "
         "--load-results " aggregate.json)
@@ -1131,36 +1147,36 @@
              seek
              ,@summary-output)])
       ;; --progress test with --harvest
-      (zero-exit
+      (nonzero-exit
        (swish-test
         "--harvest " mo-path1 " " mo-path2 " " mo-path3 " " incomplete " "
         "--progress " "test")
        expected)
       ;; --progress test with --load-results
-      (zero-exit
+      (nonzero-exit
        (swish-test
         "--progress " "test "
         "--load-results " aggregate.json)
        expected))
     (let ([expected '(seek "Some test suite did not complete")])
       ;; --progress none with --harvest
-      (zero-exit
+      (nonzero-exit
        (swish-test
         "--harvest " mo-path1 " " mo-path2 " " mo-path3 " " incomplete " "
         "--progress " "none")
        expected)
       ;; --progress none with --load-results
-      (zero-exit
+      (nonzero-exit
        (swish-test
         "--progress " "none "
         "--load-results " aggregate.json)
        expected))
     ;; --load-results and --report generating HTML output prints same summary
-    (zero-exit
+    (nonzero-exit
      (swish-test "--load-results " aggregate.json " --report " aggregate.html)
      (cons "see file:.*aggregate.html" summary-output))
     ;; can generate same HTML report via --harvest and --report
-    (zero-exit
+    (nonzero-exit
      (swish-test
       "--harvest " mo-path1 " " mo-path2 " " mo-path3 " " incomplete
       " --report " alt.html)
@@ -1194,7 +1210,7 @@
                  [else (json:write op x 0)])
                 (f))))))
       (on-exit (delete-file fake-file)
-        (zero-exit
+        (nonzero-exit
          (swish-test
           "--harvest " mo-path1 " " mo-path2 " " mo-path3 " " incomplete
           " --info")
@@ -1202,7 +1218,7 @@
            "^$"
            ,(fmt info 'chezscheme)
            ,(fmt info 'swish)))
-        (zero-exit
+        (nonzero-exit
          (swish-test
           "--harvest " mo-path1 " " mo-path2 " " mo-path3 " " incomplete
           " " fake-file

--- a/src/swish/swish-test.ms
+++ b/src/swish/swish-test.ms
@@ -67,15 +67,15 @@
   (zero-exit (swish-test "--help")
     '("Usage:"
       seek
-      "progress <mode>"
+      "<spec> .* directory .* suite"
       seek
-      "<spec> .* directory .* suite"))
+      "progress <mode>"))
   (zero-exit (swish-test "-h all")
     '("Usage:"
       seek
-      "progress <mode>"
-      seek
       "<spec> .* directory .* suite"
+      seek
+      "progress <mode>"
       seek
       "By default,"
       seek
@@ -90,6 +90,8 @@
    '("swish-test Version (?:\\d+\\.){2}\\d+ \\([[:xdigit:]dirty-]+\\)")))
 
 (isolate-mat check-options ()
+  (nonzero-exit (swish-test "--progress pilgrim")
+    '() "invalid --progress pilgrim")
   (nonzero-exit (swish-test "--coverage foo")
     '() "--coverage requires --load-profile or --save-profile")
   ;; check for required options before complaining about missing file
@@ -1034,6 +1036,73 @@
     (zero-exit
      (swish-test "--load-results " aggregate.json)
      summary-output)
+    (let ([expected
+           `(,(string-append (pregexp-quote test-file) ".* fail")
+             ,(string-append (pregexp-quote test-file2) ".* no tests")
+             ,(string-append (pregexp-quote test-file3) ".* fail")
+             ,(string-append (pregexp-quote "incomplete.ms") ".* no tests")
+             ,@summary-output)])
+      ;; --progress suite with --harvest
+      (zero-exit
+       (swish-test
+        "--harvest " mo-path1 " " mo-path2 " " mo-path3 " " incomplete " "
+        "--progress " "suite")
+       expected)
+      ;; --progress suite with --load-results
+      (zero-exit
+       (swish-test
+        "--progress " "suite "
+        "--load-results " aggregate.json)
+       expected))
+    (let ([expected
+           `(,(pregexp-quote test-file)
+             seek
+             " pass .*TEST1"
+             " SKIP .*TEST2"
+             " FAIL .*TEST3"
+             seek
+             "Tests run: 2   Pass: 1   Fail: 1   Skip: 1"
+             seek
+             ,(pregexp-quote test-file2)
+             seek
+             "Tests run: 0   Pass: 0   Fail: 0   Skip: 0"
+             seek
+             ,(pregexp-quote test-file3)
+             seek
+             " FAIL .*zero"
+             seek
+             "Tests run: 1   Pass: 0   Fail: 1   Skip: 0"
+             seek
+             ,(pregexp-quote "incomplete.ms")
+             seek
+             "Tests run: 0   Pass: 0   Fail: 0   Skip: 0"
+             seek
+             ,@summary-output)])
+      ;; --progress test with --harvest
+      (zero-exit
+       (swish-test
+        "--harvest " mo-path1 " " mo-path2 " " mo-path3 " " incomplete " "
+        "--progress " "test")
+       expected)
+      ;; --progress test with --load-results
+      (zero-exit
+       (swish-test
+        "--progress " "test "
+        "--load-results " aggregate.json)
+       expected))
+    (let ([expected '(seek "Some test suite did not complete")])
+      ;; --progress none with --harvest
+      (zero-exit
+       (swish-test
+        "--harvest " mo-path1 " " mo-path2 " " mo-path3 " " incomplete " "
+        "--progress " "none")
+       expected)
+      ;; --progress none with --load-results
+      (zero-exit
+       (swish-test
+        "--progress " "none "
+        "--load-results " aggregate.json)
+       expected))
     ;; --load-results and --report generating HTML output prints same summary
     (zero-exit
      (swish-test "--load-results " aggregate.json " --report " aggregate.html)

--- a/src/swish/swish-test.ms
+++ b/src/swish/swish-test.ms
@@ -105,7 +105,19 @@
   (nonzero-exit (swish-test "--harvest . --progress none .")
     '() "--harvest conflicts with <file> ...")
   (nonzero-exit (swish-test "--load-results foo.json .")
-    '() "--load-results conflicts with <file> ..."))
+    '() "--load-results conflicts with <file> ...")
+  (nonzero-exit (swish-test "--rerun skip --load-results foo.json .")
+    '() "--rerun conflicts with --load-results")
+  (nonzero-exit (swish-test "--rerun pass --harvest .")
+    '() "--rerun conflicts with --harvest")
+  (nonzero-exit (swish-test "--rerun sitcom .")
+    '() "invalid --rerun type sitcom")
+  ;; using \t as separator instead of space since swish-test helper
+  ;; splits on space
+  (nonzero-exit (swish-test "--rerun (pass\tfail\tsurprise) .")
+    '() "invalid --rerun type surprise")
+  (nonzero-exit (swish-test "--test-run amok")
+    '() "invalid --test-run UUID amok"))
 
 (isolate-mat load-this ()
   (write-test-file "test-load-this.ss"
@@ -228,8 +240,9 @@
   )
 
 (isolate-mat select-tests ()
+  (define subdir (uuid->string (osi_make_uuid)))
   (define test-file
-    (write-test-file "test-specified.ms"
+    (write-test-file (path-combine subdir "test-specified.ms")
       (lambda ()
         (for-each pretty-print
           '((import (swish mat))
@@ -290,6 +303,14 @@
      "SKIP *a5"
      "[-]+"
      "Tests run: 3   Pass: 2   Fail: 1   Skip: 2"))
+  ;; rerun skipped tests
+  (zero-exit
+   (swish-test "--rerun skip " (string-append test-file ".mo"))
+   '(seek
+     "pass *a4"
+     "pass *a5"
+     "[-]+"
+     "Tests run: 2   Pass: 2   Fail: 0   Skip: 0"))
   ;; exclusion tags are additive
   (nonzero-exit
    (swish-test "--progress test --not triv --not silly " test-file)
@@ -301,6 +322,22 @@
      "SKIP *a5"
      "[-]+"
      "Tests run: 2   Pass: 1   Fail: 1   Skip: 3"))
+  ;; rerun tests that passed or failed
+  (nonzero-exit
+   ;; using \t here to work around the split on spaces in swish-test helper
+   (swish-test "--rerun (pass\tfail) " (string-append test-file ".mo"))
+   '(seek
+     "FAIL *a3"
+     "pass *a4"
+     "[-]+"
+     "Tests run: 2   Pass: 1   Fail: 1   Skip: 0"))
+  ;; rerun tests that failed
+  (nonzero-exit
+   (swish-test "--rerun fail " (string-append test-file ".mo"))
+   '(seek
+     "FAIL *a3"
+     "[-]+"
+     "Tests run: 1   Pass: 0   Fail: 1   Skip: 0"))
   ;; filter first by tags and then by exclusion tags
   ;; order on command-line doesn't matter
   (nonzero-exit
@@ -313,6 +350,21 @@
      "pass *a5"
      "[-]+"
      "Tests run: 3   Pass: 3   Fail: 0   Skip: 2"))
+  ;; rerun tests that were skipped, but respect the --not broken tag constraint
+  (nonzero-exit
+   (swish-test "--rerun skip --not broken " (string-append test-file ".mo"))
+   '(seek
+     "SKIP *a3"
+     "pass *a4"
+     "[-]+"
+     "Tests run: 1   Pass: 1   Fail: 0   Skip: 1"))
+  ;; rerun skipped tests in a specified directory
+  (nonzero-exit
+   (swish-test "--rerun skip " (path-parent test-file))
+   '(seek
+     "FAIL *a3"
+     "[-]+"
+     "Tests run: 1   Pass: 0   Fail: 1   Skip: 0"))
   ;; if any test fails, suite summary shows fail
   (nonzero-exit
    (swish-test "--progress suite --tag broken --tag silly " test-file)


### PR DESCRIPTION
**Proposed changes**

Add `swish-test` options to make it easier for folks to generate a text-based summary of prior test results or to re-run prior tests that failed or were skipped. Handle limited (current-user) form of tilde expansion for filesystem operations.

* `swish-test`: allow `--progress` in combination with `--harvest` or `--load-results`.
* `swish-test`: add `--rerun` option
* `swish-test`: include exit reason when reporting failure to load profile data
* add `osi_get_home_directory`
* support `~` and paths with `~/` prefix in filesystem procedures

