### PR TITLE
Database updates

### DIFF
--- a/doc/swish/db.tex
+++ b/doc/swish/db.tex
@@ -335,6 +335,18 @@ The \code{db:start\&link} procedure may return an \var{error} of
   \var{error} \var{filename})}, where \var{error} is a SQLite error
 pair.
 
+\defineentry{db:start}
+\begin{procedure}
+  \code{(db:start \var{name} \var{filename} \var{mode} \opt{\var{db-init}})}\\
+  \code{(db:start \var{name} \var{filename} \var{mode} \opt{\var{db-options}})}
+\end{procedure}
+\returns{}
+\code{\#(ok \var{pid})} $|$
+\code{\#(error \var{error})}
+
+\code{db:start} behaves the same as \code{db:start\&link} except that
+it does not link to the calling process.
+
 \defineentry{db:stop}
 \begin{procedure}
   \code{(db:stop \var{who})}

--- a/src/swish/db.ms
+++ b/src/swish/db.ms
@@ -416,6 +416,8 @@
     [,@stmts-before (statement-count)]
     [#(EXIT #(bad-arg db:start&link "options"))
      (catch (db:start&link #f ":memory:" 'open "options"))]
+    [#(EXIT #(bad-arg db:start "options"))
+     (catch (db:start #f ":memory:" 'open "options"))]
     [,name (gensym)]
     [,_
      (db:start&link name ":memory:" 'open
@@ -652,32 +654,55 @@
     (assert (handle-gone? (g)))))
 
 (db-mat db-open ()
+  (define (test starter)
+    (match-let*
+     ([,filename
+       (make-directory-path
+        (path-combine (data-dir) "test-db.db3"))]
+      [#(ok ,file) (starter #f filename 'create)]
+      [#(ok ,tmp) (starter #f "" 'create)]
+      [#(ok ,mem) (starter #f ":memory:" 'create)]
+      [#(ok ,shared1) (starter #f "file::memory:?cache=shared" 'create)]
+      [#(ok ,shared2) (starter #f "file::memory:?cache=shared" 'create)]
+      [#(ok ,init)
+       (starter #f ":memory:" 'create
+         (let ([me self])
+           (lambda (db)
+             (send me `#(init ,(execute-sql db "pragma journal_mode"))))))]
+      [#(init (#("memory"))) (receive (after 1000 (throw 'timeout)) [,x x])])
+
+     ;; Verify in-memory using shared cache connects to same data
+     (transaction shared1
+       (execute "CREATE TABLE table1 (col1, col2, col3)")
+       (execute "INSERT INTO table1 (col1, col2, col3) VALUES(?,?,?)" 1 2 3))
+     (match-let*
+      ([(#(1 2 3))
+        (transaction shared2 (execute "SELECT col1, col2, col3 FROM table1"))])
+
+      (for-each db:stop (list file tmp mem shared1 shared2 init))
+      (catch (remove-file filename)))))
+  (test db:start&link)
+  (test db:start))
+
+(db-mat db-link ()
+  ;; Start a db gen-server and monitor it. Send a nonsense message that
+  ;; causes handle-info to fail. Verify the server is linked
+  ;; appropriately.
+  (define (test starter)
+    (match-let*
+     ([#(ok ,pid) (starter #f ":memory:" 'create)]
+      [,m (monitor pid)]
+      [,nonsense (gensym "nonsense")])
+     (send pid nonsense)
+     (receive (after 1000 'timeout)
+       [`(EXIT ,@pid #(bad-match ,@nonsense ,_)) 'linked]
+       [`(DOWN ,@m ,@pid ,reason) 'not-linked]
+       [`(EXIT ,@pid ,reason) reason])))
+  (process-trap-exit #t)
   (match-let*
-   ([,filename
-     (make-directory-path
-      (path-combine (data-dir) "test-db.db3"))]
-    [#(ok ,file) (db:start&link #f filename 'create)]
-    [#(ok ,tmp) (db:start&link #f "" 'create)]
-    [#(ok ,mem) (db:start&link #f ":memory:" 'create)]
-    [#(ok ,shared1) (db:start&link #f "file::memory:?cache=shared" 'create)]
-    [#(ok ,shared2) (db:start&link #f "file::memory:?cache=shared" 'create)]
-    [#(ok ,init)
-     (db:start&link #f ":memory:" 'create
-       (let ([me self])
-         (lambda (db)
-           (send me `#(init ,(execute-sql db "pragma journal_mode"))))))]
-    [#(init (#("memory"))) (receive (after 1000 (throw 'timeout)) [,x x])])
-
-   ;; Verify in-memory using shared cache connects to same data
-   (transaction shared1
-     (execute "CREATE TABLE table1 (col1, col2, col3)")
-     (execute "INSERT INTO table1 (col1, col2, col3) VALUES(?,?,?)" 1 2 3))
-   (match-let*
-    ([(#(1 2 3))
-      (transaction shared2 (execute "SELECT col1, col2, col3 FROM table1"))])
-
-    (db:stop file)
-    (catch (remove-file filename)))))
+   ([linked (test db:start&link)]
+    [not-linked (test db:start)])
+   'ok))
 
 (db-mat retry ()
   (capture-events)

--- a/src/swish/log-db.ss
+++ b/src/swish/log-db.ss
@@ -499,7 +499,23 @@
         (set-session-id! (+ (or id 0) 1)))
 
       (execute "drop view if exists child")
-      (execute "create view child as select T1.rowid as rowid, T1.pid as id, T1.name, T1.supervisor, T1.restart_type, T1.type, T1.shutdown, T1.timestamp as start, T2.timestamp - T1.timestamp as duration, T2.killed, T2.reason, T2.details from child_start T1 left outer join child_end T2 on T1.pid=T2.pid")
+      (execute
+       (ct:join #\space
+         "create view child as select"
+         "T1.rowid as rowid,"
+         "T1.pid as id,"
+         "T1.name,"
+         "T1.supervisor,"
+         "T1.restart_type,"
+         "T1.type,"
+         "T1.shutdown,"
+         "T1.timestamp as start,"
+         "T2.timestamp as end,"
+         "T2.timestamp - T1.timestamp as duration,"
+         "T2.killed,"
+         "T2.reason,"
+         "T2.details"
+         "from child_start T1 left outer join child_end T2 on T1.pid=T2.pid"))
 
       (create-prune-on-insert-triggers
        (child_end timestamp)


### PR DESCRIPTION
* Add `db:start` that does not explicitly `link` with the calling process
* Add end time to the `child` view


