### PR TITLE
Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ test: src/swish/Makefile
 	@./src/run-mats
 
 safe-check: src/swish/Makefile
+	@if git grep -l '[(]include "[^"]\+unsafe.ss"[)]'; then echo "inconsistent include of unsafe.ss in file(s) listed above"; exit 1; fi
 	@touch src/swish/unsafe.ss
 	@UNSAFE_PRIMITIVES=no $(MAKE) -C src/swish mat-prereq
 	@./src/run-mats

--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -2720,6 +2720,7 @@ with the path-watcher guardian\index{path-watcher guardian}.
 
 Every time a change is detected, \code{\#(path-changed \var{path}
   \var{filename} \var{events})} is sent to \var{process}, where
+\var{filename} is a string or \code{\#f} and
 \var{events} is 1 for rename, 2 for change, and 3 for rename and
 change. If the watcher encounters an error,
 \code{\#(path-watcher-failed \var{path} \var{errno})} is sent to

--- a/src/swish/app-core.ss
+++ b/src/swish/app-core.ss
@@ -175,7 +175,7 @@
 
   (define (trap-signals handler)
     (meta-cond
-     [(memq (machine-type) '(i3nt ti3nt a6nt ta6nt))
+     [windows?
       (signal-handler SIGBREAK handler)
       (signal-handler SIGHUP handler)
       (signal-handler SIGINT handler)]

--- a/src/swish/app.ms
+++ b/src/swish/app.ms
@@ -485,7 +485,7 @@
       [() 'no-extraneous-output])]))
 
 (meta-cond
- [(memq (machine-type) '(i3nt ti3nt a6nt ta6nt))
+ [windows?
   ;; test manually on Windows
   (void)]
  [else

--- a/src/swish/app.ss
+++ b/src/swish/app.ss
@@ -132,6 +132,36 @@
                      (software-version 'swish))])])
       (printf "~a~@[ Version ~a~]~@[ (~a)~]\n" name version revision)))
 
+  (meta-cond
+   [windows?
+    (define (split-path p n)
+      (let ([rest (path-rest p)])
+        (if (or (= n 0) (equal? p rest))
+            (list p)
+            (cons (path-first p) (split-path (path-rest p) (- n 1))))))
+    (define (rewrite-path script)
+      ;; Cygwin paths start with /.
+      ;; By default, MSYS2 and Git Bash automatically convert to Windows paths.
+      (match (split-path script 3)
+        [("/" "cygdrive" ,drive ,path)
+         (path-combine (string-append drive ":") path)]
+        [("/" "tmp" . ,more)
+         ;; assume Cygwin's fstab sets a usertemp mount for /tmp
+         (apply path-combine (osi_get_temp_directory) more)]
+        [("/" . ,_)
+         (let ([root (get-registry "HKEY_LOCAL_MACHINE\\Software\\Cygwin\\setup\\rootdir")])
+           (and root (path-combine root (path-rest script))))]
+        [,_ #f]))
+    (define (resolve script)
+      (if (file-exists? script)
+          script
+          (let ([new-path (rewrite-path script)])
+            (if (and new-path (file-exists? new-path))
+                new-path
+                script))))]
+   [else
+    (define (resolve script) script)])
+
   (define (run)
     (let* ([opt (parse-command-line-arguments cli)]
            [files (or (opt 'files) '())])
@@ -164,7 +194,7 @@
             (for-each load filenames)
             (new-cafe)))]
        [else                            ; script
-        (let ([script-file (car files)]
+        (let ([script-file (resolve (car files))]
               [cmdline (command-line-arguments)])
           (parameterize ([command-line cmdline]
                          [command-line-arguments (cdr cmdline)]

--- a/src/swish/foreign.ms
+++ b/src/swish/foreign.ms
@@ -69,10 +69,12 @@
 
 (define shlibtest.so
   (let ([shlib
-         (case (machine-type)
-           [(a6nt i3nt ta6nt ti3nt) "shlibtest.dll"]
-           [(a6osx arm64osx ta6osx tarm64osx) "shlibtest.dylib"]
-           [else "shlibtest.so"])])
+         (cond
+          [windows? "shlibtest.dll"]
+          [else
+           (case (machine-type)
+             [(a6osx arm64osx ta6osx tarm64osx) "shlibtest.dylib"]
+             [else "shlibtest.so"])])])
     ;; deliberately left this in src/swish, not in build/mat-prereq/bin,
     ;; so we don't happen to find shared library just because it's near
     ;; one of our binaries or is in the path

--- a/src/swish/http.ss
+++ b/src/swish/http.ss
@@ -651,8 +651,8 @@
         [timeout `#(stop normal ,state)]
         [#(path-changed ,path ,filename ,_)
          `#(no-reply
-            ,(if (and (string=? path root-dir)
-                      (string=? filename "mime-types"))
+            ,(if (and (equal? path root-dir)
+                      (equal? filename "mime-types"))
                  ($state copy [mime-types #f])
                  (clear-cache state))
             ,cache-timeout)]

--- a/src/swish/io.ms
+++ b/src/swish/io.ms
@@ -818,7 +818,7 @@
      (sort <
        (cons SIGWINCH
          (meta-cond
-          [(memq (machine-type) '(i3nt ti3nt a6nt ta6nt))
+          [windows?
            (list SIGBREAK SIGHUP SIGINT)]
           [else
            (list SIGHUP SIGINT SIGTERM)])))]
@@ -845,7 +845,7 @@
     [,_ (print-signal-handlers (open-output-string))]) ;; should not crash
    'ok)
   (meta-cond
-   [(memq (machine-type) '(i3nt ti3nt a6nt ta6nt))
+   [windows?
     ;; skip signal-handling tests on Windows
     (void)]
    [else

--- a/src/swish/mat.ss
+++ b/src/swish/mat.ss
@@ -142,7 +142,7 @@
 
   (define (add-mat name tags test)
     (if (find-mat name)
-        (errorf 'add-mat "mat ~a is already defined." name)
+        (errorf 'add-mat "mat ~a is already defined" name)
         (mats (cons (make-mat name tags test) (mats)))))
 
   (define run-mat
@@ -152,7 +152,7 @@
       (cond
        [(mat? mat/name) (do-run-mat mat/name reporter incl-tags excl-tags)]
        [(find-mat mat/name) => (lambda (mat) (do-run-mat mat reporter incl-tags excl-tags))]
-       [else (errorf 'run-mat "mat ~a is not defined." mat/name)])]))
+       [else (errorf 'run-mat "mat ~a is not defined" mat/name)])]))
 
   (define (skip? mat incl-tags excl-tags)
     (or (and (pair? incl-tags) (not (present (%mat-tags mat) incl-tags)))

--- a/src/swish/meta.ss
+++ b/src/swish/meta.ss
@@ -178,7 +178,7 @@
 
   (define-syntax windows?
     (meta-cond
-     [(memq (machine-type) '(i3nt ti3nt a6nt ta6nt))
+     [(eqv? (directory-separator) #\\)
       (identifier-syntax #t)]
      [else
       (identifier-syntax #f)]))

--- a/src/swish/osi.c
+++ b/src/swish/osi.c
@@ -645,7 +645,7 @@ static void watch_path_cb(uv_fs_event_t* handle, const char* filename, int event
     osi_add_callback1(callback, Sinteger(status));
     return;
   }
-  osi_add_callback2(callback, Sstring_utf8(filename, -1), Sinteger(events));
+  osi_add_callback2(callback, filename ? Sstring_utf8(filename, -1) : Sfalse, Sinteger(events));
 }
 
 ptr osi_tcp_nodelay(uptr port, int enable) {

--- a/src/swish/parallel.ss
+++ b/src/swish/parallel.ss
@@ -56,7 +56,7 @@
 
   (define default-options (parallel:options))
 
-  (include "swish/unsafe.ss")
+  (include "unsafe.ss")
 
   (define (shuffle-fxvector! v)
     (declare-unsafe-primitives fx> fx- fxvector-length fxvector-ref fxvector-set!)

--- a/src/swish/script-testing.ss
+++ b/src/swish/script-testing.ss
@@ -75,7 +75,7 @@
              [op (open-binary-file-to-replace out)])
         (on-exit (close-port op)
           (put-bytevector op bv))))
-    (when (memq (machine-type) '(a6nt i3nt ta6nt ti3nt))
+    (when windows?
       (for-each
        (lambda (fn)
          (let* ([in (path-combine (prereq-path) fn)]

--- a/src/swish/swish-build.ms
+++ b/src/swish/swish-build.ms
@@ -238,7 +238,7 @@
                       (path-combine base ".." "lib" "csv%v" "%m")
                       "")
                      (meta-cond
-                      [(memq (machine-type) '(a6nt ta6nt i3nt ti3nt)) #\;]
+                      [windows? #\;]
                       [else #\:])))])
     (run-fat "fat3" '() '("Hello, World!"))))
 

--- a/src/swish/testing.ss
+++ b/src/swish/testing.ss
@@ -78,7 +78,7 @@
   (define-syntax scheme-exe (identifier-syntax (get-scheme-exe)))
 
   (define scheme-environment-variable
-    (if (memq (machine-type) '(a6nt i3nt ta6nt ti3nt)) "SCHEME_WIN" "SCHEME"))
+    (if windows? "SCHEME_WIN" "SCHEME"))
 
   (define (get-scheme-exe)
     (or (getenv scheme-environment-variable)


### PR DESCRIPTION
- fix typo in mat error messages
- make includes of "unsafe.ss" consistent
- fix a potential crash in `watch-path` callback
- make Swish scripts less broken under Cygwin