### PR TITLE
Adapt define-syntactic-monad

### DIFF
--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -3358,3 +3358,79 @@ condition within the compound condition it constructs.
 The \code{with-temporaries} macro binds each macro-language
 pattern variable \var{id} to a fresh generated identifier
 within the body \code{(begin \var{e0}\ \var{e1}\ \etc)}.
+
+% ----------------------------------------------------------------------------
+\defineentry{define-syntactic-monad}
+\begin{syntax}
+  \code{(define-syntactic-monad \var{m} \var{id} \etc)}
+\end{syntax}
+\expandsto{} see below
+
+The \code{define-syntactic-monad} macro defines a macro \var{m} for defining
+and calling procedures that take implicit \code{\var{id} \etc} arguments in addition
+to any explicit arguments that may be provided.
+Such macros make it easier to write state machines in a functional style
+by allowing the programmer to specify only the values that change at a call.
+
+A call to \var{m} takes the form
+\code{(\var{m} \var{e$_0$} ([\var{id$_i$} \var{e$_i$}] \etc) \var{x} \etc)}
+or
+\code{(\var{m} \var{kwd} \var{form} \etc)}
+where \var{kwd} is
+\code{case-lambda},
+\code{define},
+\code{lambda},
+\code{let},
+\code{trace-case-lambda},
+\code{trace-define},
+\code{trace-lambda}, or
+\code{trace-let}.
+The first form constructs a call to \code{\var{e$_0$}} and is described below
+along with the \code{let} case.
+The other cases may be understood in terms of the following template
+expansions or their natural extension to tracing variants:
+
+~\code{(\var{m} lambda \var{fmls} \var{body} \etc)}
+$\rightarrow$
+\code{(lambda (\var{id} \etc{} . \var{fmls}) \var{body} \etc)}
+
+~\code{(\var{m} define (\var{proc} . \var{fmls}) \var{body} \etc)}
+$\rightarrow$
+\code{(define \var{proc} (\var{m} lambda \var{fmls} \var{body} \etc))}
+
+~\code{(\var{m} case-lambda [\var{fmls} \var{body} \etc] \etc)}
+$\rightarrow$
+\code{(case-lambda [(\var{id} \etc{} . \var{fmls}) \var{body} \etc] \etc)}
+
+The call form
+\code{(\var{m} \var{e$_0$} ([\var{id$_i$} \var{e$_i$}] \etc) \var{x} \etc)}
+constructs a call to \code{\var{e$_0$}} where the arguments are
+the \code{\var{id} \etc} with any \var{id$_i$} replaced by \var{e$_i$}
+all followed by the \code{\var{x} \etc} expressions.
+Any \var{id} that does not have an explicit
+\code{[\var{id$_i$} \var{e$_i$}]} binding in the call form
+must have a binding in scope.
+For calls within the body of an
+\code{(\var{m} case-lambda \etc)},
+\code{(\var{m} define \etc)},
+\code{(\var{m} lambda \etc)}, or
+\code{(\var{m} let \etc)}
+form such bindings are already in scope.
+As a convenience, the call syntax \code{(\var{m} \var{f})} is equivalent to
+\code{(\var{m} \var{f} ())} which specifies an empty list of implicit-binding updates.
+
+The \code{(\var{m} let \etc)} form constructs a named \code{let} using
+syntax inspired by the call form described above.
+That is,
+\code{(\var{m} let \var{name} ([\var{id$_i$} \var{e$_i$}] \etc) ([\var{x$_j$} \var{e$_j$}] \etc) \var{body} \etc)}
+constructs a named \code{let} \var{name}
+that binds \code{\var{id} \etc{} \var{x} \etc}
+with the initial value of each \var{id} coming from
+the value of the corresponding \var{e$_i$}
+or else the binding already in scope
+and the initial value of each \var{x$_j$} supplied by
+the corresponding \var{e$_j$}.
+Within \code{\var{body} \etc}, a call
+of the form \code{(\var{m} \var{name} (\var{id$_i$} \etc) \var{e$_j$} \etc)}
+can supply required values for each of the \var{x$_j$}
+along with new values for \var{id} \etc{} if needed.

--- a/src/swish/dsm.ms
+++ b/src/swish/dsm.ms
@@ -1,0 +1,252 @@
+;;; Copyright 2023 Beckman Coulter, Inc.
+;;;
+;;; Permission is hereby granted, free of charge, to any person
+;;; obtaining a copy of this software and associated documentation
+;;; files (the "Software"), to deal in the Software without
+;;; restriction, including without limitation the rights to use, copy,
+;;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;;; of the Software, and to permit persons to whom the Software is
+;;; furnished to do so, subject to the following conditions:
+;;;
+;;; The above copyright notice and this permission notice shall be
+;;; included in all copies or substantial portions of the Software.
+;;;
+;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;;; DEALINGS IN THE SOFTWARE.
+
+(import
+ (swish dsm)
+ (swish erlang)
+ (swish mat)
+ (swish testing))
+
+(mat dsm-define ()
+  ;; okay to have more than one syntactic monad in scope
+  (define-syntactic-monad M a b c)
+  (define-syntactic-monad G d e)
+  (M define (f0) (list 'f0 a b c))
+  (M define (f1 x) (list 'f1 a b c x))
+  (G define (g0) (vector 'g0 d e))
+  (G define (g2 a b) (vector 'g2 d e a b))
+  (M define (f-1 . more) (list* 'f-1 a b c more))
+  (G define (g-2 x . more) (vector 'g-2 d e x more))
+  (define (circumvent-compile-time-warning f k)
+    ;; we want to check the run-time exception, not the compile-time warning
+    ;; issued when we try to load the mat
+    (let ([loc k]) ;; assign to make cp0 give up
+      (set! loc f)
+      (k loc)))
+  (define-syntax wrong-argument-count
+    (syntax-rules ()
+      [(_ (proc arg ...))
+       (match-let*
+        ([`(catch ,reason)
+          (guard (incorrect-argument-count? reason proc))
+          (try
+           (circumvent-compile-time-warning proc
+             (lambda (f) (f arg ...))))])
+        'ok)]))
+  ;; try fixed args
+  (match-let*
+   ([(f0 x y z) (f0 'x 'y 'z)]
+    [(f0 3 1 2) (f0 3 1 2)]
+    [(f1 p d q "9") (f1 'p 'd 'q "9")]
+    [(f1 4 3 2 1) (f1 4 3 2 1)]
+    [#(g0 2 4) (g0 2 4)]
+    [#(g0 a b) (g0 'a 'b)]
+    [#(g2 m N 10 4) (g2 'm 'N 10 4)]
+    [#(g2 2 4 6 8) (g2 2 4 6 8)])
+   (wrong-argument-count (f0 'a 'b))
+   (wrong-argument-count (f0 'a 'b 'c 'D))
+   (wrong-argument-count (f1 'a 'b 'c 'D 'E))
+   (wrong-argument-count (g0 'd))
+   (wrong-argument-count (g0 'd 'e 'F))
+   (wrong-argument-count (g2 'd 'e 'a))
+   (wrong-argument-count (g2 'd 'e 'a 'b 'c))
+   'ok)
+  ;; try rest args
+  (match-let*
+   ([(f-1 "a" "b" "c" 1 2 3) (f-1 "a" "b" "c" 1 2 3)]
+    [(f-1 "a1" "b2" "c3") (f-1 "a1" "b2" "c3")]
+    [#(g-2 "d1" "e1" "required x" ()) (g-2 "d1" "e1" "required x")]
+    [#(g-2 "d1" "e1" "x" (a b)) (g-2 "d1" "e1" "x" 'a 'b)])
+   (wrong-argument-count (f-1 'a 'b))
+   (wrong-argument-count (g-2 'a 'b))
+   'ok))
+
+(mat dsm-lambda ()
+  (define-syntactic-monad A b c)
+  (define-syntactic-monad D e f g)
+  (define a0 (A lambda () (list 'a0 b c)))
+  (define a1 (A lambda (x) (list 'a1 b c x)))
+  (define d
+    (D case-lambda
+      [() (vector 'd0 e f g)]
+      [(x) (vector 'd1 e f g x)]
+      [(x y) (vector 'd2 e f g x y)]
+      [(x y . more) (vector 'dmore e f g x y more)]))
+  (match-let*
+   ([(a0 1 2) (a0 1 2)]
+    [(a0 c b) (a0 'c 'b)]
+    [(a1 3 4 6) (a1 3 4 6)]
+    [(a1 "a" "b" "c") (a1 "a" "b" "c")]
+    [#(d0 3 4 5) (d 3 4 5)]
+    [#(d1 4 5 6 extra) (d 4 5 6 'extra)]
+    [#(d2 5 6 7 even more) (d 5 6 7 'even 'more)]
+    [#(dmore 1 2 3 A B (c d e)) (d 1 2 3 'A 'B 'c 'd 'e)])
+   'ok))
+
+(mat dsm-let ()
+  (define-syntactic-monad P sym num char other)
+  (define (part ls)
+    (P let rip ([sym '()] [num '()] [char '()] [other '()]) ([ls ls] [i 0])
+      (if (null? ls)
+          (vector (reverse sym) (reverse num) (reverse char) (reverse other))
+          (let ([x (car ls)] [rest (cdr ls)] [next-i (+ i 1)])
+            (cond
+             [(symbol? x) (P rip ([sym (cons (list i x) sym)]) rest next-i)]
+             [(number? x) (P rip ([num (cons (list i x) num)]) rest next-i)]
+             [(char? x) (P rip ([char (cons (list i x) char)]) rest next-i)]
+             [else (P rip ([other (cons (list i x) other)]) rest next-i)])))))
+  (define (no-shadow n)
+    (P let lp ([sym 'a] [num 'b] [char 'c] [other 'd]) ([i 0] [ls '()])
+      (cond
+       [(= i n) (reverse ls)]
+       ;; cons should see current value of sym, num, etc.
+       [(= (mod i 4) 0) (P lp ([sym 'new-sym]) (+ i 1) (cons sym ls))]
+       [(= (mod i 4) 1) (P lp ([num 'new-num]) (+ i 1) (cons num ls))]
+       [(= (mod i 4) 2) (P lp ([char 'new-char]) (+ i 1) (cons char ls))]
+       [(= (mod i 4) 3) (P lp ([other 'new-other]) (+ i 1) (cons other ls))])))
+  (match-let*
+   ([#(() () () ()) (part '())]
+    [#(((0 a) (3 b))
+       ((1 123) (5 -9))
+       ((4 #\a) (6 #\z))
+       ((2 #f) (7 #t) (8 "str")))
+     (part '(a 123 #f b #\a -9 #\z #t "str"))]
+    [(a b c d new-sym new-num new-char new-other) (no-shadow 8)])
+   'ok))
+
+(mat dsm-call ()
+  (define-syntactic-monad FN a b k)
+  (define (f a b k x y)
+    (k a b x y k))
+  (define (g a b k) (+ a b k))
+  (match-let*
+   ([(1 2 3 4 ,@list) (f 1 2 list 3 4)]
+    [(1 2 3 4 ,@list)
+     (let ([a 1] [b 2] [k list])
+       (FN f () 3 4))]
+    [(4 3 ,@vector 2 1)
+     (let ([a 4] [b 3] [k list])
+       ;; rebinding monad variable doesn't shadow rator: we call list not
+       ;; vector, i.e., current value of k not next
+       (FN k ([k vector]) 2 1))]
+    [(10 9 1 2 ,@list)
+     (let ([a 1] [b 2] [k list])
+       ;; rebinding monad variable doesn't shadow rands: we see original values
+       ;; of a and b where we pass them in as x and y
+       (FN f ([b 9] [a 10]) a b))]
+    ;; coverage:
+    [11 (let ([a 1] [b 7] [k 3]) (FN g))])
+   'ok))
+
+(mat dsm-syntax ()
+  (define-syntax assert-syntax-error
+    (syntax-rules ()
+      [(_ message input ...)
+       (match-let*
+        ([`(catch ,reason)
+          (try (expand
+                (read-bytevector "buggy"
+                  (string->utf8
+                   (with-output-to-string
+                    (lambda ()
+                      (pretty-print
+                       '(let ()
+                          (define-syntactic-monad M a b c)
+                          input ...
+                          123))))))))]
+         [,msg message]
+         ;; make sure source info does not point to swish/dsm.ss
+         [,expected (string-append (pregexp-quote msg) " (at|near).* of buggy\\.")]
+         [,actual (exit-reason->english reason)])
+        (unless (pregexp-match expected actual)
+          (printf "expected: ~a at/near ... of buggy.\n" msg)
+          (printf "actual:   ~a\n" actual)
+          (syntax-error #'message "failed to generate expected error"))
+        'ok)]))
+  ;; clash between monad var and extra formal
+  (assert-syntax-error
+   "Exception: invalid parameter list in (lambda (a b c a) a)"
+   (M define (bad a) a))
+  (assert-syntax-error
+   "Exception: invalid parameter list in (lambda (a b c b) a)"
+   (M define (bad b) a))
+  (assert-syntax-error
+   "Exception: invalid parameter list in (lambda (a b c c) a)"
+   (M define (bad c) a))
+  ;; also caught by trace-define
+  (assert-syntax-error
+   "Exception: invalid parameter list in (lambda (a b c a) a)"
+   (M trace-define (bad a) a))
+  ;; variable z is not in monad M
+  (assert-syntax-error
+   "Exception: in syntactic monad M, unrecognized identifier z"
+   (M f ([z 3])))
+  (assert-syntax-error
+   ;; not an ideal error message
+   "Exception: duplicate bound variable a in (let ((p f) (a 3) (a 9)) (p a b c))"
+   (M f ([a 3] [a 9])))
+  (assert-syntax-error
+   ;; not an ideal error message
+   "Exception: invalid parameter list in (lambda (a b c a) 3)"
+   (M lambda (a) 3))
+  )
+
+(mat dsm-trace ()
+  (define-syntactic-monad G x y)
+  (define os (open-output-string))
+  (define f1 (G trace-lambda list3 (z) (list x y z)))
+  (define f23
+    (G trace-case-lambda jump
+      [(a) (G f23 () a #f)]
+      [(a b) (if b (+ a x y) (* a x y))]))
+  (define (g ls)
+    (define x 2)
+    (G trace-let F ([y 5]) ([ls ls] [sum 0])
+      (cond
+       [(null? ls) (+ y sum)]
+       [(> x 0) (G F ([x (- x 1)]) ls (+ x sum))]
+       [else (G F ([y (car ls)]) (cdr ls) (+ y sum))])))
+  (define-syntax expect
+    (syntax-rules ()
+      [(_ expr str ...)
+       (match-let*
+        ([,_ (parameterize ([trace-output-port os]) expr)]
+         [(str ... "") (split (get-output-string os) #\newline)])
+        'ok)]))
+  (expect (G f1 ([y 'not] [x 'iting]) 'axis)
+    "|(list3 iting not axis)"
+    "|(iting not axis)")
+  (expect (G f23 ([x 2] [y 3]) 4 #t)
+    "|(jump 2 3 4 #t)"
+    "|9")
+  (expect (G f23 ([x 2] [y 3]) 4)
+    "|(jump 2 3 4)"
+    "|(jump 2 3 4 #f)"
+    "|24")
+  (expect (g '(1 2 3))
+    "|(F 2 5 (1 2 3) 0)"
+    "|(F 1 5 (1 2 3) 2)"
+    "|(F 0 5 (1 2 3) 3)"
+    "|(F 0 1 (2 3) 8)"
+    "|(F 0 2 (3) 9)"
+    "|(F 0 3 () 11)"
+    "|14"))

--- a/src/swish/dsm.ss
+++ b/src/swish/dsm.ss
@@ -1,0 +1,54 @@
+;;; dsm.ss
+;;;
+;;; Copyright (c) 1998-2016 R. Kent Dybvig and Oscar Waddell
+;;;
+;;; Permission is hereby granted, free of charge, to any person obtaining a
+;;; copy of this software and associated documentation files (the "Software"),
+;;; to deal in the Software without restriction, including without limitation
+;;; the rights to use, copy, modify, merge, publish, distribute, sublicense,
+;;; and/or sell copies of the Software, and to permit persons to whom the
+;;; Software is furnished to do so, subject to the following conditions:
+;;;
+;;; The above copyright notice and this permission notice shall be included in
+;;; all copies or substantial portions of the Software.
+;;;
+;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+;;; THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;;; DEALINGS IN THE SOFTWARE.
+
+;;; authors: R. Kent Dybvig and Oscar Waddell
+
+(library (dsm) (export define-syntactic-monad) (import (chezscheme))
+  (define-syntax define-syntactic-monad
+    (syntax-rules ()
+      [(_ name formal ...)
+       (andmap identifier? #'(name formal ...))
+       (define-syntax name
+         (lambda (x)
+           (syntax-case x (lambda case-lambda)
+             [(key lambda more-formals . body)
+              (with-implicit (key formal ...)
+                #'(lambda (formal ... . more-formals) . body))]
+             [(key case-lambda (more-formals . body) (... ...))
+              (with-implicit (key formal ...)
+                #'(case-lambda ((formal ... . more-formals) . body) (... ...)))]
+             [(key proc ((x e) (... ...)) arg (... ...))
+              (andmap identifier? #'(x (... ...)))
+              (with-implicit (key formal ...)
+                (for-each
+                  (lambda (x)
+                    (unless (let mem ((ls #'(formal ...)))
+                              (and (not (null? ls))
+                                   (or (free-identifier=? x (car ls))
+                                       (mem (cdr ls)))))
+                      (syntax-error x (format "in syntactic monad ~s, unrecognized identifier" 'name))))
+                  #'(x (... ...)))
+                (with-syntax ([(t (... ...)) (generate-temporaries #'(arg (... ...)))])
+                  #'(let ((p proc) (x e) (... ...) (t arg) (... ...))
+                      (p formal ... t (... ...)))))]
+             [(key proc) #'(key proc ())])))]))
+  )

--- a/src/swish/dsm.ss
+++ b/src/swish/dsm.ss
@@ -1,5 +1,3 @@
-;;; dsm.ss
-;;;
 ;;; Copyright (c) 1998-2016 R. Kent Dybvig and Oscar Waddell
 ;;;
 ;;; Permission is hereby granted, free of charge, to any person obtaining a
@@ -22,33 +20,71 @@
 
 ;;; authors: R. Kent Dybvig and Oscar Waddell
 
-(library (dsm) (export define-syntactic-monad) (import (chezscheme))
+(library (swish dsm)
+  (export
+   define-syntactic-monad
+   )
+  (import
+   (chezscheme)
+   (swish meta)
+   )
   (define-syntax define-syntactic-monad
     (syntax-rules ()
       [(_ name formal ...)
        (andmap identifier? #'(name formal ...))
        (define-syntax name
          (lambda (x)
-           (syntax-case x (lambda case-lambda)
-             [(key lambda more-formals . body)
+           (define (guard-for-coverage) #t)
+           (syntax-case x (case-lambda define lambda let
+                            trace-case-lambda trace-define trace-lambda trace-let)
+             [(key define (proc-name . more-formals) . body)
+              (guard-for-coverage)
+              #'(define proc-name (key lambda more-formals  . body))]
+             [(key let proc-name ((x e) (... ...)) ([fml arg] (... ...)) . body)
+              (guard-for-coverage)
               (with-implicit (key formal ...)
+                #'(key (rec proc-name (key lambda (fml (... ...)) . body))
+                    ((x e) (... ...)) arg (... ...)))]
+             [(key lambda more-formals . body)
+              (guard-for-coverage)
+              (with-implicit (key lambda formal ...) ;; include lambda here to report correct source for errors
                 #'(lambda (formal ... . more-formals) . body))]
              [(key case-lambda (more-formals . body) (... ...))
-              (with-implicit (key formal ...)
-                #'(case-lambda ((formal ... . more-formals) . body) (... ...)))]
+              (guard-for-coverage)
+              (with-implicit (key case-lambda formal ...) ;; see lambda case above
+                #'(case-lambda [(formal ... . more-formals) . body] (... ...)))]
              [(key proc ((x e) (... ...)) arg (... ...))
               (andmap identifier? #'(x (... ...)))
               (with-implicit (key formal ...)
                 (for-each
-                  (lambda (x)
-                    (unless (let mem ((ls #'(formal ...)))
-                              (and (not (null? ls))
-                                   (or (free-identifier=? x (car ls))
-                                       (mem (cdr ls)))))
-                      (syntax-error x (format "in syntactic monad ~s, unrecognized identifier" 'name))))
-                  #'(x (... ...)))
+                 (lambda (x)
+                   (unless (let mem ((ls #'(formal ...)))
+                             (and (not (null? ls))
+                                  (or (free-identifier=? x (car ls))
+                                      (mem (cdr ls)))))
+                     (syntax-error x (format "in syntactic monad ~s, unrecognized identifier" 'name))))
+                 #'(x (... ...)))
                 (with-syntax ([(t (... ...)) (generate-temporaries #'(arg (... ...)))])
                   #'(let ((p proc) (x e) (... ...) (t arg) (... ...))
                       (p formal ... t (... ...)))))]
-             [(key proc) #'(key proc ())])))]))
+             [(key trace-define (proc-name . more-formals) . body)
+              (guard-for-coverage)
+              (with-implicit (key formal ...)
+                #'(define proc-name (key trace-lambda proc-name more-formals . body)))]
+             [(key trace-let proc-name ((x e) (... ...)) ([fml arg] (... ...)) . body)
+              (guard-for-coverage)
+              (with-implicit (key formal ...)
+                #'(key (rec proc-name (key trace-lambda proc-name (fml (... ...)) . body))
+                    ((x e) (... ...)) arg (... ...)))]
+             [(key trace-lambda who more-formals . body)
+              (guard-for-coverage)
+              (with-implicit (key trace-lambda formal ...) ;; see lambda case above
+                #'(trace-lambda who (formal ... . more-formals) . body))]
+             [(key trace-case-lambda who (more-formals . body) (... ...))
+              (guard-for-coverage)
+              (with-implicit (key trace-case-lambda formal ...) ;; see lambda case above
+                #'(trace-case-lambda who [(formal ... . more-formals) . body] (... ...)))]
+             [(key proc)
+              (guard-for-coverage)
+              #'(key proc ())])))]))
   )

--- a/src/swish/imports.ss
+++ b/src/swish/imports.ss
@@ -33,6 +33,7 @@
     (swish cli)
     (swish db)
     (swish digest)
+    (swish dsm)
     (swish erlang)
     (swish errors)
     (swish event-mgr)


### PR DESCRIPTION
This pull request adapts `define-syntactic-monad` from stex for use in Swish. This is useful, for example, when writing state machines.