### PR TITLE
Minor change to http:options and path-combine

### DIFF
--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -2408,7 +2408,9 @@ The \code{osi-port?} procedure determines whether or not the datum
 
 The \code{path-combine} procedure appends one or more paths, inserting
 the directory-separator character between each pair of paths as
-needed.
+needed, while ignoring empty paths.
+
+% fine point: we preserve directory separators present in the input
 
 % ----------------------------------------------------------------------------
 \defineentry{path-watcher-count}

--- a/doc/swish/http.tex
+++ b/doc/swish/http.tex
@@ -303,7 +303,12 @@ used:
 
   \code{file-transform} & \code{(lambda (path) \#f)} & a procedure; a
   cache process calls this procedure with a file path and expects an
-  evaluator procedure or \code{\#f} (see \S\ref{sec:dynamic-pages})
+  evaluator procedure or \code{\#f} (see \S\ref{sec:dynamic-pages}) \\
+
+  \code{validate-path} & \code{http:valid-path?} & a predicate;
+  the server raises an exception if the \code{<request>} \var{path}
+  does not satisfy this predicate. \\
+
 \end{tabular}
 
 \defineentry{http:add-server}
@@ -681,6 +686,16 @@ The \code{http:eval-dynamic-page} procedure wraps a
 syntax with the constructs described in
 Section~\ref{sec:dynamic-page-constructs}, and calls the \code{eval}
 system procedure.
+
+\defineentry{http:valid-path?}
+\begin{procedure}
+  \code{(http:valid-path? \var{path})}
+\end{procedure}
+\returns{} boolean
+
+The \code{http:valid-path?} procedure checks that the \var{path} from a \code{<request>} is a string that begins with \code{/} and contains no \code{".."} path elements when decomposed as a filesystem path.
+On Windows this procedure treats both \code{/} and \code{\textbackslash}
+as path separators since some filesystem operations accept both.
 
 \subsection {Dynamic Page Constructs}\label{sec:dynamic-page-constructs}
 

--- a/src/swish/gen-server.ms
+++ b/src/swish/gen-server.ms
@@ -598,7 +598,7 @@
    'ok))
 
 (isolate-mat debug ()
-  (define (grab-event) (receive (after 100 #f) [,x x]))
+  (define (grab-event) (test:receive (after 100 #f) [,x x]))
   (define (client-test options)
     (match-let*
      ([#(ok ,pid) (start-server 'my-test-name '())]

--- a/src/swish/http.ms
+++ b/src/swish/http.ms
@@ -1528,3 +1528,18 @@
     [#(EXIT #(websocket-invalid-header sec-websocket-accept "bad-key"))
      (do-test "/?status=101&connection=upgrade&upgrade=websocket&sec-websocket-accept=bad-key")])
    'ok))
+
+(mat validate-path ()
+  (match-let*
+   ([,sep (string (directory-separator))]
+    [#f (http:valid-path? 'rubbish)]
+    [#f (http:valid-path? "rubbish")]
+    [#t (http:valid-path? "/")]
+    [#t (http:valid-path? "/okay")]
+    [#t (http:valid-path? (path-combine "/okay" "fine" "sure"))]
+    [#f (http:valid-path? (path-combine "/okay" ".." "bad"))]
+    [#f (http:valid-path? (path-combine "/okay" "bad" "wrong" ".."))]
+    [#f (http:valid-path? (path-combine "/.." "also" "bad"))]
+    [#t (http:valid-path? (path-combine "/a" "b" "c" "d" "e"))])
+   'ok)
+  )

--- a/src/swish/http.ss
+++ b/src/swish/http.ss
@@ -1048,14 +1048,16 @@
                          [(k fn) (',http:include-help #'k (datum fn) ,path)]))])
          ,@exprs))
     (eval
-     `(http:url-handler
-       (define-syntax find-param
-         (syntax-rules ()
-           [(_ key) (http:find-param key params)]))
-       (define-syntax get-param
-         (syntax-rules ()
-           [(_ key) (http:get-param key params)]))
-       ,(wrap-3D-include path exprs))))
+     `(let ()
+        (import (swish imports))
+        (http:url-handler
+         (define-syntax find-param
+           (syntax-rules ()
+             [(_ key) (http:find-param key params)]))
+         (define-syntax get-param
+           (syntax-rules ()
+             [(_ key) (http:get-param key params)]))
+         ,(wrap-3D-include path exprs)))))
 
   (define (http:valid-path? path)
     (and (string? path)

--- a/src/swish/http.ss
+++ b/src/swish/http.ss
@@ -517,8 +517,7 @@
           (let ([state (load-watchers state)])
             ($state copy [mime-types (read-mime-types)]))))
     (define (url->abs-paths path) ;; path starts with "/"
-      (let ([path (path-combine root-dir
-                    (substring path 1 (string-length path)))]
+      (let ([path (path-combine root-dir path)]
             [search-extensions (file-search-extensions)])
         (cond
          [(directory-separator? (string-ref path (- (string-length path) 1)))

--- a/src/swish/io.ms
+++ b/src/swish/io.ms
@@ -1432,4 +1432,60 @@
      'ok))
   )
 
+(isolate-mat path-combine ()
+  (define-syntax string-append
+    (syntax-rules ()
+      [(_ arg ...)
+       (call #%string-append '(arg ...))]))
+  (define-syntax path-combine
+    (syntax-rules ()
+      [(_ arg ...)
+       (call (let () (import (swish io)) path-combine) '(arg ...))]))
+  (define sep (string (directory-separator)))
+  (define (call proc args)
+    (apply proc
+      (map
+       (lambda (s)
+         (if (symbol? s)
+             (pregexp-replace* (re "/") (symbol->string s) (pregexp-quote sep))
+             s))
+       args)))
+  (define-syntax expect
+    (syntax-rules ()
+      [(_ (pred? expected actual) ...)
+       (begin
+         (unless (pred? expected actual)
+           (syntax-violation #f "failed" #'actual))
+         ...)]))
+  ;; ignore empty path components
+  ;; don't add unnecessary path separators
+  (expect
+   (equal? "" (path-combine ""))
+   (equal? "foo" (path-combine "foo"))
+   (equal? "a" (path-combine "" "a"))
+   (equal? "a" (path-combine "a" ""))
+   (equal? "a" (path-combine "a" "" ""))
+   (equal? "a" (path-combine "" "a" ""))
+   (equal? "a" (path-combine "" "" "a"))
+   (equal? (string-append /abc) (path-combine /abc))
+   (equal? (string-append def/) (path-combine def/))
+   (equal? (string-append / "abc" / def/) (path-combine /abc def/))
+   (equal? "" (path-combine "" "" ""))
+   (equal? "abc" (path-combine "abc" "" ""))
+   (equal? (string-append "xyz" / "abc") (path-combine "xyz" "" "abc"))
+   (equal? (string-append "xyz" / "abc") (path-combine "xyz" "" /abc))
+   (equal? (string-append a/b/c/d/e) (path-combine "a" "b" "c" "d" "e"))
+   (equal? (string-append /a/b/c) (path-combine /a /b/ "c"))
+   (equal? (string-append /a/b/c) (path-combine /a /b "c"))
+   (equal? (string-append /a/b/c) (path-combine /a/ "b" /c))
+   )
+  ;; preserve path separators in the inputs even though it is ugly
+  (expect
+   (equal? (string-append def/ /abc) (path-combine def/ /abc))
+   (equal? (string-append a/ /) (path-combine a/ /))
+   (equal? (string-append def/ /abc) (path-combine def/ "" /abc))
+   (equal? (string-append /a/ /b/ /c) (path-combine "" /a/ /b/ /c))
+   )
+  )
+
 (hook-console-input)


### PR DESCRIPTION
This pull request
- adds `validate-path` to `http:options` and exposes `http:valid-path?` so a server can supply a `http:url-handler` that interprets paths that would otherwise be invalid, yet still check the extracted paths before hitting the filesystem, and
- modifies `path-combine` to avoid adding extra directory separators while allocating less in some cases.
- [edit] fixes a bug in `http:eval-dynamic-page`