### PR TITLE
update swish-build and swish-test

### DIFF
--- a/src/run-mats
+++ b/src/run-mats
@@ -15,7 +15,7 @@ fail() {
 }
 
 case $# in
-  0) TESTARGS="$(git ls-files 'src/*.ss' 'src/*.ms')"; PROGRESS="${PROGRESS:-suite}";;
+  0) TESTARGS="$(git ls-files 'src/*.ss' 'src/*.ms')"; PROGRESS="${PROGRESS:-suite-verbose}";;
   1) TESTARGS="$1"; PROGRESS="${PROGRESS:-test}";;
   *) fail;;
 esac

--- a/src/swish/swish-build
+++ b/src/swish/swish-build
@@ -33,13 +33,13 @@
 (define shared-cli
   (cli-specs
    [verbose -v count "show more compiler messages"]
-   [output-file -o (string "<output>") "write output to <output>"]
+   [output-file -o (string "<output>") "compile to <output>; see details"]
    [libdirs -L (list "<libdir>") "add <libdir> to library-directories"]
    [srcdirs -s (list "<srcdir>") "add <srcdir> to source-directories"]
    [rt-libs --rtlib (list "<lib>" ...)
      '("visit compiled libraries <lib> ... before compiling <source>;"
-       "these libraries are added to <output> unless otherwise"
-       "specified, in which case they must be provided at run time."
+       "these libraries are added to <output> unless the target is a"
+       "component or library, in which case they must be provided at run time."
        "Look for <lib> ... in library-directories (-L) if not found.")]
    [help -h --help (list "[<section>]" ...)
      (format "display help, <section>={~{~a~^|~}}" help-sections)]

--- a/src/swish/swish-build
+++ b/src/swish/swish-build
@@ -37,14 +37,19 @@
    [libdirs -L (list "<libdir>") "add <libdir> to library-directories"]
    [srcdirs -s (list "<srcdir>") "add <srcdir> to source-directories"]
    [rt-libs --rtlib (list "<lib>" ...)
-    '("visit compiled libraries <lib> ... before compiling <source>;"
-      "these libraries are added to <output> unless otherwise"
-      "specified, in which case they must be provided at run time."
-      "Look for <lib> ... in library-directories (-L) if not found.")]
+     '("visit compiled libraries <lib> ... before compiling <source>;"
+       "these libraries are added to <output> unless otherwise"
+       "specified, in which case they must be provided at run time."
+       "Look for <lib> ... in library-directories (-L) if not found.")]
    [help -h --help (list "[<section>]" ...)
-    (format "display help, <section>={~{~a~^|~}}" help-sections)]
+     (format "display help, <section>={~{~a~^|~}}" help-sections)]
    [version --version bool "print version information"]
    [info --info bool "display software-info"]
+   [prelude --prelude (list "<prelude>" ...)
+     "evaluate <prelude> expression(s) just before compiling <source>"]
+   [prelude-file --prelude-file (string "<prelude-file>")
+     '("load <prelude-file> just before compiling <source>;"
+       "evaluated after the --prelude expressions, if any.")]
    ))
 
 (define library-cli
@@ -255,7 +260,15 @@
        "\"foo.wpo\" for use by whole-program optimization.\n")
      (example (who "-c bar.ss -o bar.component --rtlib foo.library bar.library")
        "compiles the \"bar.ss\" program to \"bar.component\", which expects"
-       "\"foo.library\" and \"bar.library\" to be provided at run time.")
+       "\"foo.library\" and \"bar.library\" to be provided at run time.\n")
+     (example (who "-o foo foo.ss --prelude '(compile-profile #t)'")
+       "compiles foo.ss to foo with profile instrumentation enabled.\n")
+     (example (who "--prelude '(printf \"-->' ${HOME} '<--\\n\")' -o foo foo.ss")
+       who "concatenates <prelude> command-line arguments via string-append"
+       "before parsing and wraps the resulting expressions in a begin"
+       "form before evaluating the result. This lets us interpolate"
+       "shell values, as in this example, which prints the user's home directory,"
+       "e.g., \"-->/home/sam<---\", before compiling foo.ss to foo.")
      ])
   (let ([invalid (fold-right remq sections help-sections)])
     (unless (null? invalid)
@@ -382,6 +395,16 @@
                   (lambda (source dest)
                     (when (> (verbosity) 0) (printf "compiling ~a\n" source))
                     (compile-library source dest))])
+    (cond
+     [(opt 'prelude) =>
+      (lambda (ls)
+        (interpret ;; interpret vs. compile to omit profile data for --prelude
+         `(begin   ;; read-bytevector provides "source" information for syntax errors
+            ,@(read-bytevector "--prelude" (string->utf8 (apply string-append ls))))))])
+    (cond
+     [(opt 'prelude-file) =>
+      (lambda (filename)
+        (with-source-path 'swish-build filename load))])
     (target-case target-type
       [(library)
        (compile-library source-fn obj-fn)]

--- a/src/swish/swish-build
+++ b/src/swish/swish-build
@@ -605,8 +605,11 @@
     (software-revision 'swish))]
  [else
   (let* ([source-fn
-          (or (source-file)
-              (fail "requires a single source filename"))]
+          (cond
+           [(source-file) =>
+            (lambda (filename)
+              (with-source-path 'swish-build filename values))]
+           [else (fail "requires a single source filename")])]
          [output-fn
           (or (opt 'output-file)
               (fail "requires output filename"))]

--- a/src/swish/swish-build.ms
+++ b/src/swish/swish-build.ms
@@ -1567,6 +1567,12 @@
         (for-each pretty-print
           `((include "here.ss")
             (pretty-print x))))))
+  (define file3
+    (write-test-file "another/nested/path/main.ss"
+      (lambda ()
+        (for-each pretty-print
+          `((include "here.ss")
+            (pretty-print (+ 4 (* x 10))))))))
   ;; fails to build if source directories not specified
   (match (catch (build-example "test-sd" '()))
     [#(EXIT
@@ -1575,7 +1581,17 @@
           ("swish-build: failed for here.ss: no such file or directory.")]))
      'ok])
   (build-example "test-sd" `("-s" ,(path-parent file1)))
-  (run-thin "test-sd" '() '("123")))
+  (run-thin "test-sd" '() '("123"))
+  ;; we should also be able to find the source-file itself via -s
+  ;; source-directories use swish-build-test directly to avoid the path-combine
+  (swish-build-test
+   `("-o" ,(output-file "test-sd2")
+     "-s" ,(path-parent file3)
+     "-s" ,(path-parent file1)
+     ,(path-last file3))
+   '())
+  (run-thin "test-sd2" '() '("1234"))
+  )
 
 (isolate-mat source-file-switch ()
   (define lib1

--- a/src/swish/swish-build.ms
+++ b/src/swish/swish-build.ms
@@ -89,7 +89,7 @@
   (swish-build-test '("--help")
     '("Usage:"
       seek
-      "write output"
+      "compile to <output>"
       seek
       "source filename"))
   (swish-build-test '("-h" "details")

--- a/src/swish/swish-build.ms
+++ b/src/swish/swish-build.ms
@@ -1689,3 +1689,94 @@
   (delete-file prog.so)
   (swish-build-test `(,prog.ss "-o" ,prog.so "-b" "petite") '())
   (assert (file-exists? prog.so)))
+
+(isolate-mat prelude ()
+  (define-syntax expect-error
+    (syntax-rules (stdout stderr)
+      [(_ expr (stdout stdout-pattern ...) (stderr stderr-pattern ...))
+       (match (try expr)
+         [`(catch `(<os-process-failed> ,stdout ,stderr))
+          (match-regexps `(,stdout-pattern ...) stdout)
+          (match-regexps `(,stderr-pattern ...) stderr)])]))
+  (define (so-file fn) (string-append (path-root fn) ".so"))
+  (define setup.ss
+    (write-example (path-combine "try-prelude-source" "setup")
+      '((printf "loaded setup.ss\n"))))
+  (define lib.ss
+    (write-example (path-combine "try-prelude-lib" "lib")
+      '((library (lib) (export x) (import (scheme)) (define x 123)))))
+  (define src.ss
+    (write-example "src"
+      '((let-syntax ([foo (lambda (x) (pretty-print (length (library-directories))) #'#f)]) foo)
+        (import (lib))
+        (printf "x = ~s\n" x))))
+  (define prog (path-combine (path-parent src.ss) "prog"))
+  (define (cleanup)
+    (for-each delete-file
+      (map so-file (list setup.ss lib.ss src.ss))))
+
+  ;; multiple explicit --prelude command-line arguments, some with multiple
+  ;; <prelude> arguments (segmented artificially here to show that we
+  ;; concatenate them before parsing the prelude expressions).
+  (cleanup)
+  (swish-build-test
+   `(,src.ss "-L" ,(path-parent lib.ss)
+     "--prelude" "(library-e" "xtens" "ions '((\".ss\" . \".so\")))"
+     "--prelude" "(import-notify #t)" "-o" ,prog)
+   '("3" ;; length of library-directories, since we add "try-prelude-lib"
+     seek "import: found source file.*try-prelude-lib.lib[.]ss"
+     seek "import: compiling.*try-prelude-lib.lib[.]ss.* to .*lib[.]so"))
+  (run-thin "prog" '() '("x = 123"))
+
+  ;; like the previous test, except a --prelude expression sets
+  ;; library-directories and this supercedes the -L command-line argument,
+  ;; so we don't find the library
+  (cleanup)
+  (expect-error
+   (swish-build-test `(,src.ss "-L" ,(path-parent lib.ss)
+                       "--prelude" "(library-extensions '((\".ss\" . \".so\")))"
+                       "(library-directories \".\")"
+                       "--prelude" "(import-notify #t)" "-o" "failed") '())
+   (stdout "1"
+     "import: did not find source file.*lib[.]ss"
+     "import: did not find object file.*lib[.]so")
+   (stderr "swish-build: library [(]lib[)] not found[.]"))
+
+  ;; --prelude-file located via -s source directories
+  ;; --prelude-file content evaluated after --prelude
+  ;; show that prelude works when compiling a component (-c)
+  (cleanup)
+  (swish-build-test
+   `(,src.ss "-c"
+     "-s" ,(path-parent setup.ss)
+     "-L" ,(path-parent lib.ss)
+     "--prelude-file" "setup.ss"
+     "--prelude" "(library-extensions '((\".ss\" . \".so\")))" "(pretty-print 'one)"
+     "--prelude" "(pretty-print 'two)" "(import-notify #t)" "-o" ,prog)
+   '("one" "two" "loaded setup.ss"
+     "3" ;; length of library-directories, since we add "try-prelude-lib"
+     seek "import: found source file.*try-prelude-lib.lib[.]ss"
+     seek "import: compiling.*try-prelude-lib.lib[.]ss.* to .*lib[.]so"))
+
+  ;; --prelude-file located via explicit path
+  ;; all prelude expressions evaluated before we start to compile and hit syntax error
+  (cleanup)
+  (expect-error
+   (swish-build-test
+    `(,(write-example "incomplete" '((define)))
+      "--prelude" "(pretty-print 'one)"
+      "--prelude-file" ,setup.ss
+      "--prelude" "(pretty-print 'two)" "-o" "failed") '())
+   (stdout "one" "two" "loaded setup.ss")
+   (stderr "swish-build: invalid syntax [(]define[)]"))
+
+  ;; we try to provide useful source error
+  (cleanup)
+  (expect-error
+   (swish-build-test
+    `(,src.ss
+      "--prelude" "(pretty-print 'one) (define)"
+      "-o" "failed") '())
+   (stdout) ;; error occurrs while expanding (begin (pretty-print 'one) (define)), so no output
+   (stderr "swish-build: invalid syntax [(]define[)] at char 20 of --prelude"))
+  )

--- a/src/swish/swish-build.ms
+++ b/src/swish/swish-build.ms
@@ -1710,7 +1710,7 @@
       '((let-syntax ([foo (lambda (x) (pretty-print (length (library-directories))) #'#f)]) foo)
         (import (lib))
         (printf "x = ~s\n" x))))
-  (define prog (path-combine (path-parent src.ss) "prog"))
+  (define prog (path-combine (path-parent src.ss) (fix-exe "prog")))
   (define (cleanup)
     (for-each delete-file
       (map so-file (list setup.ss lib.ss src.ss))))
@@ -1724,8 +1724,8 @@
      "--prelude" "(library-e" "xtens" "ions '((\".ss\" . \".so\")))"
      "--prelude" "(import-notify #t)" "-o" ,prog)
    '("3" ;; length of library-directories, since we add "try-prelude-lib"
-     seek "import: found source file.*try-prelude-lib.lib[.]ss"
-     seek "import: compiling.*try-prelude-lib.lib[.]ss.* to .*lib[.]so"))
+     seek "import: found source file.*try-prelude-lib.*lib[.]ss"
+     seek "import: compiling.*try-prelude-lib.*lib[.]ss.* to .*lib[.]so"))
   (run-thin "prog" '() '("x = 123"))
 
   ;; like the previous test, except a --prelude expression sets
@@ -1755,8 +1755,8 @@
      "--prelude" "(pretty-print 'two)" "(import-notify #t)" "-o" ,prog)
    '("one" "two" "loaded setup.ss"
      "3" ;; length of library-directories, since we add "try-prelude-lib"
-     seek "import: found source file.*try-prelude-lib.lib[.]ss"
-     seek "import: compiling.*try-prelude-lib.lib[.]ss.* to .*lib[.]so"))
+     seek "import: found source file.*try-prelude-lib.*lib[.]ss"
+     seek "import: compiling.*try-prelude-lib.*lib[.]ss.* to .*lib[.]so"))
 
   ;; --prelude-file located via explicit path
   ;; all prelude expressions evaluated before we start to compile and hit syntax error

--- a/src/swish/swish-test
+++ b/src/swish/swish-test
@@ -44,8 +44,7 @@
    [test-run --test-run (string "<UUID>")
     "use the specified <UUID> to identify the test run instead of generating one"]
    [rerun --rerun (string "<type>")
-     (ct:join #\space
-       "rerun tests whose result type matches <type>, where <type> is"
+     '("rerun tests whose result type matches <type>, where <type> is"
        "one of {pass|fail|skip} or a parenthesized Scheme list of those types;"
        "here <spec> specifies test results in .ms.mo or .ss.mo files")]
    [specs (list . "<spec>") "directory | suite [{test | -t test} ...]"]))

--- a/src/swish/swish-test
+++ b/src/swish/swish-test
@@ -51,7 +51,12 @@
 
 (define test-and-report-cli
   (cli-specs
-   [progress --progress (string "<mode>") "<mode>={test|suite|none}"]
+   [progress --progress (string "<mode>")
+     '("<mode>={test|suite|suite-verbose|none}\n"
+       "where 'test' shows pass/fail/skip for each test,"
+       "'suite' shows pass/fail at the suite level, and"
+       "'suite-verbose' is like 'suite' but shows fail/skip"
+       "for individual tests that do not pass.")]
    [load-prof --load-profile (list "<file>" "<file>" ...)
     "load the specified profile(s)"]
    [save-prof --save-profile (string "<file>")
@@ -780,7 +785,7 @@
         [coverage (opt 'coverage)]
         [pre-specs (extract-pre-specs (or (opt 'specs) '()))])
     (check-report-format report 'report)
-    (unless (memq progress '(#f test suite none))
+    (unless (memq progress '(#f test suite suite-verbose none))
       (fail "invalid ~a ~s" (option-named 'progress) progress))
     (cond
      [(and load-prof (not (or save-prof coverage)))

--- a/src/swish/swish-test
+++ b/src/swish/swish-test
@@ -253,7 +253,7 @@
           (match entry
             [(,fn . ,@DIRENT_DIR) (search (combine path fn) hits)]
             [(,fn . ,@DIRENT_FILE)
-             (if (ormap (lambda (ext) (ends-with-ci? fn ext)) extensions)
+             (if (ormap (lambda (ext) (ends-with? fn ext)) extensions)
                  (cons (combine path fn) hits)
                  hits)]
             [,_ hits])) ;; not following symlinks

--- a/src/swish/swish-test
+++ b/src/swish/swish-test
@@ -243,22 +243,9 @@
     (library-directories)))
 
 (define (find-files path . extensions)
-  (define (combine path fn) (if (equal? "." path) fn (path-combine path fn)))
-  (let search ([path path] [hits '()])
-    (match (catch (list-directory path))
-      [#(EXIT ,reason) hits]
-      [,found
-       (fold-left
-        (lambda (hits entry)
-          (match entry
-            [(,fn . ,@DIRENT_DIR) (search (combine path fn) hits)]
-            [(,fn . ,@DIRENT_FILE)
-             (if (ormap (lambda (ext) (ends-with? fn ext)) extensions)
-                 (cons (combine path fn) hits)
-                 hits)]
-            [,_ hits])) ;; not following symlinks
-        hits
-        found)])))
+  (filter-files path
+    (lambda (d) #t)
+    (lambda (f) (ormap (lambda (ext) (ends-with? f ext)) extensions))))
 
 (import
  (swish mat)

--- a/src/swish/swish-test.ms
+++ b/src/swish/swish-test.ms
@@ -1124,6 +1124,27 @@
         "--load-results " aggregate.json)
        expected))
     (let ([expected
+           `(,(string-append (pregexp-quote test-file) ".* fail")
+             " SKIP .*TEST2"
+             " FAIL .*TEST3"
+             ,(string-append (pregexp-quote test-file2) ".* no tests")
+             ,(string-append (pregexp-quote test-file3) ".* fail")
+             " FAIL .*zero"
+             ,(string-append (pregexp-quote "incomplete.ms") ".* no tests")
+             ,@summary-output)])
+      ;; --progress suite-verbose with --harvest
+      (nonzero-exit
+       (swish-test
+        "--harvest " mo-path1 " " mo-path2 " " mo-path3 " " incomplete " "
+        "--progress " "suite-verbose")
+       expected)
+      ;; --progress suite-verbose with --load-results
+      (nonzero-exit
+       (swish-test
+        "--progress " "suite-verbose "
+        "--load-results " aggregate.json)
+       expected))
+    (let ([expected
            `(,(pregexp-quote test-file)
              seek
              " pass .*TEST1"


### PR DESCRIPTION
`swish-build` updates:
- fix `-s` to work for the _source_ file
- add `--prelude` and `--prelude-file` for more control over compilation
- clarify `--help` text

`swish-test` updates:
- use case-sensitive compare for file extensions
- use new `filter-files`
- add `--progress suite-verbose` option and use it in our build scripts

