### PR TITLE
Test fixes

### DIFF
--- a/src/swish/swish-build.ms
+++ b/src/swish/swish-build.ms
@@ -224,13 +224,16 @@
   ;; fat with scheme only
   (write-example "fat3" hello-fat)
   (build-example "fat3" '("-b" "scheme"))
-  ;; Set SCHEMEHEAPDIRS explicitly since Chez Scheme v10.x changes the default
-  ;; heap search path so that it is relative to the executable. Otherwise the
-  ;; fat3 binary cannot find the system petite.boot.
+  ;; To allow the fat3 binary to find petite.boot, we explicitly set
+  ;; SCHEMEHEAPDIRS. Chez v10.x changes the default heap search path
+  ;; so that it is relative to the executable. As of Chez v10.x, the
+  ;; executables are installed into the lib directory, so we must also
+  ;; include the base executable path.
   (parameterize ([SCHEMEHEAPDIRS
                   (let ([base (path-parent scheme-exe)])
                     (join
                      (list
+                      base ;; v10.x symlinks .../bin/scheme to .../lib/csv%v/%m/scheme
                       (path-combine base ".." ".." "boot" "%m")
                       (path-combine base ".." "lib" "csv%v" "%m")
                       "")

--- a/src/swish/testing.ss
+++ b/src/swish/testing.ss
@@ -194,9 +194,11 @@
                      (let ([m (monitor p)])
                        (receive (until deadline (cons p ls))
                          [`(DOWN ,@m ,@p ,r) ls])))))])
+        ;; in case p is not linked to the process running the mat
+        (for-each (lambda (p) (kill p 'shutdown)) rogues)
         (for-each
          (lambda (rogue)
-           (receive (after kill-delay (kill rogue 'shutdown))
+           (receive (after kill-delay (kill rogue 'kill))
              [`(DOWN ,m ,@rogue ,r) 'ok]))
          rogues))))
 


### PR DESCRIPTION
**Fixes**

* Fixes an issue with running a compiled app under Chez v10. The test would fail if Chez is installed using `make install`. The build server sets the `PATH` and does not expose the problem.
* Updates isolate-mat's `cleanup-after` to use shutdown escalation similar to supervisors. Upcoming changes revealed that there can be rogue process that still don't die after killing with a `shutdown` signal.
