### PR TITLE
Documentation updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ check-astyle:
 	@(astyle --project $$(git ls-files '*.c' '*.h' | grep -v 'sqlite3'))
 
 check-docs: src/swish/Makefile
-	@(cd src; ./go check-docs -uD -e '^osi_.*\*' -e '^[A-Z_]+' -e '^\$$[a-z-]+' -e '^event-mgr:unregister' ../doc)
+	@(cd src; ./go check-docs -uD -e '^osi_.*\*' -e '^[A-Z_]+' -e '^\$$[a-z-]+' -e '^event-mgr:unregister' ..)
 
 install: swish doc
 	$(MAKE) -C src/swish install

--- a/doc/scheme-coding-standard.tex
+++ b/doc/scheme-coding-standard.tex
@@ -232,13 +232,13 @@ path through \code{f}.
 \codebegin
 (define (f x)
   (if (eq? x 'old-school)
-      (catch \(e\sb{0}\) \ldots \(e\sb{n}\))
-      (try \(e\sb{0}\) \ldots \(e\sb{n}\))))
+      (catch \(e\sb{0}\) \etc{} \(e\sb{n}\))
+      (try \(e\sb{0}\) \etc{} \(e\sb{n}\))))
 (define (g x)
   (match (f x)
     [`(catch fire ,e) (throw 'water e)]
     [`(catch ,_ ,e) (throw e)]
-    \ldots))
+    \etc))
 \codeend
 
 \subsection* {Know when to use \texttt{eq?}, \texttt{eqv?},

--- a/doc/swish.tex
+++ b/doc/swish.tex
@@ -31,7 +31,7 @@
 \begin{document}
 \begin{sagianbook}{The Swish Concurrency Engine\\
     Version \input{../src/swish/swish-version.include}}{Bob Burger,
-    editor}{\copyright\ 2018-2022 Beckman Coulter, Inc.
+    editor}{\copyright\ 2018-2023 Beckman Coulter, Inc.
     Licensed under the \href{https://opensource.org/licenses/MIT}{MIT License}.}
 
 \input{swish/chapters}

--- a/doc/swish/app.tex
+++ b/doc/swish/app.tex
@@ -513,7 +513,7 @@ be passed to \code{log-db:setup} when the \code{log-db} gen-server is started.
 
 \defineentry{swish-start}
 \begin{procedure}
-  \code{(swish-start \var{arg} \ldots)}
+  \code{(swish-start \var{arg} \etc)}
 \end{procedure}
 \returns{} see below
 
@@ -681,13 +681,13 @@ containing the application configuration file name returned by \code{app:config-
 
 \defineentry{define-foreign}
 \begin{syntax}
-  \code{(define-foreign \var{name} (\var{arg-name} \var{arg-type}) ...)}
+  \code{(define-foreign \var{name} (\var{arg-name} \var{arg-type}) \etc)}
 \end{syntax}
 \expandsto{} \antipar\codebegin
 (begin
-  (define \var{name}* (foreign-procedure (symbol->string '\var{name}) (\var{arg-type} ...) ptr))
-  (define (\var{name} \var{arg-name} ...)
-    (match (\var{name}* \var{arg-name} ...)
+  (define \var{name}* (foreign-procedure (symbol->string '\var{name}) (\var{arg-type} \etc) ptr))
+  (define (\var{name} \var{arg-name} \etc)
+    (match (\var{name}* \var{arg-name} \etc)
       [(,who . ,err)
        (guard (symbol? who))
        (io-error '\var{name} who err)]

--- a/doc/swish/application.tex
+++ b/doc/swish/application.tex
@@ -49,11 +49,12 @@ returns \code{\#(ok \var{process})}. If $r$ = \code{\#(error
 \genserver{application}{terminate} The application \code{terminate}
 procedure shuts down \var{process}. When \var{process} is not
 \code{\#f}, it kills \var{process} with reason \code{shutdown} and
-waits indefinitely for it to terminate. Then it calls
-\code{(exit-process \var{exit-code})}, where \var{exit-code} is
-initially 2 but set to the value passed to
-\code{application:shutdown}. In this way, the exit code can be used
-to determine if the application shut down normally.
+waits indefinitely for it to terminate. It flushes the console
+output and error ports, ignoring any exceptions, and then calls
+\code{(osi\_exit \var{exit-code})}, where \var{exit-code} is initially
+2 but set to the value passed to \code{application:shutdown}. In this
+way, the exit code can be used to determine if the application shut
+down normally.
 
 \genserver{application}{handle-call} The application
 \code{handle-call} procedure raises an exception on all messages.
@@ -69,16 +70,6 @@ to determine if the application shut down normally.
   \var{process}, return \code{\#(stop \var{reason} \#f)}. Otherwise,
   return \code{\#(stop \var{reason} \var{process})}.
 \end{itemize}
-
-\index{application!exit-process@\code{exit-process}}
-\begin{procedure}
-  \code{(exit-process \var{exit-code})}
-\end{procedure}
-\returns{} never
-
-The \code{exit-process} procedure flushes the console output and error
-ports, ignoring any exceptions, and then calls \code{(osi\_exit
-  \var{exit-code})}.
 
 \section {Programming Interface}
 
@@ -107,6 +98,6 @@ The \code{application:shutdown} procedure kills the
 procedure does not wait for the \code{application} process to
 terminate so that it can be called from a process managed by the
 supervision hierarchy without causing a deadlock on shutdown. If the
-\code{application} process does not exist,
-\code{application:shutdown} calls \code{(exit-process
-  \var{exit-code})}.
+\code{application} process does not exist, \code{application:shutdown}
+flushes the console output and error ports, ignoring any exceptions,
+and then calls \code{(osi\_exit \var{exit-code})}.

--- a/doc/swish/cli.tex
+++ b/doc/swish/cli.tex
@@ -298,8 +298,8 @@ around optional arguments. A \var{how} of \code{\#f} defaults to the
     \code{count} & \code{\#f}\\
     \code{(string \var{x})} & \str{x}\\
     \code{(list \var{x})} & \str{x}\\
-    \code{(list \var{x} ...)} & \str{x ...}\\
-    \code{(list . \var{x})} & \str{x ...}\\
+    \code{(list \var{x} ...)} & \str{x \etc}\\
+    \code{(list . \var{x})} & \str{x \etc}\\
     \hline
   \end{tabular}
   \end{minipage}\\

--- a/doc/swish/db.tex
+++ b/doc/swish/db.tex
@@ -352,7 +352,7 @@ The \code{db:stop} procedure calls \code{(gen-server:call
 \expandsto{} \antipar\begin{alltt}
 (let ([\var{db} (sqlite:open \var{filename} \var{flags})])
   (on-exit (sqlite:close \var{db})
-    \var{body\(\sb{1}\)} \var{body\(\sb{2}\)} ...))
+    \var{body\(\sb{1}\)} \var{body\(\sb{2}\)} \etc))
 \end{alltt}
 
 The \code{with-db} macro opens the database in \var{filename},

--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -28,7 +28,7 @@ This chapter describes the design of the message-passing concurrency
 model. It provides a Scheme embedding of a significant subset of the
 Erlang programming
 language~\cite{armstrong-thesis,programming-erlang}.\footnote{Tuples,
-  denoted by \{$e_1$, \ldots, $e_n$\} in Erlang, are implemented as
+  denoted by \{$e_1$, \etc, $e_n$\} in Erlang, are implemented as
   vectors: \code{\#(\var{e$_1$}~\etc~\var{e$_n$})}. Similarly
   records, defined as syntactic sugar over tuples in Erlang, are
   implemented as syntactic sugar over vectors.}  Tuple and pattern
@@ -856,7 +856,7 @@ into arguments for \var{handle-field}:
   \code{,\var{field}} & \var{field} & \var{field} & \code{()} & \var{field} must be an identifier \\
   \code{,@\var{field}} & \var{field} & \var{unique} & \code{()} & \var{field} must be an identifier \\
   \code{[\var{field} \var{pattern} \var{option} \etc{}]} &
-    \var{field} & \var{unique} & \code{(\var{option} ...)} &
+    \var{field} & \var{unique} & \code{(\var{option} \etc)} &
     \var{unique} is matched against \var{pattern} \\
 \end{tabular}
 
@@ -1129,15 +1129,15 @@ for each foreign-handle type registered with \code{make-foreign-handle-guardian}
 % ----------------------------------------------------------------------------
 \defineentry{arg-check}
 \begin{syntax}
-  \code{(arg-check \var{who} [\var{arg} \var{pred} \ldots] \ldots)}
+  \code{(arg-check \var{who} [\var{arg} \var{pred} \etc] \etc)}
 \end{syntax}
 \expandsto{}\begin{alltt}\antipar
 (let ([who \var{who}])
   (let ([arg \var{arg}])
-    (unless (and (pred arg) \ldots)
+    (unless (and (pred arg) \etc)
       (profile-me-as arg-check)
       (bad-arg who arg)))
-  \ldots
+  \etc
   (void))\end{alltt}
 
 The \code{arg-check} macro raises a \code{bad-arg} exception if
@@ -3307,7 +3307,7 @@ condition within the compound condition it constructs.
 % ----------------------------------------------------------------------------
 \defineentry{with-temporaries}
 \begin{syntax}
-  \code{(with-temporaries (\var{id} ...) e0 e1 ...)}
+  \code{(with-temporaries (\var{id} \etc) e0 e1 \etc)}
 \end{syntax}
 \expandsto{}\begin{alltt}\antipar
 (with-syntax ([(id ...) (generate-temporaries '(id ...))])
@@ -3315,4 +3315,4 @@ condition within the compound condition it constructs.
 
 The \code{with-temporaries} macro binds each macro-language
 pattern variable \var{id} to a fresh generated identifier
-within the body \code{(begin \var{e0}\ \var{e1}\ ...)}.
+within the body \code{(begin \var{e0}\ \var{e1}\ \etc)}.

--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -1146,6 +1146,22 @@ Within coverage reports, profile counts on the \code{arg-check}
 keyword indicate the number of \code{bad-arg} cases encountered.
 
 % ----------------------------------------------------------------------------
+\defineentry{procedure/arity?}
+\begin{procedure}
+  \code{(procedure/arity? \var{mask} \opt{\var{obj}})}
+\end{procedure}
+\returns{} see below
+
+If both arguments are supplied, \code{procedure/arity?} returns true if
+\var{obj} is a procedure that supports all of the argument counts specified by
+\var{mask}.
+If only the \var{mask} is supplied, then \code{procedure/arity?}
+returns a procedure \code{(lambda (p) (procedure/arity? \var{mask} p))}
+suitable for use with \code{andmap} or \code{arg-check}, for example.
+In either case \var{mask} must be an exact integer bitmask of the
+form returned by \code{procedure-arity-mask}.
+
+% ----------------------------------------------------------------------------
 \defineentry{bad-arg}
 \begin{procedure}
   \code{(bad-arg \var{who} \var{arg})}

--- a/doc/swish/gen-server.tex
+++ b/doc/swish/gen-server.tex
@@ -138,8 +138,9 @@ process and yield \code{\#(error \#(bad-return-value \var{other}))}.
   \#(error \var{error})\alt{}%
   ignore}
 
-\code{gen-server:start} behaves the same as \code{start\&link}
-except that it does not link to the calling process.
+\code{gen-server:start} behaves the same as
+\code{gen-server:start\&link} except that it does not link to the
+calling process.
 
 \defineentry{gen-server:enter-loop}
 \begin{syntax}

--- a/doc/swish/gen-server.tex
+++ b/doc/swish/gen-server.tex
@@ -98,7 +98,7 @@ up. Timeouts during initialization should be considered carefully.
 
 \code{gen-server:start\&link} spawns the server process, links to
 the calling process, registers the server process as \var{name}, and calls
-\code{(init \var{arg} ...)} within that process. To ensure a
+\code{(init \var{arg} \etc)} within that process. To ensure a
 synchronized startup procedure, \code{gen-server:start\&link} does
 not return until \code{init} has returned.
 

--- a/doc/swish/http.tex
+++ b/doc/swish/http.tex
@@ -308,11 +308,11 @@ used:
 
 \defineentry{http:add-server}
 \begin{syntax}
-  \code{(http:add-server \var{arg} \ldots)}
+  \code{(http:add-server \var{arg} \etc)}
 \end{syntax}
 
 The \code{http:add-server} macro expands to code that appends the
-result of \code{(http:configure-server \var{arg} \ldots)} to the
+result of \code{(http:configure-server \var{arg} \etc)} to the
 \code{app-sup-spec} parameter.
 
 \defineentry{http:configure-file-server}
@@ -333,11 +333,11 @@ defaults to one constructed via
 
 \defineentry{http:add-file-server}
 \begin{syntax}
-  \code{(http:add-file-server \var{arg} \ldots)}
+  \code{(http:add-file-server \var{arg} \etc)}
 \end{syntax}
 
 The \code{http:add-file-server} macro expands to code that appends the
-result of \code{(http:configure-file-server \var{arg} \ldots)} to the
+result of \code{(http:configure-file-server \var{arg} \etc)} to the
 \code{app-sup-spec} parameter.
 
 \defineentry{http:make-default-file-url-handler}
@@ -836,20 +836,20 @@ HTML. The transformation, $H$, is described below:
   \code{\#!void} & nothing\\
   \code{\var{string}} & $E(\var{string})$\\
   \code{\var{number}} & \var{number}\\
-  \code{(begin \var{pattern} \ldots)} & $H(\var{pattern})$\ldots\\
-  \code{(cdata \var{string} \ldots)} &
-  \code{[!CDATA[\var{string}$\ldots$]]}\\
-  \code{(html5 \opt{(@ \var{attr} \ldots)} \var{pattern} \ldots)} &
-  \code{<!DOCTYPE html><html $A(\var{attr})$ $\ldots$>$H(\var{pattern})\ldots$</html>}\\
-  \code{(raw \var{string} \ldots)} & \var{string}$\ldots$\\
-  \code{(script \opt{(@ \var{attr} \ldots)} \var{string} \ldots)} &
-  \code{<script $A(\var{attr})$ $\ldots$>\var{string}$\ldots$</script>}\\
-  \code{(style \opt{(@ \var{attr} \ldots)} \var{string} \ldots)} &
-  \code{<style $A(\var{attr})$ $\ldots$>\var{string}$\ldots$</style>}\\
-  \code{(\var{tag} \opt{(@ \var{attr} \ldots)} \var{pattern} \ldots)} &
-  \code{<\var{tag} $A(\var{attr})$ $\ldots$>$H(\var{pattern})\ldots$</\var{tag}>}\\
-  \code{(\var{void-tag} \opt{(@ \var{attr} \ldots)})} &
-  \code{<\var{void-tag} $A(\var{attr})$ $\ldots$>}\\
+  \code{(begin \var{pattern} \etc)} & $H(\var{pattern})$\etc\\
+  \code{(cdata \var{string} \etc)} &
+  \code{[!CDATA[\var{string}$\etc$]]}\\
+  \code{(html5 \opt{(@ \var{attr} \etc)} \var{pattern} \etc)} &
+  \code{<!DOCTYPE html><html $A(\var{attr})$ $\etc$>$H(\var{pattern})\etc$</html>}\\
+  \code{(raw \var{string} \etc)} & \var{string}$\etc$\\
+  \code{(script \opt{(@ \var{attr} \etc)} \var{string} \etc)} &
+  \code{<script $A(\var{attr})$ $\etc$>\var{string}$\etc$</script>}\\
+  \code{(style \opt{(@ \var{attr} \etc)} \var{string} \etc)} &
+  \code{<style $A(\var{attr})$ $\etc$>\var{string}$\etc$</style>}\\
+  \code{(\var{tag} \opt{(@ \var{attr} \etc)} \var{pattern} \etc)} &
+  \code{<\var{tag} $A(\var{attr})$ $\etc$>$H(\var{pattern})\etc$</\var{tag}>}\\
+  \code{(\var{void-tag} \opt{(@ \var{attr} \etc)})} &
+  \code{<\var{void-tag} $A(\var{attr})$ $\etc$>}\\
 
   \hline
 \end{tabular}

--- a/doc/swish/pregexp.tex
+++ b/doc/swish/pregexp.tex
@@ -117,7 +117,7 @@ Otherwise it expands into a run-time call to \code{pregexp}.
 \begin{procedure}
   \code{(pregexp-match-positions \var{pat} \var{str} \opt{\var{start} \opt{\var{end}}})}
 \end{procedure}
-\returns{} \code{((\var{s}~.~\var{e}) \ldots)} or \code{\#f}
+\returns{} \code{((\var{s}~.~\var{e}) \etc)} or \code{\#f}
 
 The \code{pregexp-match-positions} procedure takes a regexp pattern
 \var{pat} and a text string \var{str} and returns a \emph{match} if
@@ -278,7 +278,7 @@ It also matches \code{pat}, \code{pit}, \code{pot}, \code{put}, and
 
 A \emph{character class} matches any one character from a set of
 characters. A typical format for this is the \emph{bracketed character
-  class} \code{[}\ldots\code{]}, which matches any one character from
+  class} \code{[}\etc\code{]}, which matches any one character from
 the non-empty sequence of characters enclosed within the
 brackets.\footnote{Requiring a bracketed character class to be
   non-empty is not a limitation, since an empty character class can be
@@ -349,7 +349,7 @@ lower-case letter or a digit.
 \subsubsection {POSIX Character Classes}
 
 A \emph{POSIX character class} is a special metasequence of the form
-\code{[:}\ldots\code{:]} that can be used only inside a bracketed
+\code{[:}\etc\code{:]} that can be used only inside a bracketed
 expression. The POSIX classes supported are:
 
 \begin{center}\begin{tabular}{ll}
@@ -472,7 +472,7 @@ the two uses of the metacharacter \code{?}.
 \subsection {Clusters}
 
 \emph{Clustering}, i.e., enclosure within parentheses
-\code{(}\ldots\code{)}, identifies the enclosed subpattern as a single
+\code{(}\etc\code{)}, identifies the enclosed subpattern as a single
 entity.  It causes the matcher to \emph{capture} the \emph{submatch},
 or the portion of the string matching the subpattern, in addition to
 the overall match.
@@ -745,7 +745,7 @@ fail to yield an overall match.
 Sometimes it is efficient to disable backtracking.  For example, we
 may wish to \emph{commit} to a choice, or we know that trying
 alternatives is fruitless.  A non-backtracking regexp is enclosed in
-\code{(?>}\ldots\code{)}.
+\code{(?>}\etc\code{)}.
 
 \code{(pregexp-match "(?>a+)." "aaaa")} $\Rightarrow$ \code{\#f}
 

--- a/doc/swish/undocumented.tex
+++ b/doc/swish/undocumented.tex
@@ -1,0 +1,6 @@
+% use \defineentry so that check-docs sees this stub documentation
+% and does not complain about missing documentation for these entries.
+
+The following are deliberately undocumented:
+
+\defineentry{reset-console-event-handler}

--- a/src/check-docs
+++ b/src/check-docs
@@ -37,23 +37,23 @@
 
 (define opt (parse-command-line-arguments cli))
 
-(define (find-files path . extensions)
-  (define (combine path fn) (if (equal? "." path) fn (path-combine path fn)))
-  (let search ([path path] [hits '()])
-    (match (catch (list-directory path))
-      [#(EXIT ,reason) hits]
-      [,found
-       (fold-left
-        (lambda (hits entry)
-          (match entry
-            [(,fn . ,@DIRENT_DIR) (search (combine path fn) hits)]
-            [(,fn . ,@DIRENT_FILE)
-             (if (member (path-extension fn) extensions)
-                 (cons (combine path fn) hits)
-                 hits)]
-            [,_ hits])) ;; not following symlinks
-        hits
-        found)])))
+(define (git-ls-files root pattern)
+  (define me self)
+  (let-values ([(to-stdin from-stdout from-stderr os-pid)
+                (spawn-os-process "git" `("ls-files" ,(path-combine root pattern)) me)])
+    (spawn&link
+     (lambda ()
+       (let ([ip (binary->utf8 from-stdout)])
+         (let lp ([ls '()])
+           (match (get-line ip)
+             [#!eof (send me `#(lines ,(reverse ls)))]
+             [,line (lp (cons line ls))])))))
+    (receive (after 10000 (throw 'timeout))
+      [#(process-terminated ,@os-pid ,exit-status ,_)
+       (unless (zero? exit-status)
+         (errorf 'git-ls-files "failed:\n~a"
+           (get-string-all (binary->utf8 from-stderr))))
+       (receive [#(lines ,ls) ls])])))
 
 (define exclude?
   (cond
@@ -126,7 +126,7 @@
       (or (opt 'libraries) '("(swish imports)")))
     (for-each
      (lambda (filename)
-       (let ([file.h (path-combine dir ".." "src" "swish" filename)])
+       (let ([file.h (path-combine dir "src" "swish" filename)])
          (when (and (not (opt 'libraries)) (file-regular? file.h))
            (for-each-regex-match file.h C-export-regex
              (lambda (entry)
@@ -138,7 +138,7 @@
          (for-each-regex-match fullname entry-regex
            (lambda (entry)
              (update-entry! exports (dequote (detex entry)) file)))))
-     (find-files dir "tex"))
+     (git-ls-files (path-combine dir "doc" "swish") "*.tex"))
     (let ([partitions (make-hashtable symbol-hash eq?)])
       (vector-for-each
        (lambda (e)

--- a/src/swish/boot.ss
+++ b/src/swish/boot.ss
@@ -1,3 +1,25 @@
+;;; Copyright 2018 Beckman Coulter, Inc.
+;;;
+;;; Permission is hereby granted, free of charge, to any person
+;;; obtaining a copy of this software and associated documentation
+;;; files (the "Software"), to deal in the Software without
+;;; restriction, including without limitation the rights to use, copy,
+;;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;;; of the Software, and to permit persons to whom the Software is
+;;; furnished to do so, subject to the following conditions:
+;;;
+;;; The above copyright notice and this permission notice shall be
+;;; included in all copies or substantial portions of the Software.
+;;;
+;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;;; DEALINGS IN THE SOFTWARE.
+
 (import (swish app))
 (eval '(let () (import (swish internal)) ($import-internal)))
 (suppress-greeting #t)

--- a/src/swish/meta.ms
+++ b/src/swish/meta.ms
@@ -1,3 +1,25 @@
+;;; Copyright 2018 Beckman Coulter, Inc.
+;;;
+;;; Permission is hereby granted, free of charge, to any person
+;;; obtaining a copy of this software and associated documentation
+;;; files (the "Software"), to deal in the Software without
+;;; restriction, including without limitation the rights to use, copy,
+;;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;;; of the Software, and to permit persons to whom the Software is
+;;; furnished to do so, subject to the following conditions:
+;;;
+;;; The above copyright notice and this permission notice shall be
+;;; included in all copies or substantial portions of the Software.
+;;;
+;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;;; DEALINGS IN THE SOFTWARE.
+
 (import (swish mat) (swish testing))
 
 ;; TODO remove if replace-source is accepted upstream

--- a/src/swish/software-info.ss
+++ b/src/swish/software-info.ss
@@ -1,3 +1,25 @@
+;;; Copyright 2018 Beckman Coulter, Inc.
+;;;
+;;; Permission is hereby granted, free of charge, to any person
+;;; obtaining a copy of this software and associated documentation
+;;; files (the "Software"), to deal in the Software without
+;;; restriction, including without limitation the rights to use, copy,
+;;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;;; of the Software, and to permit persons to whom the Software is
+;;; furnished to do so, subject to the following conditions:
+;;;
+;;; The above copyright notice and this permission notice shall be
+;;; included in all copies or substantial portions of the Software.
+;;;
+;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;;; DEALINGS IN THE SOFTWARE.
+
 #!chezscheme
 (library (swish software-info)
   (export


### PR DESCRIPTION
* add missing copyright notices
* update the copyright notice in swish.tex
* make the check-doc target more precise and provide a way to mark things as explicitly undocumented
* add missing documentation for `procedure/arity?`
* update documentation that referred to `exit-process`, which is not exported
* fix typo
* use `\etc{}` for meta-language ellipses