### PR TITLE
add osi_get_available_parallelism

### DIFF
--- a/doc/swish/osi.tex
+++ b/doc/swish/osi.tex
@@ -308,6 +308,15 @@ The \code{osi\_get\_argv} function returns a Scheme vector of strings
 constructed from the most recent arguments passed to
 \code{osi\_set\_argv}.
 
+\defineentry{osi\_get\_available\_parallelism}
+\begin{procedure}
+  \code{(osi\_get\_available\_parallelism)}
+\end{procedure}
+\returns{} an unsigned integer
+
+Returns an estimate of the default amount of parallelism a program
+should use as reported by \code{uv\_available\_parallelism}.
+
 \defineentry{osi\_get\_bytes\_used}
 \begin{function}
   \code{size\_t osi\_get\_bytes\_used(void);}

--- a/src/swish/osi.ss
+++ b/src/swish/osi.ss
@@ -45,6 +45,7 @@
    osi_finalize_statement
    osi_finalize_statement*
    osi_get_argv
+   osi_get_available_parallelism
    osi_get_bindings
    osi_get_bindings*
    osi_get_bytes_used
@@ -188,6 +189,8 @@
   (define osi_get_total_memory
     (foreign-procedure "uv_get_total_memory" () unsigned-64))
   (fdefine osi_is_service boolean)
+  (define osi_get_available_parallelism
+    (foreign-procedure "uv_available_parallelism" () unsigned-32))
 
   ;; Ports
   (define-osi osi_read_port (port uptr) (buffer ptr) (start-index size_t) (size unsigned-32) (offset integer-64) (callback ptr))

--- a/src/swish/run.c
+++ b/src/swish/run.c
@@ -111,6 +111,7 @@ static void swish_init(void) {
   add_foreign(osi_write_port);
   add_foreign(uv_get_free_memory);
   add_foreign(uv_get_total_memory);
+  add_foreign(uv_available_parallelism);
   if (g_aux_init) g_aux_init();
 }
 


### PR DESCRIPTION
I'm not sold on the name, but it matches our style of `osi_get` prefix on `uv_available_parallelism`.