### PR TITLE
Fix memory leaks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 *.h linguist-language=C
 *.ms linguist-language=Scheme
 *.sql linguist-language=SQL
-src/swish/sqlite3.c linguist-vendored=true
-src/swish/sqlite3.h linguist-vendored=true
+sqlite/sqlite3.c linguist-vendored=true
+sqlite/sqlite3.h linguist-vendored=true

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ check-astyle:
 check-docs: src/swish/Makefile
 	@(cd src; ./go check-docs -uD -e '^osi_.*\*' -e '^[A-Z_]+' -e '^\$$[a-z-]+' -e '^event-mgr:unregister' ..)
 
+warn-letrec-check:
+	@WARN_UNDEFINED=yes $(MAKE) -C src/swish all
+
 install: swish doc
 	$(MAKE) -C src/swish install
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ hash.
 
 - Chez Scheme 9.6.4 or later
 - GCC, the GNU Compiler Collection
-- GNU make
+- GNU make 4.4 or later
 - GNU C++ compiler for libuv
 - cmake for libuv
 - libsystemd-dev and uuid-dev packages

--- a/configure
+++ b/configure
@@ -438,6 +438,16 @@ if [ "${CONFIG_UNAME}" = "Darwin" ]; then
 else
   add "GNU_INSTALL:=install"
 fi
+# build server may not have GNU make >= 4.4, but we don't use -j there either
+TMPFILE="$(mktemp)"
+echo "target: .WAIT" > "${TMPFILE}"
+if make -qf "${TMPFILE}" 2> /dev/null ; then
+  add "SYNC=.WAIT"
+else
+  add "SYNC="
+  echo "Note: make does not support .WAIT, so make -j may not work."
+fi
+rm "${TMPFILE}"
 
 set_output ";;" src/osi-bootstrap.ss
 if [ "${Windows}" = "yes" ]; then

--- a/doc/address-sanitizer.md
+++ b/doc/address-sanitizer.md
@@ -1,0 +1,151 @@
+# Address Sanitizer
+
+- Address Sanitizer is a memory error detector for C/C++ documented
+  [here](https://github.com/google/sanitizers/wiki/AddressSanitizer).
+- Address Sanitizer is now built into both LLVM and GCC.
+- Often referred to as ASAN.
+- Since ASAN is faster than Valgrind we might use it more often.
+
+## Caveats
+
+- Address Sanitizer does not work under `ptrace`, (GDB, `strace`, etc.).
+  Under GDB, for example, we get exit 1 and a log entry saying that
+  LeakSanitizer encountered a fatal error.
+- Address Sanitizer doesn't handle `S_call_help`; see instructions below
+  showing how to add an exclusion for this.
+- Address Sanitizer reports leaks to `stderr` by default, which breaks
+  some mats. The instructions below show how to change this.
+- We get no ASAN output if we go through the `_exit` path in `osi_exit`
+  or `swish_run`. One way this can happen is that `uv_close_loop`
+  returns `UV_EBUSY` if we have open handles. For example, in the
+  `process-detached` automated test, I forgot to close the
+  `tcp-listener` and we still had a handle active when we wanted to exit
+  (i.e., when running the test individually).
+- By default, ASAN checks at runtime how the application links to the
+  library. This check trips when we load the libosi shared library while
+  compiling the boot file. We can work around it by setting
+  `ASAN_OPTIONS` as described later, but we may be able to set
+  `LD_PRELOAD` as another alternative or build Chez Scheme with ASAN
+  linked in.
+  - Setting `LD_PRELOAD` is problematic. If we set it at the shell, ASAN
+    ends up trying to check `make` and aborts due to apparent leaks
+    there. We might be able to tweak the Makefile to set `LD_PRELOAD`
+    while compiling our boot file.
+- Don't build with the static ASAN package; we want the dynamic libasan
+  package so we can build our libosi shared library.
+
+## Setup on macOS
+
+1.  May need recent clang from homebrew:
+    `export PATH=/usr/local/opt/llvm/bin:$PATH`
+2.  May need to explicitly enable leak checking:
+    `export ASAN_OPTIONS=detect_leaks=1:verify_asan_link_order=0`
+3.  Need to ignore "nano zone abandoned": `export MallocNanoZone=0`
+4.  For unknown reasons, we need to compile Chez Scheme with ASAN turned
+    on:
+    `./configure CC=clang CFLAGS="-fsanitize=address -g -fno-omit-frame-pointer" --installprefix=~/tmp/scout`
+5.  For Swish, need to point to custom Chez Scheme (not in /usr to avoid
+    System Integrity Protections) and apparently we need ASAN linked to
+    Chez Scheme (see step 4):
+    `./configure CC=clang CFLAGS="-fsanitize=address -g -fno-omit-frame-pointer" --prefix=~/tmp/scout --scheme=~/src/chez-scheme/a6osx/bin/a6osx/scheme`
+6.  Swish's configure will suggest something like this:
+    `export SCHEMEHEAPDIRS="~/src/chez-scheme/a6osx/boot/%m:~/src/chez-scheme/a6osx/bin/lib/csv%v/%m"`
+
+## Setup on Linux
+
+ASAN likely works out of the box with LLVM and GCC.
+
+- Fedora: if necessary, try `dnf install libasan-static`.
+- Ubuntu: if necessary, try `apt install libasan6`.
+
+## Build and run Swish with ASAN
+
+1.  ASAN needs a lot of virtual memory. Check that `ulimit -v` is not
+    set. You may need to edit `~/.bashrc` and start a new shell to
+    remove the limit.
+
+2.  build using dynamic Address Sanitizer:
+
+    ``` bash
+    $ ./configure CFLAGS="-fsanitize=address -g -fno-omit-frame-pointer"
+    # we need the following while building the boot file
+    $ export ASAN_OPTIONS="verify_asan_link_order=0"
+    $ make clean
+    $ make -C src/swish mat-prereq
+    ```
+
+3.  set environment variables and prepare filesystem:
+
+    ``` bash
+    # ignore the "leak" due to setjmp/longjmp in S_call_help:
+    $ echo "leak:S_call_help" > ignore-S_call_help
+    $ export LSAN_OPTIONS=suppressions="${PWD}/ignore-S_call_help"
+    # redirect output so mats that check stderr will pass and
+    # disable verify_asan_link_order for the same of repl.ms
+    # and other mats that invoke scheme-exe:
+    $ mkdir -p /tmp/asan-logs
+    $ export ASAN_OPTIONS=log_path=/tmp/asan-logs/log:detect_leaks=1:verify_asan_link_order=0
+    # enable more checks, if desired:
+    $ export ASAN_OPTIONS="${ASAN_OPTIONS}:check_initialization_order=true detect_stack_use_after_return=true strict_string_checks=true"
+    ```
+
+4.  run `make test` or `cd src; ./run-suite swish/io.ms` for example
+
+5.  check the files written to the /tmp/asan-logs `log_path`;
+
+    - expect to see /tmp/asan-logs/log.\<pid\> files containing:
+
+      ``` example
+      -----------------------------------------------------
+      Suppressions used:
+        count      bytes template
+            1        200 S_call_help
+      -----------------------------------------------------
+      ```
+
+    - a quick way to find unexpected logs is
+
+      ``` bash
+      $ sha1sum /tmp/asan-logs/* | grep -v 06daefdb280f66d645dd06272ad3edce254d9617
+      ```
+
+## Tips
+
+- To identify where we're leaking in the mats, it helps to patch
+  `run-os-process` in swish/testing.ss by adding the following just
+  after `(write-stdin to-stdin)`; then we can correlate the log.\<pid\>
+  file showing a leak with the cmdline.\<pid\> file showing what we fed
+  to `run-os-process`.
+
+  ``` scheme
+  (call-with-output-file (format "/tmp/asan-logs/cmdline.~s" os-pid) write-stdin)
+  ```
+
+- To iterate on checking leaks in a suite:
+
+  ``` bash
+  # $1 is suite name, e.g., swish/foreign.ms
+  function foo {
+    rm /tmp/asan-logs/* ;
+    ./run-suite $1;
+    sha1sum /tmp/asan-logs/* | grep -v 06daefdb280f66d645dd06272ad3edce254d9617 ;
+  }
+  # $1 is suite name, $2 is test name
+  # (won't work with erlang.ms etc. where we need access to internal library)
+  function bar {
+    rm /tmp/asan-logs/* ;
+    ./run-mat -b $1 $2;
+    sha1sum /tmp/asan-logs/* | grep -v 06daefdb280f66d645dd06272ad3edce254d9617 ;
+  }
+  ```
+
+# Why not Valgrind?
+
+- Valgrind may be more capable. For example it may detect some errors in
+  Scheme code.
+- However, Valgrind is slower than ASAN.
+- libuv 1.45.0 introduced `io_uring` support
+  - this improved linux file I/O performance
+  - but we now hit this [valgrind false positive
+    issue](https://github.com/libuv/libuv/issues/4008)
+- Hopefully we will be able use either tool in the future.

--- a/src/repl.ss
+++ b/src/repl.ss
@@ -2,6 +2,7 @@
 
 (let-syntax ([_ (begin ;; run this code at expand time
                   (compile-imported-libraries #t)
+                  (undefined-variable-warnings (equal? (getenv "WARN_UNDEFINED") "yes"))
                   (let ([base (path-parent (cd))]
                         [which (if (equal? (getenv "PROFILE_MATS") "yes")
                                    'profile

--- a/src/run-mat
+++ b/src/run-mat
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 if [ $# = 0 ]; then
-  echo "Usage: $0 suite [test ...]"
+  echo "Usage: $0 [-b] suite [test ...]"
   echo ""
   echo " For example:"
   echo "   $0 swish/json"
@@ -9,13 +9,28 @@ if [ $# = 0 ]; then
   echo "   $0 swish/json.ms"
   echo "   $0 swish/profile.ss"
   echo "   $0 swish/erlang chain-reaction"
+  echo ""
+  echo " -b  means build mat-prereq and use that to run test"
   exit
+fi
+
+BUILD=0
+RUN=./go
+
+if [ "$1" = '-b' ]; then
+  shift;
+  BUILD=1
+  RUN=../build/mat-prereq/bin/swish
 fi
 
 find . -name "*.mo" -delete
 rm -f ../data/server.profile
 rm -f ../data/TestLog.db3
-make -s -C swish
+if [ ${BUILD} -eq 0 ]; then
+  make -s -C swish
+else
+  make -s -C swish mat-prereq
+fi
 
 FILENAME="$1"
 if [ ! -f "${FILENAME}" ]; then
@@ -24,7 +39,7 @@ fi
 
 shift
 
-./go -q <<EOF
+${RUN} -q <<EOF
 (reset-handler abort)
 (import (swish mat) (swish profile) (swish testing))
 (cd "..")

--- a/src/swish/.gitignore
+++ b/src/swish/.gitignore
@@ -14,6 +14,7 @@
 /osi.obj
 /run.o
 /run.obj
+/scheme_aux.h
 /script-testing.so
 /sh-config
 /sha1.o

--- a/src/swish/Mf-base
+++ b/src/swish/Mf-base
@@ -25,7 +25,7 @@ build-dirs:
 	@mkdir -p ../../${BUILD}/bin
 	@mkdir -p ../../${BUILD}/lib
 
-all: ready ${CORE} ${AUXLIB} ${REMINDERS}
+all: ready ${SYNC} ${CORE} ${AUXLIB} ${REMINDERS}
 
 %.include: %.tmp-include
 	@if cmp --quiet "$@" "$<"; then \
@@ -43,6 +43,8 @@ swish-version.include-changed:
 
 chezscheme-revision.include-changed:
 	touch $(SSRC)
+	rm -f scheme_aux.h
+	$(MAKE) scheme_aux.h
 
 swish-revision.tmp-include:
 	@git describe --always --match none --abbrev=40 --dirty > "$@"
@@ -57,7 +59,13 @@ chezscheme-revision.tmp-include:
 	  cat "${SCHEME_REVISION_PATH}/revision" > "$@" ; \
 	fi
 
-${OsiObj}: ${SQLITE_SRCPATH}/sqlite3.h swish.h sha.h sha-private.h
+${OsiObj}: ${SQLITE_SRCPATH}/sqlite3.h swish.h sha.h sha-private.h scheme_aux.h
+
+sqlite.c: scheme_aux.h
+
+scheme_aux.h:
+	@sed -n 's/^EXPORT \([^S].*\) Sinteger64_value.*/typedef \1 Sint64_t;/p' < "${SCHEME_REVISION_PATH}/scheme.h" > scheme_aux.h
+	@sed -n 's/EXPORT.*Stry_integer64_value.*/#define HAS_TRY_INT64_VALUE/p' < "${SCHEME_REVISION_PATH}/scheme.h" >> scheme_aux.h
 
 io-constants.ss: io-constants${EXESUFFIX}
 	./$< > $@
@@ -101,6 +109,7 @@ clean: platform-clean
 	rm -f ../../${BUILD}/lib/swish/*.wpo
 	rm -f ${SwishLibs}
 	rm -f ${SHLIBTEST}
+	rm -f scheme_aux.h
 	rm -f chezscheme-revision.include
 	rm -f swish-revision.include
 	rm -f swish-version.include
@@ -163,7 +172,7 @@ install-internal: install-check all
 
 .PHONY: mat-prereq
 mat-prereq:: | ${SETUP}
-mat-prereq:: ${SHLIBTEST} ${TESTREQUEST}
+mat-prereq:: ${SHLIBTEST} ${TESTREQUEST} scheme_aux.h
 	@printf "making mat-prereq ... "
 	@rm -rf ../../build/mat-prereq
 	@$(MAKE) install-batteries install-bin install-internal INSTALLROOT="$$(${NORMALIZE_PATH} ../../build/mat-prereq)" SWISH_VERSION=".x.y.z" MACHINE_TYPE="arch" > /dev/null

--- a/src/swish/Mf-base
+++ b/src/swish/Mf-base
@@ -121,45 +121,45 @@ ifeq (,${INSTALLROOT})
 endif
 
 install-doc: install-check
-	${GNU_INSTALL} --directory ${INSTDOCDIR}
-	${GNU_INSTALL} --mode=444 ../../LICENSE ${INSTDOCDIR}
-	${GNU_INSTALL} --mode=444 ../../NOTICE ${INSTDOCDIR}
-	${GNU_INSTALL} --mode=444 ../../doc/swish.pdf ${INSTDOCDIR}
+	${GNU_INSTALL} --directory "${INSTDOCDIR}"
+	${GNU_INSTALL} --mode=444 ../../LICENSE "${INSTDOCDIR}"
+	${GNU_INSTALL} --mode=444 ../../NOTICE "${INSTDOCDIR}"
+	${GNU_INSTALL} --mode=444 ../../doc/swish.pdf "${INSTDOCDIR}"
 
 install-batteries: install-check
-	${GNU_INSTALL} --directory ${INSTLIBDIR}
-	${GNU_INSTALL} --mode=444 ${SCHEMEBOOT}/petite.boot ${INSTLIBDIR}
-	${GNU_INSTALL} --mode=444 ${SCHEMEBOOT}/scheme.boot ${INSTLIBDIR}
-	${GNU_INSTALL} --mode=444 ${SCHEMEBOOT}/scheme.h ${INSTLIBDIR}
+	${GNU_INSTALL} --directory "${INSTLIBDIR}"
+	${GNU_INSTALL} --mode=444 "${SCHEMEBOOT}"/petite.boot "${INSTLIBDIR}"
+	${GNU_INSTALL} --mode=444 "${SCHEMEBOOT}"/scheme.boot "${INSTLIBDIR}"
+	${GNU_INSTALL} --mode=444 "${SCHEMEBOOT}"/scheme.h "${INSTLIBDIR}"
 
 install-bin: install-check all
-	${GNU_INSTALL} --directory ${INSTLIBDIR}
-	${GNU_INSTALL} ../../${BUILD}/bin/swish${EXESUFFIX} ${INSTLIBDIR}
-	${GNU_INSTALL} swish-build ${INSTLIBDIR}
-	${GNU_INSTALL} swish-test ${INSTLIBDIR}
-	${GNU_INSTALL} --mode=444 ../../${BUILD}/bin/swish.boot ${INSTLIBDIR}
-	${GNU_INSTALL} --mode=444 ../../${BUILD}/bin/swish.library ${INSTLIBDIR}
-	${GNU_INSTALL} --mode=444 ../../${BUILD}/bin/swish-core.library ${INSTLIBDIR}
+	${GNU_INSTALL} --directory "${INSTLIBDIR}"
+	${GNU_INSTALL} ../../${BUILD}/bin/swish${EXESUFFIX} "${INSTLIBDIR}"
+	${GNU_INSTALL} swish-build "${INSTLIBDIR}"
+	${GNU_INSTALL} swish-test "${INSTLIBDIR}"
+	${GNU_INSTALL} --mode=444 ../../${BUILD}/bin/swish.boot "${INSTLIBDIR}"
+	${GNU_INSTALL} --mode=444 ../../${BUILD}/bin/swish.library "${INSTLIBDIR}"
+	${GNU_INSTALL} --mode=444 ../../${BUILD}/bin/swish-core.library "${INSTLIBDIR}"
 ifeq ($(MACHINE_TYPE:nt=), ${MACHINE_TYPE}) # if not Windows
-	${GNU_INSTALL} --mode=444 ${SwishLibs} ${INSTLIBDIR}
+	${GNU_INSTALL} --mode=444 ${SwishLibs} "${INSTLIBDIR}"
 else
-	${GNU_INSTALL} ${SwishLibs} ${INSTLIBDIR}
+	${GNU_INSTALL} ${SwishLibs} "${INSTLIBDIR}"
 endif
-	${GNU_INSTALL} --directory ${INSTALLROOT}/bin
-	ln -sf ${INSTLIBDIR}/swish${EXESUFFIX} ${INSTALLROOT}/bin/swish
-	ln -sf ${INSTLIBDIR}/swish-build ${INSTALLROOT}/bin/swish-build
-	ln -sf ${INSTLIBDIR}/swish-test ${INSTALLROOT}/bin/swish-test
-	${GNU_INSTALL} --directory ${INSTLIBDIR}/lib
-	cd ../../${BUILD}/lib ; find . -type f -name '*.wpo' -a -not -iname 'internal*' -exec ${GNU_INSTALL} --mode=444 -D -T {} ${INSTLIBDIR}/wpo/{} \;
-	cd ../../${BUILD}/lib ; find . -type f -name '*.so' -a -not -iname 'internal*' -exec ${GNU_INSTALL} --mode=444 -D -T {} ${INSTLIBDIR}/lib/{} \;
-	${GNU_INSTALL} --mode=444 ../../${BUILD}/lib/swish/mat.so ${INSTLIBDIR}/lib/swish
-	${GNU_INSTALL} --mode=444 ../../${BUILD}/lib/swish/profile.so ${INSTLIBDIR}/lib/swish
-	${GNU_INSTALL} --mode=444 ../../${BUILD}/lib/swish/testing.so ${INSTLIBDIR}/lib/swish
-	${GNU_INSTALL} --directory ${INSTWEBDIR}
-	cd ../../web ; git ls-files | xargs -I {} ${GNU_INSTALL} --mode=444 -D -T {} ${INSTWEBDIR}/{}
+	${GNU_INSTALL} --directory "${INSTALLROOT}"/bin
+	ln -sf "${INSTLIBDIR}"/swish${EXESUFFIX} "${INSTALLROOT}"/bin/swish
+	ln -sf "${INSTLIBDIR}"/swish-build "${INSTALLROOT}"/bin/swish-build
+	ln -sf "${INSTLIBDIR}"/swish-test "${INSTALLROOT}"/bin/swish-test
+	${GNU_INSTALL} --directory "${INSTLIBDIR}"/lib
+	cd ../../${BUILD}/lib ; find . -type f -name '*.wpo' -a -not -iname 'internal*' -exec ${GNU_INSTALL} --mode=444 -D -T {} "${INSTLIBDIR}"/wpo/{} \;
+	cd ../../${BUILD}/lib ; find . -type f -name '*.so' -a -not -iname 'internal*' -exec ${GNU_INSTALL} --mode=444 -D -T {} "${INSTLIBDIR}"/lib/{} \;
+	${GNU_INSTALL} --mode=444 ../../${BUILD}/lib/swish/mat.so "${INSTLIBDIR}"/lib/swish
+	${GNU_INSTALL} --mode=444 ../../${BUILD}/lib/swish/profile.so "${INSTLIBDIR}"/lib/swish
+	${GNU_INSTALL} --mode=444 ../../${BUILD}/lib/swish/testing.so "${INSTLIBDIR}"/lib/swish
+	${GNU_INSTALL} --directory "${INSTWEBDIR}"
+	cd ../../web ; git ls-files | xargs -I {} ${GNU_INSTALL} --mode=444 -D -T {} "${INSTWEBDIR}"/{}
 
 install-internal: install-check all
-	cd ../../${BUILD}/lib ; find . -type f -name 'internal*.so' -exec ${GNU_INSTALL} --mode=444 -D -T {} ${INSTLIBDIR}/lib/{} \;
+	cd ../../${BUILD}/lib ; find . -type f -name 'internal*.so' -exec ${GNU_INSTALL} --mode=444 -D -T {} "${INSTLIBDIR}"/lib/{} \;
 
 .PHONY: mat-prereq
 mat-prereq:: | ${SETUP}

--- a/src/swish/app.ms
+++ b/src/swish/app.ms
@@ -430,9 +430,15 @@
         '((log-file ":memory:")
           (app:start)
           ;; simulate winning race to exit-process with an earlier app:shutdown
-          (#%$set-top-level-value! '$console-input-port 'bogus)
-          (app:shutdown 1)
-          (receive (after 100 (osi_exit 3)))))
+          ;; (all within one expression since we can't read after closing stdin)
+          (let ([p (#%$top-level-value '$console-input-port)])
+            (#%$set-top-level-value! '$console-input-port #f)
+            ;; close port so leak checker is happy
+            (close-port p)
+            ;; poison the value so exit-process has to be careful
+            (#%$set-top-level-value! '$console-input-port 'bogus)
+            (app:shutdown 1)
+            (receive (after 100 (osi_exit 3))))))
       '("expected non-zero exit")))
    [#(EXIT `(<os-process-failed> [exit-status 1] ,stdout ,stderr))
     (match-regexps '("ok") stdout)

--- a/src/swish/compile.ss
+++ b/src/swish/compile.ss
@@ -13,7 +13,10 @@
   (let ([stock-compile-library (compile-library-handler)])
     (lambda (source dest)
       (printf "compiling ~a\n" source)
-      (parameterize ([compile-file-message #f] [target-file dest])
+      (parameterize ([compile-file-message #f]
+                     [undefined-variable-warnings (equal? (getenv "WARN_UNDEFINED") "yes") ]
+                     [print-extended-identifiers #t]
+                     [target-file dest])
         (stock-compile-library source dest)))))
 (compile-library-handler swish-compile-library)
 

--- a/src/swish/db.ms
+++ b/src/swish/db.ms
@@ -390,7 +390,9 @@
     ;; check int64 error during sqlite:marshal-bindings
     [,too-large (ash 1 64)]
     [,expected-error
-     (format "Exception in Sinteger64_value: ~a is out of range." too-large)]
+     (if (pregexp-match ".*HAS_TRY_INT64_VALUE.*" (utf8->string (read-file "src/swish/scheme_aux.h")))
+         (exit-reason->english `#(osi-error osi_marshal_bindings osi_marshal_bindings ,UV_EINVAL))
+         (format "Exception in Sinteger64_value: ~a is out of range." too-large))]
     [#(EXIT ,reason)
      (catch (sqlite:marshal-bindings (list too-large)))]
     [,@expected-error (exit-reason->english reason)]

--- a/src/swish/db.ms
+++ b/src/swish/db.ms
@@ -988,7 +988,8 @@
              (pregexp-quote (format "#<bindings ~s>" datum))
              (pregexp-quote ")")))
           output)))
-      data))))
+      data))
+   (gc)))
 
 (db-mat check-options ()
   (match-let*

--- a/src/swish/digest.ms
+++ b/src/swish/digest.ms
@@ -315,6 +315,7 @@
              "Exception in get-hash: cannot read from closed digest."))
          h*)])
       'ok))
+   (gc)
    'ok))
 
 (mat sha1 ()
@@ -382,4 +383,5 @@
     ["#<digest-provider swish>" (format "~s" default-digest-provider)]
     ["#<SHA1 digest>" (format "~s" (open-digest 'sha1))]
     )
+   (gc)
    'ok))

--- a/src/swish/erlang.ms
+++ b/src/swish/erlang.ms
@@ -2944,9 +2944,12 @@
 ;; on slower systems it may be helpful to limit the available virtual memory
 ;; e.g., via ulimit, so that this test does not time out while paging
 (isolate-mat out-of-memory ()
-  (repl-test 1
-    '(make-vector (most-positive-fixnum))
-    "out of memory"))
+  (define-environment-parameters ASAN_OPTIONS)
+  ;; disable memory leak checking: out of memory is a hard exit
+  (parameterize ([ASAN_OPTIONS "detect_leaks=0"])
+    (repl-test 1
+      '(make-vector (most-positive-fixnum))
+      "out of memory")))
 
 (isolate-mat exit-handler ()
   (define-syntax run-spawned

--- a/src/swish/erlang.ss
+++ b/src/swish/erlang.ss
@@ -1051,7 +1051,7 @@
     (with-interrupts-disabled
      (parameterize ([print-graph #t])
        (let ([op (console-error-port)]
-             [ht (or (event-condition-table) (make-eq-hashtable))])
+             [ht (or (event-condition-table) (make-weak-eq-hashtable))])
          (event-condition-table ht)
          (fprintf op "\nDate: ~a\n" (date-and-time))
          (fprintf op "Timestamp: ~a\n" (erlang:now))

--- a/src/swish/erlang.ss
+++ b/src/swish/erlang.ss
@@ -141,6 +141,8 @@
           #f
           #f)]))
 
+  (define erlang:now osi_get_time)
+
   (define-syntax self
     (identifier-syntax
      (#3%$top-level-value '#{self lgnnu3lheosakvgyylzmvq5uw-0})))
@@ -168,6 +170,17 @@
      (lambda (new)
        (lambda (contents)
          ((new) contents)))))
+
+  (define (make-queue)
+    (let ([q (make-q)])
+      (q-prev-set! q q)
+      (q-next-set! q q)
+      q))
+
+  (define (queue-empty? queue)
+    (eq? (q-next queue) queue))
+
+  (define enqueued? q-prev)
 
   (define-record-type mon
     (nongenerative)
@@ -237,8 +250,6 @@
       (if x
           (fxlogbit1 3 (pcb-flags p))
           (fxlogbit0 3 (pcb-flags p)))))
-
-  (define erlang:now osi_get_time)
 
   (define (panic event)
     (on-exit (osi_exit 80)
@@ -443,17 +454,6 @@
     (demonitor m)
     (receive (until 0 #t)
       [`(DOWN ,@m ,_ ,_) #t]))
-
-  (define (make-queue)
-    (let ([q (make-q)])
-      (q-prev-set! q q)
-      (q-next-set! q q)
-      q))
-
-  (define (queue-empty? queue)
-    (eq? (q-next queue) queue))
-
-  (define enqueued? q-prev)
 
   (define (@enqueue process queue precedence)
     (when (enqueued? process)

--- a/src/swish/errors.ss
+++ b/src/swish/errors.ss
@@ -141,9 +141,6 @@
            (get-output-string op))]
         [else (format "~s" x)])]))
 
-  (define current-exit-reason->english
-    (make-parameter swish-exit-reason->english))
-
   (define (src->english x)
     (match x
       [#(,at ,offset ,file) (format " ~a offset ~a of ~a" at offset file)]
@@ -170,6 +167,9 @@
          (fold-left add-stack (cons-k reason (cons-k r k*)) inner*)]
         [,_ (cons-k reason k*)]))
     (add-stack '() reason))
+
+  (define current-exit-reason->english
+    (make-parameter swish-exit-reason->english))
 
   (define-syntax redefine
     (syntax-rules ()

--- a/src/swish/foreign.ms
+++ b/src/swish/foreign.ms
@@ -48,7 +48,7 @@
 
 (define (run-script exprs output)
   (script-test shlib-repl '()
-    (format "(reset-handler abort)\n~{~s\n~}#!eof\n" exprs)
+    (format "(reset-handler (lambda () (app:shutdown 1)))\n~{~s\n~}#!eof\n" exprs)
     output))
 
 (define (run-repl shlib-imports shlib-test-expr* write-config success)

--- a/src/swish/http.ms
+++ b/src/swish/http.ms
@@ -208,11 +208,10 @@
 
 (define (simple-tcp x)
   (let-values ([(ip op) (connect-tcp "127.0.0.1" (get-http-port))])
-    (put-bytevector op x)
-    (flush-output-port op)
-    (let ([r (get-bytevector-all ip)])
-      (close-port op)
-      r)))
+    (on-exit (begin (close-port op) (close-port ip))
+      (put-bytevector op x)
+      (flush-output-port op)
+      (get-bytevector-all ip))))
 
 (define (simple-get x)
   (simple-tcp (string->utf8 (format "GET ~a HTTP/1.1\r\nConnection: close\r\n\r\n" x))))
@@ -1076,7 +1075,9 @@
         (assert (process? (g))))
 
       ;; I/O Continues after the connection exited
-      (check-loopback '(4 3 2 1 0)))))
+      (check-loopback '(4 3 2 1 0))
+      (close-port op)
+      (close-port ip))))
 
 (http-mat switch-protocol-fail ()
   (supervisor:start&link 'http-sup 'one-for-all 0 1

--- a/src/swish/http.ss
+++ b/src/swish/http.ss
@@ -176,16 +176,16 @@
          #'(handler conn request header params))]))
 
   (define (http-listener:start&link name sup init-port url-handler options)
-    (define-state-tuple <http-listener> tcp-listener cache-manager pid->op)
+    (define-state-tuple <http-listener> tcp-listener cache-manager pid->ports)
     (define (init)
       (process-trap-exit #t)
       (match-let* ([#(ok ,cache-mgr) (cache-mgr:start&link sup options)])
         `#(ok ,(<http-listener> make
                  [tcp-listener (listen-tcp "::" init-port self)]
                  [cache-manager cache-mgr]
-                 [pid->op (ht:make process-id eq? process?)]))))
+                 [pid->ports (ht:make process-id eq? process?)]))))
     (define (terminate reason state)
-      ;; Ignore the pid->op table. In the rare event that this
+      ;; Ignore the pid->ports table. In the rare event that this
       ;; gen-server fails, the dispatchers can continue
       ;; processing. The garbage collector will clean up if necessary.
       (close-tcp-listener ($state tcp-listener)))
@@ -211,15 +211,17 @@
                              (conn:start&link cache-mgr ip op options)])
                            (http:handle-input conn url-handler options)))))))])
           (monitor pid)
-          `#(no-reply ,($state copy* [pid->op (ht:set pid->op pid op)])))]
+          `#(no-reply ,($state copy* [pid->ports (ht:set pid->ports pid (cons ip op))])))]
         [#(accept-tcp-failed ,_ ,_ ,_)
          `#(stop ,msg ,state)]
         [`(DOWN ,_ ,pid ,_)
          (cond
-          [(ht:ref ($state pid->op) pid #f) =>
-           (lambda (op)
-             (force-close-output-port op)
-             `#(no-reply ,($state copy* [pid->op (ht:delete pid->op pid)])))]
+          [(ht:ref ($state pid->ports) pid #f) =>
+           (lambda (ports)
+             (match-let* ([(,ip . ,op) ports])
+               (force-close-output-port op)
+               (close-port ip))
+             `#(no-reply ,($state copy* [pid->ports (ht:delete pid->ports pid)])))]
           [else
            `#(no-reply ,state)])]))
     (gen-server:start&link name))

--- a/src/swish/io.ms
+++ b/src/swish/io.ms
@@ -193,6 +193,52 @@
      (osi_spawn_detached* "*" '("x" . 0))])
    'ok))
 
+(isolate-mat process-detached ()
+  (import (swish script-testing))
+  (define listener (listen-tcp "::1" 0 self))
+  (define test-port (listener-port-number listener))
+  (define start (string->utf8 "Engage!"))
+  (define cookie (osi_make_uuid))
+  (define (get-expected ip expected-bv)
+    (define end (bytevector-length expected-bv))
+    (let lp ([i 0])
+      (or (fx= i end)
+          (and (eqv? (get-u8 ip) (bytevector-u8-ref expected-bv i))
+               (lp (fx+ i 1))))))
+  (define test-file.ss
+    (write-test-file "test-file.ss"
+      (lambda ()
+        (for-each pretty-print
+          `((spawn&link (lambda () (receive (after 60000 (throw 'up)))))
+            (define-values (cip cop) (connect-tcp "::1" ,test-port))
+            ;; announce our presence
+            (put-bytevector cop ',start)
+            (flush-output-port cop)
+            (put-bytevector cop
+              ;; read bytes of cookie and echo bytevector back in reverse
+              (let lp ([ls '()] [n ,(bytevector-length cookie)])
+                (if (= n 0)
+                    (u8-list->bytevector ls)
+                    (lp (cons (get-u8 cip) ls) (- n 1)))))
+            (flush-output-port cop)
+            (app:shutdown))))))
+  (spawn-os-process-detached (osi_get_executable_path) (list test-file.ss))
+  (receive (after 60000 (throw 'timeout))
+    [#(accept-tcp ,@listener ,sip ,sop)
+     (match-let* ([#t (get-expected sip start)]    ;; expect start message
+                  [,_ (put-bytevector sop cookie)] ;; put cookie forward order
+                  [,_ (flush-output-port sop)]
+                  [,eikooc (u8-list->bytevector (reverse (bytevector->u8-list cookie)))]
+                  [#t (get-expected sip eikooc)])  ;; expect client to reverse cookie
+       (close-port sip)
+       (close-port sop)
+       'ok)])
+  (close-tcp-listener listener)
+  ;; no spam from detached process
+  (receive (after 200 'ok)
+    [(,x <= `#(process-terminated ,os-pid ,exit-status ,term-signal))
+     (throw x)]))
+
 (isolate-mat files ()
   (define (make-buffers)
     (fold-left

--- a/src/swish/mat.ss
+++ b/src/swish/mat.ss
@@ -377,15 +377,16 @@
     (define meta-data (json:make-object))
     (define obj (make-mat-data filename meta-data '()))
     (let ([ip (open-file-to-read filename)])
-      (let rd ()
-        (let ([r (json:read ip)])
-          (unless (eof-object? r)
-            (match (json:ref r '_type_ #f)
-              ["mat-result"
-               (json:update! obj 'results (lambda (old) (cons r old)) #f)]
-              ["meta-kv"
-               (json:set! meta-data (string->symbol (meta-kv-key r)) (meta-kv-value r))])
-            (rd)))))
+      (on-exit (close-port ip)
+        (let rd ()
+          (let ([r (json:read ip)])
+            (unless (eof-object? r)
+              (match (json:ref r '_type_ #f)
+                ["mat-result"
+                 (json:update! obj 'results (lambda (old) (cons r old)) #f)]
+                ["meta-kv"
+                 (json:set! meta-data (string->symbol (meta-kv-key r)) (meta-kv-value r))])
+              (rd))))))
     (json:set! obj 'results (reverse (json:ref obj 'results '())))
     obj)
 

--- a/src/swish/swish-test.ms
+++ b/src/swish/swish-test.ms
@@ -1317,7 +1317,8 @@
   (define abort.ms
     (write-test-file "abort.ms"
       (lambda ()
-        (pretty-print '(abort)))))
+        ;; call exit instead of abort to clean up and prevent apparent leaks
+        (pretty-print '(exit 1)))))
   (define no-tests.ms (write-test-file "no-tests.ms" void))
   (define pass.ms
     (write-test-file "pass.ms"

--- a/src/swish/websocket.ss
+++ b/src/swish/websocket.ss
@@ -164,6 +164,8 @@
              (check-header header 'sec-websocket-accept (encode-key key))
              (values ip op))]
           [,status
+           (close-port ip)
+           (close-port op)
            (throw `#(websocket-upgrade-failed ,status))]))))
 
   (define (random-bytevector n)


### PR DESCRIPTION
This pull request
* fixes a memory leak in an error path of `sqlite:marshal-bindings`
* fixes a memory leak in `console-event-handler`
* fixes a few places where we need to close ports
* adds notes on running Swish with Address Sanitizer

It also
* adds a missing test for `spawn-os-process-detached`
* adds a `-b` option to `run-mat` to simplify running a specific mat using the mat-prereq artifacts
* reorders some definitions to avoid `letrec*` checks
* quotes paths in `make install` targets
* updates the `.gitattributes` file