### PR TITLE
Profiler enhancements

### DIFF
--- a/doc/swish/app.tex
+++ b/doc/swish/app.tex
@@ -371,7 +371,7 @@ the directory specified by \code{base-dir}.
 
 \defineentry{include-line}
 \begin{syntax}
-  \code{(include-line \var{filenme} \opt{\var{not-found}})}
+  \code{(include-line \var{filename} \opt{\var{not-found}})}
 \end{syntax}
 \returns{} see below
 

--- a/src/swish/profile.ss
+++ b/src/swish/profile.ss
@@ -47,7 +47,7 @@
    (swish string-utils)
    )
 
-  (define-state-tuple <profile-state> ht filename context waketime)
+  (define-state-tuple <profile-state> ht filename waketime)
 
   (define (profile:prepare)
     (library-extensions
@@ -107,7 +107,6 @@
       [(pem path range) #`(module () (add-profile-exclusion `#(at ,range ,path)))]))
 
   (define-tuple <profile-config> excluded-paths excluded-ranges source-directories)
-  (define-tuple <profile-data> context entries)
 
   (define profile-exclusions (make-hashtable string-hash string=?))
   (define source-dirs (make-hashtable string-hash string=?))
@@ -194,7 +193,6 @@
           (let ([x (fasl-read ip)])
             (unless (eof-object? x)
               (match x
-                [`(<profile-data> ,entries) (add! entries)]
                 [`(<profile-config> ,excluded-paths ,excluded-ranges ,source-directories)
                  (vector-for-each profile-exclude! excluded-paths excluded-ranges)
                  (vector-for-each add-source-dir! source-directories)]
@@ -223,26 +221,26 @@
                (cons (vector-ref keys i) (vector-ref vals i))
                ls))))))
 
-  (define (profile-save filename context sfd-table)
+  (define (profile-save filename sfd-table)
     (let ([op (open-binary-file-to-replace (make-directory-path filename))])
       (on-exit (close-port op)
         (fasl-write (current-profile-config) op)
         (let-values ([(keys vals) (hashtable-entries sfd-table)])
           (vector-for-each
            (lambda (sfd source-table)
-             (fasl-write (<profile-data> make [context context] [entries (source-table->list source-table)]) op))
+             (fasl-write (source-table->list source-table) op))
            keys vals))
         'ok)))
 
   (define (profile-update state)
-    (<profile-state> open state [context filename ht])
+    (<profile-state> open state [filename ht])
     (add-filedata ht
       (with-interrupts-disabled
        (let ([data (profile-dump)])
          (profile-clear)
          data)))
     (profile-release-counters)
-    (profile-save filename context ht))
+    (profile-save filename ht))
 
   (define (resolve path)
     (if (path-absolute? path)
@@ -278,7 +276,6 @@
              [state (<profile-state> make
                       [ht ht]
                       [filename filename]
-                      [context #f]
                       [waketime (next-waketime)])])
         (when input-fn (profile-load ht input-fn))
         `#(ok ,state ,($state waketime)))]))

--- a/src/swish/profile.ss
+++ b/src/swish/profile.ss
@@ -747,8 +747,6 @@
     (define (invalid-sfd? sfd)
       (cond
        [(eq-hashtable-ref okay sfd #f) #f]
-       [(path-absolute? (source-file-descriptor-path sfd))
-        "absolute path"]
        [else
         (let ([ip (open-source-file sfd)])
           (cond

--- a/src/swish/profile.ss
+++ b/src/swish/profile.ss
@@ -197,7 +197,20 @@
                 [`(<profile-data> ,entries) (add! entries)]
                 [`(<profile-config> ,excluded-paths ,excluded-ranges ,source-directories)
                  (vector-for-each profile-exclude! excluded-paths excluded-ranges)
-                 (vector-for-each add-source-dir! source-directories)])
+                 (vector-for-each add-source-dir! source-directories)]
+                [,_
+                 (guard
+                  (and (list? x)
+                       (andmap
+                        (lambda (p)
+                          (match p
+                            [(,so . ,count)
+                             (and (source-object? so)
+                                  (exact? count)
+                                  (nonnegative? count))]
+                            [,_ #f]))
+                        x)))
+                 (add! x)])
               (lp)))))))
 
   (define (source-table->list source-table)


### PR DESCRIPTION
- Enable profiler to load the output of `(profile-dump)`
- Allow profiler to ingest absolute paths
- Eliminate `<profile-data>`
- Fix documentation typo