### PR TITLE
lift some work out of pregexp-match-positions-aux

### DIFF
--- a/src/swish/pregexp.ms
+++ b/src/swish/pregexp.ms
@@ -35,9 +35,11 @@
        (assert (equal? exp 'res))
        (test-cases clause ...))]))
 
+(define-tuple <pregexp> pat backrefs)
+
 (test set1
 
-  (pregexp "c.r")
+  (<pregexp> pat (pregexp "c.r"))
   (:sub (:or (:seq #\c :any #\r)))
 
   (pregexp-match-positions "brain" "bird")
@@ -403,10 +405,10 @@
 (test set6
 
   ;; PLT bug 6095 from Neil W. Van Dyke
-  (pregexp "[a-z-]")
+  (<pregexp> pat (pregexp "[a-z-]"))
   (:sub (:or (:seq (:one-of-chars (:char-range #\a #\z) #\-))))
                                         ;
-  (pregexp "[-a-z]")
+  (<pregexp> pat (pregexp "[-a-z]"))
   (:sub (:or (:seq (:one-of-chars #\- (:char-range #\a #\z)))))
 
   ;; PLT bug 6442 from David T. Pierson
@@ -421,10 +423,10 @@
   3
 
   ;; PLT bug 7232 from Neil Van Dyke
-  (pregexp "[-a]")
+  (<pregexp> pat (pregexp "[-a]"))
   (:sub (:or (:seq (:one-of-chars #\- #\a))))
                                         ;
-  (pregexp "[a-]")
+  (<pregexp> pat (pregexp "[a-]"))
   (:sub (:or (:seq (:one-of-chars #\a #\-))))
 
   )


### PR DESCRIPTION
The pregexp-match-positions-aux procedure was burrowing through the entire regexp to construct an alist of backrefs. That can be inefficient since pregrexp-match-positions calls it in a loop. Instead, we construct the list of backref keys at expand time, if possible.

Note: be sure to set (print-graph #t) if you expand uses of the (re ...) macro, write the expanded output to a port, and attempt to read and evaluate the expanded code. (This practice is neither common nor recommended.)

