### PR TITLE
export and simplify get-bytevector-exactly-n

### DIFF
--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -1790,6 +1790,20 @@ cleared with \code{(clear-output-port \var{op})}, and
 \code{(close-output-port \var{op})} is called again.
 
 % ----------------------------------------------------------------------------
+\defineentry{get-bytevector-exactly-n}
+\begin{procedure}
+  \code{(get-bytevector-exactly-n \var{ip} \var{n})}
+\end{procedure}
+\returns{} a bytevector of length \var{n}
+
+The \code{get-bytevector-exactly-n} procedure takes a binary input
+port \var{ip} and an exact nonnegative integer \var{n} and
+returns a bytevector of the next \var{n} bytes from \var{ip}.
+If \var{ip} reaches end-of-file before it obtains \var{n} bytes,
+\code{get-bytevector-exactly-n} throws an \code{unexpected-eof}
+exception.
+
+% ----------------------------------------------------------------------------
 \defineentry{get-datum/annotations-all}
 \begin{procedure}
   \code{(get-datum/annotations-all \var{ip} \var{sfd} \var{bfp})}

--- a/src/swish/http.ms
+++ b/src/swish/http.ms
@@ -104,7 +104,7 @@
          (my-respond
           (http:call-with-ports conn
             (lambda (ip op)
-              (get-bytevector-n ip
+              (get-bytevector-exactly-n ip
                 (string->number
                  (or (find-param "count")
                      (http:get-header "Content-Length" header)))))
@@ -255,7 +255,7 @@
     (let* ([status (http:read-status ip 4096)]
            [header (http:read-header ip 1048576)]
            [len (http:get-content-length header)]
-           [content (and len (f (get-bytevector-n ip len)))])
+           [content (and len (f (get-bytevector-exactly-n ip len)))])
       (<response> make
         [status status]
         [header header]

--- a/src/swish/io.ms
+++ b/src/swish/io.ms
@@ -53,7 +53,7 @@
   (let* ([me self]
          [reader (spawn&link
                   (lambda ()
-                    (let ([x (get-bytevector-n ip len)])
+                    (let ([x (get-bytevector-exactly-n ip len)])
                       (send me `#(read ,self ,x)))))])
     (receive [#(read ,@reader ,x) x])))
 
@@ -1166,6 +1166,7 @@
       (syntax-rules ()
         [(_ ip check-n check-calls dest-op)
          (let* ([bv (get-bytevector-n ip chunk-size)]
+                [! (assert (bytevector? bv))]
                 [n (bytevector-length bv)]
                 [! (set! check-n (+ check-n n))]
                 [! (put-bytevector dest-op bv)]
@@ -1254,5 +1255,74 @@
     [#t (<= (live-osi-ports) original-ports)])
    'ok)
   )
+
+(isolate-mat get-bytevector-exactly-n ()
+  (define who 'get-bytevector-exactly-n)
+  (match-let*
+   ([,op-misguided
+     (let-values ([(op get) (open-bytevector-output-port)])
+       op)]
+    [,ip-text (open-input-string "")]
+    ;; must be binary input port
+    [`(catch #(bad-arg ,@who ,@op-misguided))
+     (try (get-bytevector-exactly-n op-misguided 7))]
+    [`(catch #(bad-arg ,@who ,@ip-text))
+     (try (get-bytevector-exactly-n ip-text 7))]
+    ;; must be non-negative fixnum
+    [,ip (open-bytevector-input-port '#vu8(0 1 2 3 4 5 6 7 8 9))]
+    [`(catch #(bad-arg ,@who 2.0))
+     (try (get-bytevector-exactly-n ip 2.0))]
+    [`(catch #(bad-arg ,@who -1))
+     (try (get-bytevector-exactly-n ip -1))]
+    ;; success
+    [#vu8(0 1 2) (get-bytevector-exactly-n ip 3)]
+    [#vu8() (get-bytevector-exactly-n ip 0)]
+    [#vu8(3) (get-bytevector-exactly-n ip 1)]
+    [#vu8(4 5 6 7 8 9) (get-bytevector-exactly-n ip 6)]
+    [#vu8() (get-bytevector-exactly-n ip 0)]
+    ;; fail
+    [`(catch unexpected-eof) (try (get-bytevector-exactly-n ip 1))]
+    [#vu8(1 2 3 4) (begin (file-position ip 1) (get-bytevector-exactly-n ip 4))]
+    [`(catch unexpected-eof) (try (get-bytevector-exactly-n ip (+ 1 (port-input-count ip))))]
+    ;; exercise cases where we must call port's r! multiple times
+    ;; success via retry
+    [,byte 0]
+    [,count 10]
+    [,ip (make-custom-binary-input-port "trickle"
+           (lambda (bv start n)
+             (cond
+              [(= count 0) 0]
+              [else
+               (bytevector-u8-set! bv start byte)
+               (set! byte (fxmod (fx+ byte 1) 256))
+               (set! count (- count 1))
+               1]))
+           #f #f #f)]
+    [#vu8(0) (get-bytevector-exactly-n ip 1)]
+    [#vu8(1 2) (get-bytevector-exactly-n ip 2)]
+    [#vu8(3 4 5) (get-bytevector-exactly-n ip 3)]
+    [#vu8(6 7 8 9) (get-bytevector-exactly-n ip 4)]
+    [,test-n
+     (lambda (len)
+       (set! byte 0)
+       (match-let*
+        ([,bv (get-bytevector-exactly-n ip len)]
+         [#t (bytevector? bv)]
+         [,@len (bytevector-length bv)])
+        (do ([i 0 (fx+ i 1)] [expect 0 (fxmod (fx+ expect 1) 256)])
+            ((fx= i len) 'ok)
+          (assert (fx= expect (bytevector-u8-ref bv i))))))]
+    [,_ (set! count (+ 127 513 4096))]
+    [ok (test-n 127)]
+    [ok (test-n 513)]
+    [ok (test-n 4096)]
+    ;; fail at eof
+    [`(catch unexpected-eof) (try (test-n 1))]
+    [,_ (set! count 7)]
+    [ok (test-n 3)]
+    ;; fail on retry
+    [`(catch unexpected-eof) (try (test-n 5))]
+    )
+   'ok))
 
 (hook-console-input)

--- a/src/swish/io.ss
+++ b/src/swish/io.ss
@@ -23,6 +23,7 @@
 #!chezscheme
 (library (swish io)
   (export
+   $get-bytevector-exactly-n
    <stat>
    <uname>
    binary->utf8
@@ -35,6 +36,7 @@
    force-close-output-port
    foreign-handle-count
    foreign-handle-print
+   get-bytevector-exactly-n
    get-datum/annotations-all
    get-file-size
    get-real-path
@@ -317,6 +319,19 @@
            [ip (binary->utf8 raw-ip)])
       (on-exit (close-port ip)
         (handler ip sfd source-offset))))
+
+  (define ($get-bytevector-exactly-n ip size)
+    (let ([bv (make-bytevector size)])
+      (let ([count (get-bytevector-n! ip bv 0 size)])
+        (if (or (eof-object? count) (not (fx= count size)))
+            (throw 'unexpected-eof)
+            bv))))
+
+  (define (get-bytevector-exactly-n ip size)
+    (arg-check 'get-bytevector-exactly-n
+      [ip input-port? binary-port?]
+      [size fixnum? fxnonnegative?])
+    ($get-bytevector-exactly-n ip size))
 
   (define (get-datum/annotations-all ip sfd bfp)
     (let f ([bfp bfp])

--- a/src/swish/swish-build
+++ b/src/swish/swish-build
@@ -693,7 +693,7 @@
                    (let ([end (get-source-offset ip)])
                      (and (> end 0)
                           (begin (file-position ip 0) #t)
-                          (get-bytevector-n ip end)))))]
+                          (get-bytevector-exactly-n ip end)))))]
               [tmp (tmp-filename output-fn)]
               [ip (open-binary-file-to-read output-fn)]
               [op (open-file tmp (+ O_WRONLY O_CREAT O_TRUNC) #o777 'binary-output)])

--- a/src/swish/websocket.ss
+++ b/src/swish/websocket.ss
@@ -258,17 +258,6 @@
         [127 (get-u64 ip)]
         [,len len]))
 
-    (define (get-bytevector-exactly-n ip size)
-      (declare-unsafe-primitives get-bytevector-n! fx+ fx- fx=)
-      (let ([bv (make-bytevector size)])
-        (let lp ([i 0])
-          (let ([count (get-bytevector-n! ip bv i (fx- size i))])
-            (if (eof-object? count)
-                (throw 'unexpected-eof)
-                (let ([next (fx+ i count)])
-                  (unless (fx= next size) (lp next))))))
-        bv))
-
     (define (read-frame ip limit)
       (let* ([fin&opcode (get-u8 ip)]
              [final? (fxbit-set? fin&opcode 7)]
@@ -283,8 +272,8 @@
                   (throw `#(websocket-control-frame-too-long ,payload-len)))]
              [_ (when (> payload-len limit)
                   (throw 'websocket-message-limit-exceeded))]
-             [mask-key (and masked? (get-bytevector-exactly-n ip 4))]
-             [payload (get-bytevector-exactly-n ip payload-len)])
+             [mask-key (and masked? ($get-bytevector-exactly-n ip 4))]
+             [payload ($get-bytevector-exactly-n ip payload-len)])
         (when masked?
           (mask-bytevector! payload 0 payload-len mask-key))
         (values final? opcode payload)))


### PR DESCRIPTION
Export `get-bytevector-exactly-n` since there were other places where we tried to read a fixed field of _n_ bytes off the wire without checking the length of the result returned by `get-bytevector-n`.

We can simplify the code extracted from websocket.ss since Chez Scheme already handles the looping internally. We just need to check the result.
