### PR TITLE
clean up test-request shared library

### DIFF
--- a/src/swish/Mf-base
+++ b/src/swish/Mf-base
@@ -119,6 +119,7 @@ clean: platform-clean
 	rm -f ../../${BUILD}/lib/swish/*.wpo
 	rm -f ${SwishLibs}
 	rm -f ${SHLIBTEST}
+	rm -f ${TESTREQUEST}
 	rm -f scheme_aux.h
 	rm -f chezscheme-revision.include
 	rm -f swish-revision.include


### PR DESCRIPTION
Remove the test-request shared library on `make clean`. Failing to do this meant that the osi.ms submit-request mat could fail when switching architectures despite a `make clean` before switching.


