### PR TITLE
Websocket improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,6 +179,9 @@ jobs:
           path: |
             data/mat-report.html
             src/swish/*.mo
+      - name: Run safe-check tests
+        if: ${{ matrix.config.chez == 'main' && !startsWith(matrix.config.os, 'macos') }}
+        run: .github/workflows/unless-failed.sh safe-check
       - name: Run coverage
         run: .github/workflows/unless-failed.sh coverage
       - name: Archive coverage results

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MAKEFLAGS += --no-print-directory
-.PHONY: clean coverage check-docs doc install pristine swish test
+.PHONY: clean coverage check-docs doc install pristine swish test safe-check
 
 swish: src/swish/Makefile
 	$(MAKE) -C src/swish all
@@ -13,6 +13,11 @@ src/swish/Makefile:
 
 test: src/swish/Makefile
 	@$(MAKE) -C src/swish mat-prereq
+	@./src/run-mats
+
+safe-check: src/swish/Makefile
+	@touch src/swish/unsafe.ss
+	@UNSAFE_PRIMITIVES=no $(MAKE) -C src/swish mat-prereq
 	@./src/run-mats
 
 coverage: src/swish/Makefile

--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -2355,6 +2355,20 @@ The \code{path-watcher?} procedure determines whether or not the datum
 \var{x} is a path watcher.
 
 % ----------------------------------------------------------------------------
+\defineentry{port->notify-port}
+\begin{procedure}
+  \code{(port->notify-port \var{p} \var{notify!})}
+\end{procedure}
+\returns{} a port
+
+The \code{port->notify-port} procedure takes a custom binary port \var{p} and a
+\var{notify!} procedure of one argument.
+It marks port \var{p} as closed and returns a new custom port whose \code{r!} or
+\code{w!} procedure calls \var{notify!} with the number of bytes returned.
+This procedure is currently restricted to ports returned by \code{connect-tcp}
+and ports obtained from an \code{\#(accept-tcp \var{listener} \var{ip} \var{op})} tuple.
+
+% ----------------------------------------------------------------------------
 \defineentry{print-osi-ports}
 \begin{procedure}
   \code{(print-osi-ports \opt{\var{op}})}

--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -259,10 +259,13 @@ Asynchronous I/O operations for COM ports, named pipes, external
 operating system processes, files, console input, and TCP connections
 are implemented with custom binary ports so that they have the same
 interface as the system I/O procedures. The system I/O procedures are
-not used because they perform synchronous I/O.  The custom port buffer
-size is set to 1024\footnote{1024 was chosen because Chez Scheme uses
-  1024 for the buffer size of buffered transcoded ports.} with
-\code{custom-port-buffer-size}.  The custom binary port read and write
+not used because they perform synchronous I/O.  The default custom port buffer
+size is set to 1024 with \code{custom-port-buffer-size}.\footnote{1024 was
+chosen because prior versions of Chez Scheme use 1024 for the buffer size
+of buffered transcoded ports.}
+When compiled with Chez Scheme versions 9.6.2 and later, Swish uses
+\code{file-buffer-size} as the buffer size for custom file ports.
+The custom binary port read and write
 procedures call \code{osi\_read\_port} and \code{osi\_write\_port}
 with callbacks that send a message to the calling process, which waits
 until it receives the message.

--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -2648,6 +2648,17 @@ The \code{tcp-listener-count} procedure returns the number of open TCP
 listeners\index{TCP listener}.
 
 % ----------------------------------------------------------------------------
+\defineentry{tcp-nodelay}
+\begin{procedure}
+  \code{(tcp-nodelay \var{port} \var{enabled?})}
+\end{procedure}
+\returns{} a boolean
+
+The \code{tcp-nodelay} procedure calls \code{osi\_tcp\_nodelay} to enable
+or disable the Nagle algorithm on the specified TCP/IP \var{port}.
+It returns true if successful or false otherwise.
+
+% ----------------------------------------------------------------------------
 \defineentry{watch-path}
 \begin{procedure}
   \code{(watch-path \var{path} \var{process})}

--- a/doc/swish/http.tex
+++ b/doc/swish/http.tex
@@ -774,14 +774,19 @@ defined in Section~\ref{sec:websocket-protocol} to the given
 The \var{options} are the same as defined for \code{ws:upgrade}.
 
 \defineentry{ws:send}
+\defineentry{ws:send"!} % use " to escape the ! for index entry
 \begin{procedure}
-  \code{(ws:send \var{server} \var{message})}
+  \code{(ws:send \var{server} \var{message})}\\
+  \code{(ws:send! \var{server} \var{message})}
 \end{procedure}
 \returns{} \code{ok}
 
 The \code{ws:send} procedure uses \code{gen-server:cast} to transmit
 the bytevector or string \var{message} to the websocket process or
 registered name \var{server}.
+The \code{ws:send!} procedure is like \code{ws:send} except that it does
+not copy bytevector messages, but may instead destructively update them
+to apply a mask for transmission.
 
 \defineentry{ws:close}
 \begin{procedure}

--- a/doc/swish/osi.tex
+++ b/doc/swish/osi.tex
@@ -968,6 +968,17 @@ and the port number, e.g. \code{127.0.0.1:80}.
 An IPv6 address is shown in bracketed colon-hexadecimal notation
 followed by a colon and the port number, e.g. \code{[::1]:80}.
 
+\defineentry{osi\_tcp\_nodelay}
+\begin{function}
+  \code{ptr osi\_tcp\_nodelay(uptr \var{port}, int \var{enable});}
+\end{function}
+
+The \code{osi\_tcp\_nodelay} function calls \code{uv\_tcp\_nodelay} to
+enable or disable \code{TCP\_NODELAY} for the specified TCP/IP \var{port}
+based on the value of \var{enable}.
+It returns \code{\#t} if successful and \code{\#f} otherwise.
+Enabling \code{TCP\_NODELAY} disables the Nagle algorithm.
+
 \subsection {SQLite Functions}
 
 For each open SQLite database, a single worker thread performs the

--- a/doc/swish/undocumented.tex
+++ b/doc/swish/undocumented.tex
@@ -3,4 +3,5 @@
 
 The following are deliberately undocumented:
 
+\defineentry{not-reached}
 \defineentry{reset-console-event-handler}

--- a/doc/swish/undocumented.tex
+++ b/doc/swish/undocumented.tex
@@ -3,5 +3,7 @@
 
 The following are deliberately undocumented:
 
+\defineentry{make-tcp-write2}
 \defineentry{not-reached}
+\defineentry{osi\_tcp\_write2}
 \defineentry{reset-console-event-handler}

--- a/src/swish/.gitignore
+++ b/src/swish/.gitignore
@@ -42,4 +42,5 @@
 /test-request.obj
 /test-request.pdb
 /test-request.so
+/unsafe.ss.dep
 /vc140.pdb

--- a/src/swish/Mf-base
+++ b/src/swish/Mf-base
@@ -1,4 +1,4 @@
-.PHONY: all build-dirs clean platform-clean ready reminders submodules
+.PHONY: all build-dirs clean platform-clean ready reminders submodules touch-includes
 
 SETUP := Makefile submodules build-dirs \
          chezscheme-revision.include swish-revision.include swish-version.include
@@ -9,8 +9,18 @@ SSRC := $(shell git ls-files '*.ss')
 
 export CC CPPFLAGS CFLAGS LD LDFLAGS
 
+# We want to recompile code that includes unsafe.ss if it changes. So generate a
+# make include that touches any file that includes unsafe.ss and update those
+# dependencies if unsafe.ss itself changes. Use a grep pattern that won't match
+# Mf-base itself.
+unsafe.ss.dep: unsafe.ss
+	@git grep -l '[(]include "unsafe.ss"[)]' | tr '\n' ' ' > unsafe.ss.dep
+	@echo -e ': unsafe.ss\n\ttouch --reference unsafe.ss $$@' >> unsafe.ss.dep
+
 ready:: | ${SETUP}
-ready:: io-constants.ss ${SwishLibs}
+ready:: io-constants.ss unsafe.ss.dep ${SwishLibs}
+
+-include unsafe.ss.dep
 
 submodules:
 	@if cd ../.. && git submodule status --recursive | grep -q '^[^ ]'; then \

--- a/src/swish/erlang.ss
+++ b/src/swish/erlang.ss
@@ -1641,6 +1641,32 @@
     (syntax-rules ()
       [(_ var e) (#%$set-top-level-value! 'var e)]))
 
+  (define-syntax define-or-redefine
+    (syntax-rules ()
+      [(_ var stub e)
+       (meta-cond
+        [(top-level-bound? 'var) (module () (redefine var e))]
+        [else
+         (define var (let ([var (lambda () stub)]) e))
+         (export var)])]))
+
+  ;; switch to redefine when we drop support for v9.5.8
+  (define-or-redefine make-codec-buffer
+    (lambda (bp) (make-bytevector 4))
+    (make-process-parameter (make-codec-buffer)
+      (lambda (x)
+        (unless (procedure? x)
+          (bad-arg 'make-codec-buffer x))
+        x)))
+
+  ;; switch to redefine when we drop support for v9.5.8
+  (define-or-redefine transcoded-port-buffer-size 1024
+    (make-process-parameter (transcoded-port-buffer-size)
+      (lambda (x)
+        (unless (and (fixnum? x) (fxpositive? x))
+          (bad-arg 'transcoded-port-buffer-size x))
+        x)))
+
   (define event-condition-table (make-parameter #f))
   (define (reset-console-event-handler) (event-condition-table #f))
 

--- a/src/swish/erlang.ss
+++ b/src/swish/erlang.ss
@@ -111,13 +111,6 @@
          (lambda () b1 b2 ...)
          (lambda () finally))]))
 
-  (define-syntax no-interrupts
-    (syntax-rules ()
-      [(_ body ...)
-       (let ([x (begin (disable-interrupts) body ...)])
-         (enable-interrupts)
-         x)]))
-
   (define-syntax (receive x)
     (syntax-case x ()
       [(_ (after timeout t1 t2 ...) (pattern b1 b2 ...) ...)
@@ -356,6 +349,7 @@
         thunk))))
 
   ($import-internal throw)
+  (include "unsafe.ss")
 
   (define (bad-arg who arg)
     (no-inline throw `#(bad-arg ,who ,arg)))

--- a/src/swish/gen-server.ss
+++ b/src/swish/gen-server.ss
@@ -230,14 +230,9 @@
      [(server request timeout)
       (do-call server request timeout #t)]))
 
-  (define-syntax no-interrupts
-    (syntax-rules ()
-      [(_ body ...)
-       (let ([x (begin (disable-interrupts) body ...)])
-         (enable-interrupts)
-         x)]))
-
   (define debug-table (make-weak-eq-hashtable))
+
+  (include "unsafe.ss")
 
   (define (do-call server request timeout timeout?)
     (define (failed-call reason e)

--- a/src/swish/http.ms
+++ b/src/swish/http.ms
@@ -1457,6 +1457,32 @@
          (receive (after 1000 (throw 'no-server-close))
            [#(ws:closed ,@s 1002 "no response from ping") 'ok])]))))
 
+(http-mat websocket-pong ()
+  ;; Send multiple pings, fail if pong is not processed.
+  (define me self)
+  (capture-events)
+  (supervisor:start&link 'http-sup 'one-for-all 0 1
+    (http:configure-server #f 0
+      (http:url-handler
+       (ws:upgrade conn request me
+         (ws:options
+          [ping-frequency 100]
+          [pong-timeout 1000])))))
+  (let* ([c (ws:connect "127.0.0.1" (get-http-port) "/" self)]
+         [_ (receive [#(ws:init ,@c) 'ok])]
+         [s (receive [#(ws:init ,s) s])])
+    ;; This delay needs to be more than the pong-timeout.
+    (receive (after 2000 'ok))
+    (ws:close c)
+    (receive (after 1000 (throw 'no-client-close))
+      [#(ws:closed ,@c 1000 "") 'ok]
+      [#(ws:closed ,@c ,code ,reason)
+       (throw `#(client-closed-for-bad-reason ,code ,reason))])
+    (receive (after 1000 (throw 'no-server-close))
+      [#(ws:closed ,@s 1000 "") 'ok]
+      [#(ws:closed ,@s ,code ,reason)
+       (throw `#(server-closed-for-bad-reason ,code ,reason))])))
+
 (http-mat websocket-client-connect-errors ()
   (define (do-test req)
     (catch (ws:connect "127.0.0.1" (get-http-port) req self)))

--- a/src/swish/http.ms
+++ b/src/swish/http.ms
@@ -1414,9 +1414,9 @@
         (let ([str (make-string (+ max-size 1) #\b)])
           (ws:send c str)
           (receive (after 1000 (throw 'no-server-close))
-            [#(ws:closed ,@s 1002 ,_) 'ok]))
+            [#(ws:closed ,@s 1009 ,_) 'ok]))
         (receive (after 1000 (throw 'no-client-close))
-          [#(ws:closed ,@c 1002 ,_) 'ok]
+          [#(ws:closed ,@c 1009 ,_) 'ok]
           [#(ws:closed ,@c 1001 ,_)
            ;; When the message size is large, it is likely the server
            ;; side closes the connection, and the client side fails

--- a/src/swish/http.ms
+++ b/src/swish/http.ms
@@ -1197,8 +1197,13 @@
     (receive (after 1000 (throw 'get-msg-timeout))
       [#(ws:message ,@from ,msg) msg]))
 
-  (define (send/expect p1 p2 data)
-    (ws:send p1 data)
+  (define (send/expect do-send p1 p2 data)
+    ;; ws:send! is destructive only if data is a bytevector;
+    ;; for strings, we have to convert to utf8 in either case
+    (do-send p1
+      (if (and (eq? do-send ws:send!) (bytevector? data))
+          (bytevector-copy data)
+          data))
     (assert (equal? data (get-msg p2))))
 
   (define primes '(7 11 13 239 241 251))
@@ -1209,8 +1214,12 @@
      (lambda (prime)
        (for-each
         (lambda (size)
-          (send/expect p1 p2 (build-buffer size (make-byte-stream prime)))
-          (send/expect p1 p2 (build-string size (make-byte-stream prime))))
+          (let ([buffer (build-buffer size (make-byte-stream prime))])
+            (send/expect ws:send p1 p2 buffer)
+            (send/expect ws:send! p1 p2 buffer))
+          (let ([str (build-string size (make-byte-stream prime))])
+            (send/expect ws:send p1 p2 str)
+            (send/expect ws:send! p1 p2 str)))
         buffer-sizes))
      primes))
 
@@ -1346,7 +1355,9 @@
     [#(EXIT #(bad-arg ws:send a))
      (catch (ws:send 'test 'a))]
     [#(EXIT #(bad-arg ws:send 0))
-     (catch (ws:send 'test 0))])
+     (catch (ws:send 'test 0))]
+    [#(EXIT #(bad-arg ws:send! 12))
+     (catch (ws:send! 'test 12))])
    'ok))
 
 (http-mat websocket-linking ()

--- a/src/swish/io.ms
+++ b/src/swish/io.ms
@@ -1110,17 +1110,24 @@
        (match-let*
         ([`(catch #(bad-arg fn bad)) (try (fn arg ...))] ...)
         'ok)]))
-  (assert-bad-args
-   [123 (open-file-port 123 O_RDONLY S_IFREG)]
-   [123 (get-real-path 123)]
-   [123 (get-stat 123)]
-   [123 (list-directory 123)]
-   [123 (read-file 123)]
-   [123 (spawn-os-process 123 '() self)]
-   [(oops) (spawn-os-process "nosuchfile" '(oops) self)]
-   [due (spawn-os-process "nosuchfile" '() 'due)]
-   [123 (spawn-os-process-detached 123 '())]
-   [(oops) (spawn-os-process-detached"nosuchfile" '(oops))]))
+  (define listener (listen-tcp "::1" 0 self))
+  (define-values (cip cop)
+    (connect-tcp
+     (listener-address listener)
+     (listener-port-number listener)))
+  (on-exit (begin (close-port cip) (close-port cop) (close-tcp-listener listener))
+    (assert-bad-args
+     [123 (open-file-port 123 O_RDONLY S_IFREG)]
+     [123 (get-real-path 123)]
+     [123 (get-stat 123)]
+     [123 (list-directory 123)]
+     [123 (read-file 123)]
+     [123 (spawn-os-process 123 '() self)]
+     [(oops) (spawn-os-process "nosuchfile" '(oops) self)]
+     [due (spawn-os-process "nosuchfile" '() 'due)]
+     [123 (spawn-os-process-detached 123 '())]
+     [(oops) (spawn-os-process-detached"nosuchfile" '(oops))]
+     [,cip (make-tcp-write2 cip)])))
 
 (isolate-mat notify-port ()
   (define-syntax foreach

--- a/src/swish/io.ms
+++ b/src/swish/io.ms
@@ -1037,4 +1037,130 @@
    [123 (spawn-os-process-detached 123 '())]
    [(oops) (spawn-os-process-detached"nosuchfile" '(oops))]))
 
+(isolate-mat notify-port ()
+  (define-syntax foreach
+    (syntax-rules ()
+      [(_ ([v ls] ...) e0 e1 ...)
+       (for-each (lambda (v ...) e0 e1 ...) ls ...)]))
+  (define checked-error-case? #f)
+  (define (test-tcp data cpbs-before cpbs-after chunks)
+    (define size (bytevector-length data))
+    (define chunk-size (max 1 (quotient size chunks)))
+    (define-syntax do-write
+      (syntax-rules ()
+        [(_ op check-n check-calls)
+         (let* ([n (put-bytevector-some op data 0 chunk-size)]
+                [! (when (zero? (port-output-index op))
+                     ;; initial write flushed buffer before we were instrumented, so update check-n
+                     (set! check-n (+ check-n n)))]
+                [fp (port-position op)]
+                [new-op
+                 ;; instrument port while we may have some buffered data
+                 (port->notify-port op
+                   (lambda (count)
+                     (set! check-calls (+ check-calls 1))
+                     (set! check-n (+ check-n count))))])
+           (assert (port-closed? op))
+           (assert (= fp (port-position new-op)))
+           (let lp ([n n])
+             (let ([remaining (- size n)])
+               (when (> remaining 0)
+                 (let ([block-size (min remaining chunk-size)])
+                   (lp (+ n (put-bytevector-some new-op data n block-size)))))))
+           ;; don't close the port yet; that would also close the input side
+           (flush-output-port new-op)
+           new-op)]))
+    (define-syntax do-read
+      (syntax-rules ()
+        [(_ ip check-n check-calls dest-op)
+         (let* ([bv (get-bytevector-n ip chunk-size)]
+                [n (bytevector-length bv)]
+                [! (set! check-n (+ check-n n))]
+                [! (put-bytevector dest-op bv)]
+                [fp (port-position ip)]
+                [new-ip
+                 ;; instrument port while we may have some buffered data
+                 (port->notify-port ip
+                   (lambda (count)
+                     (set! check-calls (+ check-calls 1))
+                     (set! check-n (+ check-n count))))])
+           (assert (port-closed? ip))
+           (assert (= fp (port-position new-ip)))
+           (let lp ([n n])
+             (let ([remaining (- size n)])
+               (when (> remaining 0)
+                 (let* ([block-size (min remaining chunk-size)]
+                        [bv (get-bytevector-n new-ip block-size)])
+                   (assert (bytevector? bv))
+                   (put-bytevector dest-op bv)
+                   (lp (+ n (bytevector-length bv))))))))]))
+    (define sip-calls 0)
+    (define sop-calls 0)
+    (define cip-calls 0)
+    (define cop-calls 0)
+    (define sip-n 0)
+    (define sop-n 0)
+    (define cip-n 0)
+    (define cop-n 0)
+    (custom-port-buffer-size cpbs-before)
+    (let* ([listener (listen-tcp "::" 0 self)]
+           [test-port (listener-port-number listener)])
+      (on-exit (close-tcp-listener listener)
+        (let-values ([(cip cop) (connect-tcp "::1" test-port)])
+          (unless checked-error-case?
+            (match (try (port->notify-port cip 'bad-proc))
+              [`(catch #(bad-arg port->notify-port bad-proc))
+               (set! checked-error-case? #t)]))
+          (receive (after 5000 (throw 'timeout-connecting-tcp))
+            [#(accept-tcp ,@listener ,sip ,sop)
+             (spawn&link
+              (lambda ()
+                (custom-port-buffer-size cpbs-after)
+                (let-values ([(op get) (open-bytevector-output-port)])
+                  (do-read sip sip-n sip-calls op)
+                  (assert (equal? data (get)))
+                  (close-port (do-write sop sop-n sop-calls)))))])
+          (custom-port-buffer-size cpbs-after)
+          (let ([new-cop (do-write cop cop-n cop-calls)])
+            (let-values ([(op get) (open-bytevector-output-port)])
+              (do-read cip cip-n cip-calls op)
+              (assert (equal? data (get))))
+            (close-port new-cop))
+          (match-let* ([,@size sip-n]
+                       [,@size sop-n]
+                       [,@size cip-n]
+                       [,@size cop-n]
+                       [#t (= sip-calls cip-calls)]
+                       [,low (* sip-calls chunk-size)]
+                       [,high (+ low chunk-size)]
+                       [#t (<= low size high)]
+                       ;; The number of cop-calls and sop-calls is complicated
+                       ;; by Chez Scheme's internal max-put-copy constant. Calls
+                       ;; to put-bytevector-some below a certain size (currently
+                       ;; 256) will copy bytes to the ports buffer without going
+                       ;; through the instrumented w! procedure.
+                       [#t (>= cop-calls 1)]
+                       [#t (>= sop-calls 1)])
+            'ok)))))
+  (define (live-osi-ports) (gc) (osi-port-count))
+  (define original-ports (live-osi-ports))
+  (foreach ([size buffer-sizes])
+    (foreach ([prime primes])
+      (let ([buf (build-buffer size (make-byte-stream prime))])
+        ;; increasing buffer size: allocate new and copy
+        (test-tcp buf 512 1000 7)
+        ;; decreeasing buffer size: reuse original
+        (test-tcp buf 1000 512 7)
+        ;; different number of chunks
+        (test-tcp buf 1000 512 128))))
+  (match-let*
+   ([,bad-port (open-input-string "")]
+    [`(catch #(bad-arg port->notify-port ,@bad-port))
+     (try (port->notify-port bad-port values))]
+    [#t checked-error-case?]
+    ;; check that we collected the osi-ports
+    [#t (<= (live-osi-ports) original-ports)])
+   'ok)
+  )
+
 (hook-console-input)

--- a/src/swish/io.ms
+++ b/src/swish/io.ms
@@ -405,6 +405,91 @@
       (gc)
       (assert (handle-gone? (g))))))
 
+;; This test shows why we can't re-use the port's buffer as the codec buffer
+;; for an output port.
+(isolate-mat make-codec-buffer ()
+  (define fill-char #\A)
+  (define test-dir
+    (make-directory-path (path-combine (tmp-dir) "make-codec-buffer")))
+  ;; test reusing port's buffer as codec buffer with multi-byte character
+  ;; encoding at that crosses a buffer boundary
+  (define (check buffer-size)
+    ;; characters with 2-byte, 3-byte, and 4-byte utf-8 encodings
+    (define mischief '(#\δ #\Ⓓ #\🌓))
+    (define bv-len (* 2 buffer-size))
+    (define payload (make-bytevector bv-len))
+    (for-each
+     (lambda (mb-char)
+       (let* ([mbce-bv (string->utf8 (string mb-char))]
+              [mbce-len (bytevector-length mbce-bv)])
+         ;; try each overlap near buffer boundary
+         (do ([i 0 (+ i 1)]) ((= i mbce-len))
+           (let ([offset (- bv-len i mbce-len)])
+             (bytevector-fill! payload (char->integer fill-char))
+             (bytevector-copy! mbce-bv 0 payload offset mbce-len)
+             (assert (equal? payload (string->utf8 (utf8->string payload))))
+             (parameterize ([file-buffer-size buffer-size]
+                            [custom-port-buffer-size buffer-size])
+               (check-crossing payload offset mb-char
+                 (- bv-len (- mbce-len 1))))))))
+     mischief))
+  (define (check-crossing payload offset mb-char str-len)
+    (define utf8-file (make-directory-path (path-combine test-dir "file.utf8")))
+    ;; write binary file and read as text
+    (let ([bin-op (open-binary-file-to-replace utf8-file)])
+      (on-exit (close-port bin-op)
+        (put-bytevector bin-op payload))
+      (let* ([ip (open-file-to-read utf8-file)]
+             [s (on-exit (close-port ip) (get-string-all ip))])
+        (assert (= (string-length s) str-len))
+        (do ([i 0 (+ i 1)]) ((= i str-len))
+          (match-let* ([,expected (if (= i offset) mb-char fill-char)]
+                       [,@expected (string-ref s i)])
+            'ok)))
+      ;; Check use of port-position for input port.
+      ;;
+      ;; Chez Scheme's custom-binary-port set-position! handler invalidates the
+      ;; buffered data so we call the OS to fill port's buffer (which is also
+      ;; internal codec buffer in Swish) and we can safely decode multi-byte
+      ;; character sequence.
+      (let* ([ip (open-file-to-read utf8-file)]
+             [positions (make-fxvector str-len)])
+        (do ([i 0 (+ i 1)]) ((fx= i str-len))
+          (fxvector-set! positions i (port-position ip))
+          (read-char ip))
+        (do ([i 0 (+ i 1)]) ((fx= i str-len))
+          (let ([j (random str-len)]
+                [tmp (fxvector-ref positions i)])
+            (fxvector-set! positions i (fxvector-ref positions j))
+            (fxvector-set! positions j tmp)))
+        (do ([i 0 (+ i 1)]) ((fx= i str-len))
+          (let ([j (fxvector-ref positions i)])
+            (set-port-position! ip j)
+            (match-let* ([,expected (if (= j offset) mb-char fill-char)]
+                         [,@expected (read-char ip)])
+              'ok)))))
+    ;; write text and read as binary
+    (let ([op (open-file-to-replace utf8-file)])
+      (on-exit (close-port op)
+        (put-string op (utf8->string payload)))
+      (let* ([bip (open-binary-file-to-read utf8-file)]
+             [bv (on-exit (close-port bip) (get-bytevector-all bip))])
+        (match-let* ([,@payload bv])
+          'ok))))
+  (assert (= 1 (bytevector-length (string->utf8 (string fill-char)))))
+  (delete-tree test-dir)
+  (on-exit (delete-tree test-dir)
+    (parameterize ([transcoded-port-buffer-size 1])
+      (check 4) ;; minimum buffer size
+      (check 128)
+      (check 511) ;; not a power of two
+      (check 2048))
+    (parameterize ([transcoded-port-buffer-size 1024])
+      (check 4) ;; minimum buffer size
+      (check 128)
+      (check 511) ;; not a power of two
+      (check 2048))))
+
 (isolate-mat read ()
   (read-bytevector "src/swish/io.ms" (read-file "src/swish/io.ms")))
 

--- a/src/swish/io.ss
+++ b/src/swish/io.ss
@@ -77,6 +77,7 @@
    path-watcher-create-time
    path-watcher-path
    path-watcher?
+   port->notify-port
    print-foreign-handles
    print-osi-ports
    print-path-watchers
@@ -129,13 +130,23 @@
     ctime
     birthtime)
 
+  ;; decided it was better to add a subtype field than to lose (sealed #t)
   (define-record-type osi-port
     (nongenerative)
     (sealed #t)
     (fields
      (immutable name)
      (immutable create-time)
+     (immutable subtype)
      (mutable handle)))
+
+  ;; Use port-subtype (not _port_subtypes) so we get compile-time checking that
+  ;; element is in the universe while letting everything expand into eq? check.
+  (define-enumeration port-subtype (fd file tcp pipe) _port_subtypes)
+
+  (define (tcp-osi-port? x)
+    (and (osi-port? x)
+         (eq? (osi-port-subtype x) (port-subtype tcp))))
 
   (define (get-osi-port-handle who p)
     (unless (osi-port? p)
@@ -184,17 +195,20 @@
     (unless (osi-port? port)
       (bad-arg 'close-osi-port port))
     (with-interrupts-disabled
-     (let ([handle (osi-port-handle port)])
-       (when handle
-         (match (osi_close_port* handle
-                  (let ([p self])
-                    (lambda (result) ;; ignore failures
-                      (keep-live port)
-                      (complete-io p))))
-           [#t
-            (osi-ports port #f)
-            (wait-for-io (osi-port-name port))]
-           [(,who . ,errno) (io-error (osi-port-name port) who errno)])))))
+     (@close-osi-port port)))
+
+  (define (@close-osi-port port)
+    (let ([handle (osi-port-handle port)])
+      (when handle
+        (match (osi_close_port* handle
+                 (let ([p self])
+                   (lambda (result) ;; ignore failures
+                     (keep-live port)
+                     (complete-io p))))
+          [#t
+           (osi-ports port #f)
+           (wait-for-io (osi-port-name port))]
+          [(,who . ,errno) (io-error (osi-port-name port) who errno)]))))
 
   (define (force-close-output-port op)
     (unless (port-closed? op)
@@ -215,35 +229,81 @@
   (define (binary->utf8 bp)
     (transcoded-port bp (make-utf8-transcoder)))
 
-  (define (make-iport name port close?)
-    (define fp 0)
-    (define (r! bv start n)
-      (let ([count (read-osi-port port bv start n -1)])
-        (set! fp (+ fp count))
-        count))
-    (define (gp) fp)
-    (make-custom-binary-input-port name r! gp #f
-      (and close? (lambda () (close-osi-port port)))))
+  ;; Chez Scheme's custom ports don't provide a way to associate custom data with the port.
+  (define scheme-port->osi-port (make-weak-eq-hashtable))
+  (define (@set-port-osi-port! port osi-port)
+    (cond
+     [(not osi-port) (eq-hashtable-delete! scheme-port->osi-port port)]
+     [(tcp-osi-port? osi-port)
+      (eq-hashtable-set! scheme-port->osi-port port osi-port)]
+     ;; restrict to TCP ports for now
+     [else (void)]))
+
+  (define (@port-osi-port p)
+    (eq-hashtable-ref scheme-port->osi-port p #f))
+
+  (define-syntax maybe-hook
+    (syntax-rules ()
+      [(_ orig-expr notify!-expr)
+       (let ([orig orig-expr] [notify! notify!-expr])
+         (if (not notify!)
+             orig
+             (lambda (bv start n)
+               (let ([count (orig bv start n)])
+                 (notify! count)
+                 count))))]))
+
+  (define @make-iport
+    (case-lambda
+     [(name port close?) (@make-iport name port close? #f 0)]
+     [(name port close? on-r! current-fp)
+      (define fp current-fp)
+      (define (r! bv start n)
+        (let ([count (read-osi-port port bv start n -1)])
+          (set! fp (+ fp count))
+          count))
+      (define (gp) fp)
+      (define (close)
+        (with-interrupts-disabled
+         (@set-port-osi-port! p #f)
+         (when close? (@close-osi-port port))))
+      (define p
+        (make-custom-binary-input-port name (maybe-hook r! on-r!)
+          gp #f close))
+      (@set-port-osi-port! p port)
+      p]))
 
   (define (make-osi-input-port p)
     (unless (osi-port? p)
       (bad-arg 'make-osi-input-port p))
-    (make-iport (osi-port-name p) p #t))
+    (with-interrupts-disabled
+     (@make-iport (osi-port-name p) p #t)))
 
-  (define (make-oport name port)
-    (define fp 0)
-    (define (w! bv start n)
-      (let ([count (write-osi-port port bv start n -1)])
-        (set! fp (+ fp count))
-        count))
-    (define (gp) fp)
-    (define (close) (close-osi-port port))
-    (make-custom-binary-output-port name w! gp #f close))
+  (define @make-oport
+    (case-lambda
+     [(name port) (@make-oport name port #f 0)]
+     [(name port on-w! current-fp)
+      (define fp current-fp)
+      (define (w! bv start n)
+        (let ([count (write-osi-port port bv start n -1)])
+          (set! fp (+ fp count))
+          count))
+      (define (gp) fp)
+      (define (close)
+        (with-interrupts-disabled
+         (@set-port-osi-port! p #f)
+         (@close-osi-port port)))
+      (define p
+        (make-custom-binary-output-port name (maybe-hook w! on-w!)
+          gp #f close))
+      (@set-port-osi-port! p port)
+      p]))
 
   (define (make-osi-output-port p)
     (unless (osi-port? p)
       (bad-arg 'make-osi-output-port p))
-    (make-oport (osi-port-name p) p))
+    (with-interrupts-disabled
+     (@make-oport (osi-port-name p) p)))
 
   (define (open-utf8-bytevector bv)
     (binary->utf8 (open-bytevector-input-port bv)))
@@ -405,8 +465,11 @@
   (define osi-port-count (foreign-handle-count 'osi-ports))
   (define print-osi-ports (foreign-handle-print 'osi-ports))
 
-  (define (@make-osi-port name handle)
-    (osi-ports (make-osi-port name (erlang:now) handle) handle))
+  (define @make-osi-port
+    (case-lambda
+     [(name handle) (@make-osi-port name handle (port-subtype file))]
+     [(name handle subtype)
+      (osi-ports (make-osi-port name (erlang:now) subtype handle) handle)]))
 
   ;; Path watching
 
@@ -681,7 +744,7 @@
     (with-interrupts-disabled
      (match (osi_open_fd* fd close?)
        [(,who . ,errno) (io-error name who errno)]
-       [,handle (@make-osi-port name handle)])))
+       [,handle (@make-osi-port name handle (port-subtype fd))])))
 
   (define (tilde-expand path)
     (if (and (> (string-length path) 0)
@@ -863,11 +926,11 @@
        [#(,to-stdin ,from-stdout ,from-stderr ,os-pid)
         (values
          (let ([name (format "process ~d stdin" os-pid)])
-           (make-oport name (@make-osi-port name to-stdin)))
+           (@make-oport name (@make-osi-port name to-stdin (port-subtype pipe))))
          (let ([name (format "process ~d stdout" os-pid)])
-           (make-iport name (@make-osi-port name from-stdout) #t))
+           (@make-iport name (@make-osi-port name from-stdout (port-subtype pipe)) #t))
          (let ([name (format "process ~d stderr" os-pid)])
-           (make-iport name (@make-osi-port name from-stderr) #t))
+           (@make-iport name (@make-osi-port name from-stderr (port-subtype pipe)) #t))
          os-pid)]
        [(,who . ,errno) (io-error path who errno)])))
 
@@ -949,10 +1012,10 @@
                           (send process
                             `#(accept-tcp-failed ,listener ,(car r) ,(cdr r)))
                           (let* ([name (@safe-get-ip-address r "")]
-                                 [port (@make-osi-port name r)])
+                                 [port (@make-osi-port name r (port-subtype tcp))])
                             (send process
-                              `#(accept-tcp ,listener ,(make-iport name port #f)
-                                  ,(make-oport name port)))))
+                              `#(accept-tcp ,listener ,(@make-iport name port #f)
+                                  ,(@make-oport name port)))))
                       (unless (pair? r)
                         (osi_close_port* r 0))))))
        [(,who . ,errno)
@@ -987,7 +1050,7 @@
                   (lambda (r)
                     (if (pair? r)
                         (set! result r)
-                        (set! result (@make-osi-port (@safe-get-ip-address r name) r)))
+                        (set! result (@make-osi-port (@safe-get-ip-address r name) r (port-subtype tcp))))
                     (complete-io p))))
          [#t
           (wait-for-io name)
@@ -995,7 +1058,59 @@
             [(,who . ,errno) (io-error name who errno)]
             [,port
              (let ([name (osi-port-name port)])
-               (values (make-iport name port #f) (make-oport name port)))])]))))
+               (values (@make-iport name port #f) (@make-oport name port)))])]))))
+
+  (define (reuse-or-make-new-buffer p get-buffer)
+    (define (reuse-or-make orig get-length make-new copy!)
+      (let ([len (get-length orig)])
+        (if (fx>= len target-len)
+            orig
+            (let ([new (make-new target-len)])
+              (copy! orig 0 new 0 len)
+              new))))
+    (define orig (get-buffer p))
+    (define target-len (custom-port-buffer-size))
+    (cond
+     [(bytevector? orig)
+      (reuse-or-make orig bytevector-length make-bytevector bytevector-copy!)]
+     [else not-reached]))
+
+  (define (port->notify-port p notify!)
+    (define who 'port->notify-port)
+    (with-interrupts-disabled
+     (let ([osi-port (@port-osi-port p)])
+       (define (return new-p)
+         ;; prevent close-port from closing underlying osi-port if we collect p
+         (mark-port-closed! p)
+         (@set-port-osi-port! p #f)
+         (@set-port-osi-port! new-p osi-port)
+         new-p)
+       ;; limited to TCP ports for now
+       (unless (tcp-osi-port? osi-port) (bad-arg who p))
+       (unless (procedure? notify!) (bad-arg who notify!))
+       ;; see Chez Scheme's binary-custom-port-port-position for fp calculations below
+       (cond
+        [(input-port? p)
+         (let* ([fp (- (port-position p) (port-input-count p))]
+                [new-ip (@make-iport (port-name p) osi-port
+                          ;; preserve no close for tcp input port
+                          (not (tcp-osi-port? osi-port))
+                          notify! fp)])
+           (set-port-input-buffer! new-ip
+             (reuse-or-make-new-buffer p port-input-buffer))
+           (set-port-input-size! new-ip (port-input-size p))
+           (set-port-input-index! new-ip (port-input-index p))
+           (return new-ip))]
+        [(output-port? p)
+         (let* ([out-index (port-output-index p)]
+                [fp (- (port-position p) out-index)]
+                [new-op (@make-oport (port-name p) osi-port notify! fp)])
+           (set-port-output-buffer! new-op
+             (reuse-or-make-new-buffer p port-output-buffer))
+           (set-port-output-size! new-op (port-output-size p))
+           (set-port-output-index! new-op out-index)
+           (return new-op))]
+        [else not-reached]))))
 
   (define-record-type sighandler
     (nongenerative)

--- a/src/swish/io.ss
+++ b/src/swish/io.ss
@@ -98,6 +98,7 @@
    stat-directory?
    stat-regular-file?
    tcp-listener-count
+   tcp-nodelay
    watch-path
    with-sfd-source-offset
    write-osi-port
@@ -1119,6 +1120,14 @@
            (set-port-output-index! new-op out-index)
            (return new-op))]
         [else not-reached]))))
+
+  (define (tcp-nodelay port enabled?)
+    (arg-check 'tcp-nodelay [port output-port?])
+    (with-interrupts-disabled
+     (let ([osi-port (@port-osi-port port)])
+       (unless (tcp-osi-port? osi-port)
+         (errorf 'tcp-nodelay "invalid port ~s" port))
+       (osi_tcp_nodelay (osi-port-handle osi-port) enabled?))))
 
   (define-record-type sighandler
     (nongenerative)

--- a/src/swish/meta.ss
+++ b/src/swish/meta.ss
@@ -30,6 +30,7 @@
    find-clause
    find-source
    get-clause
+   not-reached
    pretty-syntax-violation
    profile-me
    profile-me-as
@@ -64,7 +65,12 @@
   (define-syntax (profile-omit x)
     (syntax-case x ()
       [(kwd expr ...)
-       (datum->syntax #'kwd `(begin ,@(syntax->datum #'(expr ...))))]))
+       (if (compile-profile)
+           (datum->syntax #'kwd `(begin ,@(syntax->datum #'(expr ...))))
+           #`(begin expr ...))]))
+
+  (define-syntax not-reached
+    (identifier-syntax (profile-omit (assert #f))))
 
   (define (find-source x)
     (let ([annotation (syntax->annotation x)])

--- a/src/swish/osi.c
+++ b/src/swish/osi.c
@@ -600,6 +600,14 @@ static void watch_path_cb(uv_fs_event_t* handle, const char* filename, int event
   osi_add_callback2(callback, Sstring_utf8(filename, -1), Sinteger(events));
 }
 
+ptr osi_tcp_nodelay(uptr port, int enable) {
+  stream_port_t* p = (stream_port_t*)port;
+  if (p->vtable != &tcp_vtable)
+    return osi_make_error_pair("uv_tcp_nodelay", UV_EINVAL);
+  int rc = uv_tcp_nodelay(&(p->h.tcp), enable);
+  return (rc < 0) ? Sfalse : Strue;
+}
+
 static int string_list_length(ptr x) {
   int n = 0;
   while (Spairp(x)) {

--- a/src/swish/osi.h
+++ b/src/swish/osi.h
@@ -106,6 +106,7 @@ EXPORT ptr osi_listen_tcp(const char* address, uint16_t port, ptr callback);
 EXPORT void osi_close_tcp_listener(uptr listener);
 EXPORT ptr osi_get_tcp_listener_port(uptr listener);
 EXPORT ptr osi_get_ip_address(uptr port);
+EXPORT ptr osi_tcp_nodelay(uptr port, int enable);
 
 // Message Digest
 EXPORT ptr osi_open_SHA1();

--- a/src/swish/osi.h
+++ b/src/swish/osi.h
@@ -74,6 +74,8 @@ EXPORT ptr osi_read_port(uptr port, ptr buffer, size_t start_index, uint32_t siz
 EXPORT ptr osi_write_port(uptr port, ptr buffer, size_t start_index, uint32_t size, int64_t offset, ptr callback);
 EXPORT ptr osi_close_port(uptr port, ptr callback);
 
+EXPORT ptr osi_tcp_write2(uptr port, ptr bv1, ptr bv2, size_t start_index2, uint32_t size2, ptr callback);
+
 // Process
 EXPORT void osi_exit(int status);
 EXPORT ptr osi_spawn(const char* path, ptr args, ptr callback);

--- a/src/swish/osi.ss
+++ b/src/swish/osi.ss
@@ -125,6 +125,7 @@
    osi_stop_signal*
    osi_tcp_nodelay
    osi_tcp_nodelay*
+   osi_tcp_write2*
    osi_unlink
    osi_unlink*
    osi_unmarshal_bindings
@@ -190,6 +191,8 @@
   (define-osi osi_read_port (port uptr) (buffer ptr) (start-index size_t) (size unsigned-32) (offset integer-64) (callback ptr))
   (define-osi osi_write_port (port uptr) (buffer ptr) (start-index size_t) (size unsigned-32) (offset integer-64) (callback ptr))
   (define-osi osi_close_port (port uptr) (callback ptr))
+
+  (define-osi osi_tcp_write2 (port uptr) (bv1 ptr) (bv2 ptr) (start-index2 size_t) (size2 unsigned-32) (callback ptr))
 
   ;; Process
   (fdefine osi_exit (status int) void)

--- a/src/swish/osi.ss
+++ b/src/swish/osi.ss
@@ -123,6 +123,8 @@
    osi_step_statement*
    osi_stop_signal
    osi_stop_signal*
+   osi_tcp_nodelay
+   osi_tcp_nodelay*
    osi_unlink
    osi_unlink*
    osi_unmarshal_bindings
@@ -219,6 +221,7 @@
   (fdefine osi_close_tcp_listener (listener uptr) void)
   (define-osi osi_get_tcp_listener_port (listener uptr))
   (define-osi osi_get_ip_address (port uptr))
+  (define-osi osi_tcp_nodelay (port uptr) (enabled? boolean))
 
   (define (uuid->string uuid)
     (unless (and (bytevector? uuid) (= (bytevector-length uuid) 16))

--- a/src/swish/run.c
+++ b/src/swish/run.c
@@ -102,6 +102,7 @@ static void swish_init(void) {
   add_foreign(osi_start_signal);
   add_foreign(osi_step_statement);
   add_foreign(osi_stop_signal);
+  add_foreign(osi_tcp_nodelay);
   add_foreign(osi_unlink);
   add_foreign(osi_unmarshal_bindings);
   add_foreign(osi_watch_path);

--- a/src/swish/run.c
+++ b/src/swish/run.c
@@ -103,6 +103,7 @@ static void swish_init(void) {
   add_foreign(osi_step_statement);
   add_foreign(osi_stop_signal);
   add_foreign(osi_tcp_nodelay);
+  add_foreign(osi_tcp_write2);
   add_foreign(osi_unlink);
   add_foreign(osi_unmarshal_bindings);
   add_foreign(osi_watch_path);

--- a/src/swish/unsafe.ss
+++ b/src/swish/unsafe.ss
@@ -1,0 +1,47 @@
+;;; Copyright 2023 Beckman Coulter, Inc.
+;;;
+;;; Permission is hereby granted, free of charge, to any person
+;;; obtaining a copy of this software and associated documentation
+;;; files (the "Software"), to deal in the Software without
+;;; restriction, including without limitation the rights to use, copy,
+;;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;;; of the Software, and to permit persons to whom the Software is
+;;; furnished to do so, subject to the following conditions:
+;;;
+;;; The above copyright notice and this permission notice shall be
+;;; included in all copies or substantial portions of the Software.
+;;;
+;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;;; DEALINGS IN THE SOFTWARE.
+
+;; This file provides macros that are for internal use only.
+;;
+;; We could pull these in via a library but there is currently no way to unload
+;; a library. In general we can't provide these macros via internal.ss because
+;; that breaks "#!eof mats" since they run after we evaluate boot.ss and poison
+;; $import-internal.
+
+;; Use with care. Build with UNSAFE_PRIMITIVES=no to disable.
+(define-syntax declare-unsafe-primitives
+  (if (equal? (getenv "UNSAFE_PRIMITIVES") "no")
+      (syntax-rules () [(_ ...) (begin)])
+      (syntax-rules ()
+        [(_ prim ...)
+         (begin
+           (define-syntax prim (identifier-syntax ($primitive 3 prim)))
+           ...)])))
+
+;; Use with care. Unlike with-interrupts-disabled, no-interrupts is unsafe if
+;; body forms can raise an exception.
+(define-syntax no-interrupts
+  (syntax-rules ()
+    [(_ body ...)
+     (let ([x (begin (disable-interrupts) body ...)])
+       (enable-interrupts)
+       x)]))

--- a/src/swish/websocket.ss
+++ b/src/swish/websocket.ss
@@ -500,6 +500,7 @@
               [(eq? reason 'normal) 1000]
               [(eq? reason 'websocket-message-limit-exceeded) 1009]
               [(i/o-decoding-error? reason) 1007]
+              [(condition? reason) 1011]
               [else 1002])
              "")]
           [`(EXIT ,@process ,reason)

--- a/src/swish/websocket.ss
+++ b/src/swish/websocket.ss
@@ -498,6 +498,7 @@
            (do-close reason
              (cond
               [(eq? reason 'normal) 1000]
+              [(eq? reason 'websocket-message-limit-exceeded) 1009]
               [(i/o-decoding-error? reason) 1007]
               [else 1002])
              "")]

--- a/src/swish/websocket.ss
+++ b/src/swish/websocket.ss
@@ -565,6 +565,7 @@
       (handshake conn request)
       (http:switch-protocol
        (lambda (ip op)
+         (tcp-nodelay op #t)
          (ws:established ip op #f process options)))]))
 
   (define ws:connect
@@ -579,6 +580,7 @@
         [process process?]
         [options (ws:options is?)])
       (let-values ([(ip op) (http-upgrade hostname port request)])
+        (tcp-nodelay op #t)
         (spawn
          (lambda ()
            (ws:established ip op #t process options))))]))


### PR DESCRIPTION
This pull request:
* fixes an issue where we could close a WebSocket due to ping timeout while reading fragmented payloads (To do this, we add a `port->notify-port` mechanism that allows us to monitor the results of `w!` or `r!` for TCP custom ports.);

* provides more accurate `ws:closed` codes when closing a WebSocket;

* adds a test to verify that we process WebSocket pong messages;

* adds a `not-reached` macro that will help us clean up profile coverage output by explicitly calling out cases we should not reach;

* leverages recently added Chez Scheme parameters, if available, to improve both file and WebSocket performance;

* adds infrastructure for using optimized unsafe primitives while adding a CI build that tests with safe versions of these primitives (naturally such code requires careful review, but the ability to test with safe primitives is an improvement over hard-coding `#3%` primitives),

* adds a way to disable Nagle's algorithm and uses this for WebSocket,

* fixes code that assumed `get_bytevector-n` would return as many bytes as requested,

* reduces copying by masking WebSocket payloads in place,

* tries to reduce copying by reusing the first payload as codec buffer,

* adds and uses `osi_tcp_write2` to send the header and payload in a single system call without copying.
