### PR TITLE
Read a json object when a form is posted with content-type set to app…

### DIFF
--- a/src/swish/http.ms
+++ b/src/swish/http.ms
@@ -495,6 +495,14 @@
             "Content-Type: application/x-www-form-urlencoded\r\n"
             "\r\n"
             "echo=ok"))]
+    ["HTTP/1.1 200 \r\nContent-Length: 13\r\nCache-Control: no-cache\r\n\r\n{\"echo\":\"ok\"}"
+     (test (string-append
+            "POST /mat?cmd=echo+form HTTP/1.1\r\n"
+            "Connection: close\r\n"
+            "Content-Length: 13\r\n"
+            "Content-Type: application/json\r\n"
+            "\r\n"
+            "{\"echo\":\"ok\"}"))]
     [`(<result> [reason http-input-violation] [output ,@internal-server-error])
      (test-error&output
       (string-append

--- a/src/swish/http.ss
+++ b/src/swish/http.ss
@@ -478,6 +478,14 @@
                       (get-chunk! ip content len)
                       (parse-encoded-kv content 0 len)))
                   timeout)]
+               [(starts-with? type "application/json")
+                (when (> len content-limit)
+                  (throw 'http-content-limit-exceeded))
+                (http:call-with-ports conn
+		  (lambda (ip op)
+		     (let ([content (make-bytevector len)])
+		       (get-chunk! ip content len)
+		       (json:bytevector->object content))))]
                [else (json:make-object)])])
         (on-exit (delete-tmp-files data)
           (f data)))]))


### PR DESCRIPTION
Hi, this is a terrific piece of software. I have built a basic RESTful web service using the http library built in to Swish. 

I noticed when testing an http client with a POST or PATCH and Content-Type set to application/json, the `call-with-form` procedure was not parsing the content in a json object. This is not a bug, as the documentation agrees with the code: 
"The http:call-with-form procedure checks JSON object header for a content-type of multipart/form-
data or application/x-www-form-urlencoded."

This pull request contains code to add this functionality to call-with-form in this scenario. I suppose that posting json content might not be considered a form use-case, and so I can understand if this pull request is declined. Another approach is to use the same `call-with-ports` solution in my application itself.

Also The documentation needs to be updated before merging.

Anyway I thought I would contribute this for your consideration.

Thanks,
Carl
