### PR TITLE
ci: remove windows-2019 runner image usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,9 +86,6 @@ jobs:
             os: windows-2022
             chez: v9.6.4
           - machine: a6nt
-            os: windows-2019
-            chez: v9.6.4
-          - machine: a6nt
             os: windows-2022
             chez: v9.6.4
           - machine: ta6nt


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/12045
