### PR TITLE
swish-test: preserve stdout / stderr

### DIFF
--- a/src/swish/swish-test.ms
+++ b/src/swish/swish-test.ms
@@ -376,7 +376,8 @@
   ;; failure exit code if specified test not found
   (nonzero-exit
    (swish-test "--progress test " test-file " this-test-does-not-exist")
-   '(seek "Exception in run-mat: mat this-test-does-not-exist is not defined"))
+   '(seek "*** Some test suite did not complete ***")
+   "Exception in run-mat: mat this-test-does-not-exist is not defined")
   ;; if all *specified* tests pass, show pass, exit code zero
   (zero-exit
    (swish-test "--progress suite " test-file " a1 a2 a4")
@@ -1644,8 +1645,5 @@
      "Tests run: 1   Pass: 1   Fail: 0   Skip: 0"))
   (nonzero-exit
    (swish-test test-file)
-   (map pregexp-quote
-     (list
-      "Exception: library (help) not found"
-      ""
-      (format "Test Failed: ~a" test-file)))))
+   `(seek ,(pregexp-quote (format "Test Failed: ~a" test-file)))
+   (pregexp-quote "Exception: library (help) not found")))

--- a/src/swish/testing.ss
+++ b/src/swish/testing.ss
@@ -257,7 +257,7 @@
       (let ([to-stdin (binary->utf8 to-stdin)]
             [from-stdout (binary->utf8 from-stdout)]
             [from-stderr (binary->utf8 from-stderr)])
-        (define (spawn-handler pid tag ip)
+        (define (spawn-handler pid tag ip op)
           (define lines '())
           (define (spawn-drain handle-input)
             (spawn&link
@@ -272,12 +272,12 @@
           (define (print)
             (let ([c (read-char ip)])
               (unless (eof-object? c)
-                (write-char c)
-                (flush-output-port)
+                (write-char c op)
+                (flush-output-port op)
                 (print))))
           (spawn-drain (if (memq tag redirected) print collect-lines)))
-        (spawn-handler self 'stdout from-stdout)
-        (spawn-handler self 'stderr from-stderr)
+        (spawn-handler self 'stdout from-stdout (current-output-port))
+        (spawn-handler self 'stderr from-stderr (current-error-port))
         (on-exit (begin (close-output-port to-stdin)
                         (close-input-port from-stdout)
                         (close-input-port from-stderr))


### PR DESCRIPTION
**Fixes**

`swish-test` was sending both `stdout` and `stderr` to `stdout`.

**Proposed changes**

Preserve separate output ports in the handler that drains output from spawned OS processes.