### PR TITLE
fix define-tuple is? predicate to handle alias or library rename

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 ---
 name: Test
 on: [push]
+env:
+  RELEASED: v10.2.0
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -43,7 +45,7 @@ jobs:
           cp boot/a6le/* ../build/lib/csv9.6.4/a6le
           export PATH=$(realpath ../build/bin):${PATH}
           export SCHEMEHEAPDIRS=$(realpath ../build/lib/csv9.6.4/a6le):
-          git checkout main
+          git checkout "${RELEASED}"
           git clean -dxf .
           ./configure --force -m=a6le
           make re.boot
@@ -52,8 +54,6 @@ jobs:
           make bootquick XM=arm64osx
           make bootquick XM=a6nt
           make bootquick XM=i3le
-          make bootquick XM=ta6nt
-          make bootquick XM=ta6le
   mats:
     continue-on-error: ${{ startsWith(matrix.machine, 't') }}
     needs: build
@@ -62,40 +62,34 @@ jobs:
       matrix:
         config:
           - machine: a6osx
-            os: macos-13
-            chez: v9.6.4
+            os: macos-15-intel
+            chez: released
           - machine: a6osx
-            os: macos-13
+            os: macos-15-intel
             chez: main
           - machine: arm64osx
-            os: macos-14
+            os: macos-15
+            chez: released
+          - machine: arm64osx
+            os: macos-15
             chez: main
           - machine: i3le
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             chez: main
           - machine: a6le
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             chez: v9.6.4
           - machine: a6le
-            os: ubuntu-22.04
+            os: ubuntu-24.04
+            chez: released
+          - machine: a6le
+            os: ubuntu-24.04
             chez: main
-          - machine: ta6le
-            os: ubuntu-22.04
-            chez: main
-          - machine: i3nt
-            os: windows-2022
-            chez: v9.6.4
           - machine: a6nt
-            os: windows-2022
-            chez: v9.6.4
-          - machine: ta6nt
-            os: windows-2022
-            chez: v9.6.4
+            os: windows-2025
+            chez: released
           - machine: a6nt
-            os: windows-2022
-            chez: main
-          - machine: ta6nt
-            os: windows-2022
+            os: windows-2025
             chez: main
     runs-on: ${{ matrix.config.os }}
     defaults:
@@ -108,7 +102,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt-get install gcc-multilib lib32ncurses5-dev\
+          sudo apt-get install gcc-multilib libncurses-dev:i386 \
             libsystemd-dev:i386 libx11-dev:i386 uuid-dev:i386
       - name: Setup 64-bit Linux
         if: ${{ endsWith(matrix.config.machine, 'a6le') }}
@@ -143,28 +137,65 @@ jobs:
       - name: Fail if no cache
         if: ${{ steps.mats-restore-bootfiles.outputs.cache-hit != 'true' }}
         run: exit 1
-      - name: Build Chez Scheme ${{ matrix.config.chez }}
+      - name: Resolve Chez Scheme version
+        # We can't reference RELEASED within the matrix config,
+        # so resolve placeholders like "released" here.
+        id: resolve
+        run: |
+          V="${{ matrix.config.chez }}"
+          if [ "$V" = "released" ]; then
+            V="${RELEASED}"
+          fi
+          echo "chez=$V" >> "$GITHUB_OUTPUT"
+      - name: Build Chez Scheme v9.6.4
+        if: ${{ matrix.config.chez == 'v9.6.4' && matrix.config.machine == 'a6le' }}
         run: |
           M=${{ matrix.config.machine }}
           cd ChezScheme
-          git checkout -q -f ${{ matrix.config.chez }}
-          git reset --hard ${{ matrix.config.chez }}
-          if [ "${{ matrix.config.chez }}" = "main" ]; then
-            ./configure -m=$M --force
-            make bin/zuo
-            if [ "$RUNNER_OS" = "Windows" ]; then
-              cmd //c build.bat $M //force //as-is //MD  //kernel
-            else
-              cd $M
-              ../bin/zuo . kernel
-              cd ..
-            fi
+          git checkout -q -f v9.6.4
+          git reset --hard v9.6.4
+          ./configure -m=$M
+          cd $M/c
+          make
+          cd ../..
+          echo "$(realpath "$PWD/$M/bin/$M")" >> $GITHUB_PATH
+          echo "SCHEMEHEAPDIRS=$(realpath $PWD/$M/boot/$M)" >> $GITHUB_ENV
+          echo "done building in $PWD"
+      - name: Build Chez Scheme ${{ steps.resolve.version.chez }}
+        if: ${{ matrix.config.chez != 'v9.6.4' }}
+        run: |
+          M=${{ matrix.config.machine }}
+          cd ChezScheme
+          git checkout -q -f "${RELEASED}"
+          git reset --hard "${RELEASED}"
+          ./configure -m=$M --force
+          make bin/zuo
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            cmd //c build.bat $M //force //as-is //MD //kernel
           else
-            ./configure -m=$M
-            cd $M/c
-            make
-            cd ../..
+            ./bin/zuo $M kernel
           fi
+      - name: Build Chez Scheme ${{ steps.resolve.version.chez }}
+        if: ${{ matrix.config.chez == 'main' }}
+        run: |
+          M=${{ matrix.config.machine }}
+          cd ChezScheme
+          cp $M/boot/$M/*.boot $M/bin/$M
+          mv $M $M-released
+          git checkout -q -f main --
+          git reset --hard main
+          ./configure -m=$M --force --cross
+          make bin/zuo
+          ./bin/zuo $M boot --host-workarea $M-released
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            cmd //c build.bat $M //force //as-is //MD //kernel
+          else
+            ./bin/zuo $M kernel
+          fi
+      - name: Set SCHEMEHEAPDIRS
+        run: |
+          M=${{ matrix.config.machine }}
+          cd ChezScheme
           if [ "$RUNNER_OS" = "Windows" ]; then
             echo "$(cygpath -u "$PWD/$M/bin/$M")" >> $GITHUB_PATH
             echo "SCHEMEHEAPDIRS=$(cygpath -w "$PWD/$M/boot/$M")" >> $GITHUB_ENV
@@ -172,7 +203,6 @@ jobs:
             echo "$(realpath "$PWD/$M/bin/$M")" >> $GITHUB_PATH
             echo "SCHEMEHEAPDIRS=$(realpath $PWD/$M/boot/$M)" >> $GITHUB_ENV
           fi
-          echo "done building in $PWD"
       - name: Build Swish
         run: ./configure && make
       - name: Run tests
@@ -180,7 +210,7 @@ jobs:
       - name: Archive test results
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.config.machine }}-${{ matrix.config.os }}-${{ matrix.config.chez }}-test
+          name: ${{ matrix.config.machine }}-${{ matrix.config.os }}-${{ steps.resolve.outputs.chez }}-test
           path: |
             data/mat-report.html
             src/swish/*.mo
@@ -192,7 +222,7 @@ jobs:
       - name: Archive coverage results
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.config.machine }}-${{ matrix.config.os }}-${{ matrix.config.chez }}-coverage
+          name: ${{ matrix.config.machine }}-${{ matrix.config.os }}-${{ steps.resolve.outputs.chez }}-coverage
           path: |
             data/mat-report.html
             src/swish/*.mo
@@ -200,12 +230,12 @@ jobs:
         if: ${{ matrix.config.chez == 'main' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.config.machine }}-${{ matrix.config.os }}-${{ matrix.config.chez }}-coverage-report
+          name: ${{ matrix.config.machine }}-${{ matrix.config.os }}-${{ steps.resolve.outputs.chez }}-coverage-report
           path: |
             data/coverage.html
             data/src/**/*.html
       - name: Assemble tarball
-        if: ${{ matrix.config.chez != 'main' && !startsWith(matrix.config.machine, 't') }}
+        if: ${{ matrix.config.chez == 'released' }}
         # install only the binaries and replace absolute symlinks with relative symlinks
         run: |
           git fetch --tags
@@ -214,12 +244,12 @@ jobs:
             target="$(realpath "$f")"
             ln -vsf "../$(realpath --relative-to="${PWD}/build/swish" "${target}")" "$f"
           done
-          tar -cvf ${{ matrix.config.machine }}-${{ matrix.config.os }}-${{ matrix.config.chez }}-build.tar build/swish
+          tar -cvf ${{ matrix.config.machine }}-${{ matrix.config.os }}-${{ steps.resolve.outputs.chez }}-build.tar build/swish
       - name: Archive build artifacts
-        if: ${{ matrix.config.chez != 'main' && !startsWith(matrix.config.machine, 't') }}
+        if: ${{ matrix.config.chez == 'released' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.config.machine }}-${{ matrix.config.os }}-${{ matrix.config.chez }}-build.tar
-          path: ${{ matrix.config.machine }}-${{ matrix.config.os }}-${{ matrix.config.chez }}-build.tar
+          name: ${{ matrix.config.machine }}-${{ matrix.config.os }}-${{ steps.resolve.outputs.chez }}-build.tar
+          path: ${{ matrix.config.machine }}-${{ matrix.config.os }}-${{ steps.resolve.outputs.chez }}-build.tar
       - name: Check for failures
         run: if test -f failures; then cat failures; exit 1; fi

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ The latest design document can be found
 Swish uses [libuv](http://libuv.org) for cross-platform asynchronous
 I/O.
 
-Although Swish can be run in threaded Chez Scheme for convenience, it
-is not thread safe and should be used from the main thread only.
+Swish requires a non-threaded Chez Scheme runtime.
+Swish does not support threaded Chez Scheme builds.
 
 # Versioning
 

--- a/src/swish/dsm.ms
+++ b/src/swish/dsm.ms
@@ -250,3 +250,47 @@
     "|(F 0 2 (3) 9)"
     "|(F 0 3 () 11)"
     "|14"))
+
+(mat dsm-alias ()
+  (define-syntactic-monad M a b)
+  ;; alias should work
+  (alias P M)
+  #; ;; The following macro may work, but stock identifier-syntax will not work.
+  (define-syntax (P x)
+    (syntax-case x ()
+      [(k x ...) (with-implicit (k M) #'(M x ...))]))
+  (define-tuple <testf> f0 f1 call)
+  (define-syntax (build x)
+    (syntax-case x ()
+      [(_ A)
+       ;; resort to with-implicit for DRY test-helper macro
+       (with-implicit (A a b)
+         #'(let ()
+             (A define (f0 y) (list 'f0 a b y))
+             (<testf> make
+               [f0 f0]
+               [f1 (A lambda (z) `#(f1 ,a ,b ,z))]
+               [call (lambda (f a b d) (A f () d))]
+               )))]))
+  (match-let*
+   ([`(<testf> [f0 ,Mf0] [f1 ,Mf1] [call ,Mcall]) (build M)]
+    [`(<testf> [f0 ,Pf0] [f1 ,Pf1] [call ,Pcall]) (build P)]
+    [(f0 1 2 3) (Mcall Mf0 1 2 3)]
+    [(f0 2 3 4) (Mcall Pf0 2 3 4)]
+    [(f0 3 4 5) (Pcall Mf0 3 4 5)]
+    [(f0 4 5 6) (Pcall Pf0 4 5 6)]
+    [#(f1 1 2 3) (Mcall Mf1 1 2 3)]
+    [#(f1 2 3 4) (Mcall Pf1 2 3 4)]
+    [#(f1 3 4 5) (Pcall Mf1 3 4 5)]
+    [#(f1 4 5 6) (Pcall Pf1 4 5 6)]
+    [(a: (5 3 1) b: (6 4 2))
+     (let ([a '()] [b '()])
+       (M let lp1 () ([ls '(1 2 3 4 5 6)])
+         (match ls
+           [() `(a: ,a b: ,b)]
+           [(,h . ,t)
+            (guard (odd? h))
+            (P lp1 ([a (cons h a)]) t)]
+           [(,h . ,t)
+            (let ([b (cons h b)]) (M lp1 () t))])))])
+   'ok))

--- a/src/swish/erlang.ms
+++ b/src/swish/erlang.ms
@@ -1418,15 +1418,62 @@
      (equal? x (match x [,(exp <= (5 #f foo . ,_)) exp])))))
 
 (mat t14 ()
-  ;; Using identifier-syntax or a library rename, the tuple
-  ;; constructor should always create the original type.
+  ;; Tuple constructors, accessors, predicates, and copy operations
+  ;; should expect the symbolic type named in the original define-tuple
+  ;; form regardless of alias, identifier-syntax, or library renames.
+  #0=
+  (define-syntax exercise-variants
+    (syntax-rules ()
+      [(_ <t0> [<t1> robust?] ...)
+       (match-let*
+        ([,p0 (<t0> make [x 1] [y 2])]
+         [,x0 (<t0> x p0)]
+         [,y0 (<t0> y p0)]
+         [,getx0 (<t0> x)]
+         [,gety0 (<t0> y)]
+         [,is0? (<t0> is?)]
+         [#f (is0? '#(<t0>))]
+         [,swap0 (lambda (p) (<t0> copy* p [x y] [y x]))]
+         [,swapped (swap0 p0)]
+         [,zap0 (lambda (p) (<t0> copy p [x 0]))]
+         [,zapped (zap0 p0)])
+        (match-let*
+         ([,p1 (<t1> make [x 1] [y 2])]
+          [,@p0 p1]
+          [,@x0 (<t1> x p1)]
+          [,@y0 (<t1> y p1)]
+          [,@x0 (getx0 p1)]
+          [,@y0 (gety0 p1)]
+          [,getx1 (<t1> x)]
+          [,gety1 (<t1> y)]
+          [,@x0 (getx1 p0)]
+          [,@y0 (gety1 p0)]
+          [,is1? (<t1> is?)]
+          [#t (is0? p1)]
+          [#t (is1? p0)]
+          [#f (is1? '#(<t0>))]
+          [#f (is1? '#(<t1> x y))]
+          [,swap1 (lambda (p) (<t1> copy* p [x y] [y x]))]
+          [,@swapped (swap0 p1)]
+          [,@swapped (swap1 p0)]
+          [,zap1 (lambda (p) (<t1> copy p [x 0]))]
+          [,@zapped (zap0 p1)]
+          [,@zapped (zap1 p0)]
+          [`(<t0> [x ,@x0] [y ,@y0]) p1])
+         (meta-cond
+          [robust?
+           ;; At present, match cannot resolve the fields if <t1> expands to
+           ;; <t0>. That might change if we moved some match code into the <t0>
+           ;; macro transformer, but it could be difficult to generate good
+           ;; error messages.
+           (match-let* ([`(<t1> [x ,@x0] [y ,@y0]) p0])
+             'ok)]))
+        ...)]))
   (let ()
     (define-tuple <point> x y)
     (define-syntax <should-be-a-point> (identifier-syntax <point>))
-    (assert
-     (equal? (<point> make [x 1] [y 2])
-       (<should-be-a-point> make [x 1] [y 2]))))
-
+    (alias <also-a-point> <point>)
+    (exercise-variants <point> [<should-be-a-point> #f] [<also-a-point> #t]))
   (repl-test 0
     '(begin
        (library (A)
@@ -1439,11 +1486,11 @@
          (import (rename (A) (<point> <should-be-a-point>))))
 
        (let ()
-         (import (scheme) (A) (B))
-         (assert
-          (equal? (<point> make [x 1] [y 2])
-            (<should-be-a-point> make [x 1] [y 2])))
-         (exit 0)))))
+         (import (scheme) (swish erlang) (A) (B))
+         #0#
+         (match (try (exercise-variants <point> [<should-be-a-point> #t]))
+           [`(catch ,reason) (exit 1)]
+           [,_ (exit 0)])))))
 
 ;; single-clause match -> match-let*
 (mat t15 ()
@@ -2827,6 +2874,20 @@
                             (match-let* ([x x] [y not] [snoo z] [now now])
                               'ok)])))])
        inject))
+   ;; alias works, since we can resolve the property, but identifier-syntax wouldn't work
+   (let ()
+     (define-match-extension P0
+       (lambda (v pattern)
+         (syntax-case pattern ()
+           [(_quasi (p var . rest))
+            #`((bind var `(,#,v P0 p . rest)))])))
+     (alias P1 P0)
+     (match-let*
+      ([`(P0 z 1 4) 'one]
+       [(one P0 P0 1 4) z]
+       [`(P1 g 7 11) 'two]
+       [(two P0 P1 7 11) g])
+      'ok))
    ))
 
 (mat uuid ()

--- a/src/swish/erlang.ss
+++ b/src/swish/erlang.ss
@@ -1606,21 +1606,21 @@
                 (and (eq? (datum make) 'make)
                      (valid-bindings? #'bindings))
                 #`(vector 'name #,@(make-tuple #'(field ...) #'bindings))]
-               [(name copy e . bindings)
+               [(_name copy e . bindings)
                 (and (eq? (datum copy) 'copy)
                      (valid-bindings? #'bindings))
                 (handle-copy x #'e #'bindings 'copy)]
-               [(name copy* e . bindings)
+               [(_name copy* e . bindings)
                 (and (eq? (datum copy*) 'copy*)
                      (valid-bindings? #'bindings))
                 (handle-copy x #'e #'bindings 'copy*)]
-               [(name open expr prefix field-names)
+               [(_name open expr prefix field-names)
                 (and (eq? (datum open) 'open) (identifier? #'prefix))
                 (handle-open x #'expr #'prefix #'field-names)]
-               [(name open expr field-names)
+               [(_name open expr field-names)
                 (eq? (datum open) 'open)
                 (handle-open x #'expr #f #'field-names)]
-               [(name is? . args)
+               [(_name is? . args)
                 (eq? (datum is?) 'is?)
                 (let ([is?
                        #'(lambda (x)
@@ -1631,27 +1631,27 @@
                     [() is?]
                     [(e) #`(#,is? e)]
                     [else (syntax-case x ())]))]
-               [(name fn e)
+               [(_name fn e)
                 (syntax-datum-eq? #'fn #'field)
                 (with-syntax ([getter (replace-source x #'(name fn))])
                   #`(getter e))]
                ...
-               [(name fn)
+               [(_name fn)
                 (syntax-datum-eq? #'fn #'field)
                 #`(lambda (x)
                     (unless (name is? x)
                       (throw `#(bad-tuple name ,x ,#,(find-source x))))
                     (#3%vector-ref x #,(find-index #'fn #'(field ...) 1)))]
                ...
-               [(name no-check fn e)
+               [(_name no-check fn e)
                 (and (eq? (datum no-check) 'no-check)
                      (syntax-datum-eq? #'fn #'field))
                 #`(#3%vector-ref e #,(find-index #'fn #'(field ...) 1))]
                ...
-               [(name fn)
+               [(_name fn)
                 (identifier? #'fn)
                 (syntax-violation #f "unknown field" x #'fn)]
-               [(name fn expr)
+               [(_name fn expr)
                 (identifier? #'fn)
                 (syntax-violation #f "unknown field" x #'fn)]
                ))

--- a/src/swish/options.ms
+++ b/src/swish/options.ms
@@ -384,6 +384,19 @@
       [11 (foo y b)]
       )
      'ok))
+  ;; alias works
+  (let ()
+    (define-options foo
+      (required [x])
+      (optional [y (default 0)]))
+    (alias bar foo)
+    (alias <zap> <foo>)
+    (match-let*
+     ([,a (foo [x 11])]
+      [11 (bar x a)]
+      [0 (bar y a)]
+      [`(<zap> [x 11] [y 0]) a])
+     'ok))
   )
 
 (mat procedure/arity ()

--- a/src/swish/swish-test.ms
+++ b/src/swish/swish-test.ms
@@ -867,6 +867,13 @@
       (mat-data-results obj)))
   ;; case where all tests pass
   (zero-exit (swish-test "--progress none " all-pass) '())
+  ;; Tests like the following failed on ta6nt when we switched to the Github
+  ;; windows-2025 image. The tests pass on the corresponding non-threaded build,
+  ;; a6nt. Bob found that this test passed on ta6nt if we remove "--progress
+  ;; none", which suggests a bug on ta6nt when a spawned Swish OS process exits
+  ;; having written nothing to stdout (which is connected to a pipe). Since
+  ;; threaded builds like ta6nt are not supported, we removed them from our
+  ;; github test actions.
   (zero-exit (swish-test "--progress none --harvest " mo-all-pass) '())
   ;; case where some tests fail
   (nonzero-exit


### PR DESCRIPTION
**Fixes**

Fix the macro generated by define-tuple so that the `is?` predicate expects the original name despite the use of alias and library renaming, just as `make` was fixed in 32eea8d7c93784fdb6146aeed2960f7ac5b32f26.

**Proposed changes**

* Add regression tests for other exported macros that generate macros that could be susceptible to a similar bug.
* Update the Github test runners and test matrix:
   - remove 32-bit builds for all but i3le.
   - remove v9.6.4 builds for all but a6le; macos-15-intel could not build v9.6.4
   - remove builds that use the (unsupported) threaded Chez Scheme runtime

