### PR TITLE
Another attempt at more robust macOS test builds

### DIFF
--- a/src/swish/db.ms
+++ b/src/swish/db.ms
@@ -1065,10 +1065,26 @@
     [,_ (event-mgr:notify `#(,self waiting))]
     [ok (receive [in-sync 'ok])]
     [,@expected (reverse rev-actual)])
+   (define lo delay-ms)
+   (define hi (* 2 delay-ms))
+   (define okay? #t)
+   (define rows-checked 0)
+   (define DEBUG? (and (member (getenv "DEBUG") '("yes" "true" "y" "t")) #t))
+   (define op (open-output-string))
    (define (print-row id ts1 ts2 delta)
-     (when (getenv "DEBUG")
-       (printf "~3a ~13a ~13a ~5a\n" id ts1 ts2 delta)))
+     (fprintf op "~3a ~13a ~13a ~5a\n" id ts1 ts2 delta))
+   (define p
+     (spawn&link
+      (lambda ()
+        (process-trap-exit #t)
+        (send me 'ready)
+        (receive
+          [`(EXIT ,pid ,reason)
+           (when (or DEBUG? (informative-exit-reason? reason))
+             (display-string (get-output-string op)))]))))
+   (receive [ready 'ok])
    (transaction db
+     (fprintf op ";; check that (<= ~s delta ~s)\n" lo hi)
      (print-row "id" "queued" "actual" "delta")
      (for-each
       (lambda (v)
@@ -1076,8 +1092,14 @@
           [#(,id ,ts1 ,julian)
            (let ([ts2 (julian->timestamp julian)])
              (print-row id ts1 ts2 (- ts2 ts1))
-             (assert (<= delay-ms (- ts2 ts1) (* 2 delay-ms))))]))
-      (execute "select id, queued, actual from log order by rowid asc")))))
+             (set! rows-checked (+ rows-checked 1))
+             (when okay?
+               (set! okay? (<= lo (- ts2 ts1) hi))))]))
+      (execute "select id, queued, actual from log order by rowid asc")))
+   (match-let*
+    ([#t okay?]                           ; all rows matched
+     [,@rows-checked (apply + expected)]) ; checked all rows
+    p)))
 
 (db-mat cache-timeout ()
   (match-let*

--- a/src/swish/http.ms
+++ b/src/swish/http.ms
@@ -776,7 +776,7 @@
   (let-values ([(ip op) (connect-tcp "127.0.0.1" (get-http-port))])
     (put-bytevector op (string->utf8 "Malformed Request\r\n\r\n"))
     (flush-output-port op)
-    (receive (after 10 (throw 'no-child-log))
+    (test:receive (after 10 (throw 'no-child-log))
       [`(<child-end> [reason #(http-unhandled-input ,x)])
        (assert (string=? (utf8->string x) "Malformed Request"))])
     (close-port op))
@@ -792,7 +792,7 @@
       (spawn&link
        (lambda ()
          (send me `#(read ,(utf8->string (get-bytevector-all ip)))))))
-    (receive (after 100 (throw 'timeout))
+    (test:receive (after 100 (throw 'timeout))
       [#(read ,x)
        (unless (string=? x
                  (string-append
@@ -807,7 +807,7 @@
         [fail-msg `#(accept-tcp-failed "listener" "who" "errno")])
     (link http)
     (send http fail-msg)
-    (receive (after 100 (throw 'timeout))
+    (test:receive (after 100 (throw 'timeout))
       [`(EXIT ,@http ,@fail-msg) 'ok])))
 
 (http-mat http-respond ()
@@ -1058,7 +1058,7 @@
           (match ls
             [() 'ok]
             [(,n . ,rest)
-             (receive (after 100 (throw `#(failed-to-read-data ,n)))
+             (test:receive (after 100 (throw `#(failed-to-read-data ,n)))
                [#(read ,@n) (lp rest)])])))
 
       (check-loopback '(9 8 7 6 5))
@@ -1387,14 +1387,14 @@
         (send pid msg)
         (check c s)))
     (define (check-crash c s)
-      (receive (after 100 (throw 'no-client-close))
+      (test:receive (after 100 (throw 'no-client-close))
         [#(ws:closed ,@c 1011 "") 'ok])
-      (receive (after 100 (throw 'no-child-log))
+      (test:receive (after 100 (throw 'no-child-log))
         [`(<child-end> [pid ,@s] [reason crashed]) 'ok]))
     (define (check-normal c s)
-      (receive (after 100 (throw 'no-client-close))
+      (test:receive (after 100 (throw 'no-client-close))
         [#(ws:closed ,@c 1000 "") 'ok])
-      (receive (after 100 (throw 'no-child-log))
+      (test:receive (after 100 (throw 'no-child-log))
         [`(<child-end> [pid ,@s] [reason normal]) 'ok]))
     (do-test #f 'crash check-crash)
     (do-test #t 'crash check-crash)


### PR DESCRIPTION
This pull request
* updates the database `commit-delay` test to log debugging information if the test fails,
* scales more timeouts in the HTTP mats,
* and uses `test:receive` to report the time elapsed in `receive` before hitting a clause or timeout.

If these changes look okay, we may want to consider pulling this in ahead of the JSON changes where macOS test failures seem to have caused problems for some of the builds.