### PR TITLE
add common-path-prefix to fix profile report bug

### DIFF
--- a/doc/swish/erlang.tex
+++ b/doc/swish/erlang.tex
@@ -1810,6 +1810,22 @@ fixnum between 0 and 65535 inclusive or a string, exception
 \code{\#(bad-arg connect-tcp \var{port-spec})} is raised.
 
 % ----------------------------------------------------------------------------
+\defineentry{common-path-prefix}
+\begin{procedure}
+  \code{(common-path-prefix \var{paths})}
+\end{procedure}
+\returns{} a string or \code{\#f}
+
+The \code{common-path-prefix} procedure finds the longest common directory
+prefix of a list of strings representing filesystem paths. It returns \code{\#f}
+if the list is empty or no common prefix exists. The result includes the
+trailing directory separator.
+The procedure compares paths case-sensitively, regardless of the case sensitivity of the native filesystem.
+On Windows, \code{/} and \code{\textbackslash} are
+treated as equivalent; the separator style in the result comes from the first
+path.
+
+% ----------------------------------------------------------------------------
 \defineentry{directory?}
 \begin{procedure}
   \code{(directory? \var{path})}

--- a/src/swish/io.ms
+++ b/src/swish/io.ms
@@ -25,6 +25,7 @@
  (swish erlang)
  (swish io)
  (swish mat)
+ (swish meta)
  (swish osi)
  (swish script-testing)
  (swish testing)
@@ -1487,5 +1488,102 @@
    (equal? (string-append /a/ /b/ /c) (path-combine "" /a/ /b/ /c))
    )
   )
+
+(isolate-mat common-path-prefix ()
+  (define / (string (directory-separator)))
+  (define (/p . args) (apply path-combine / args))
+  (define (/p/ . args) (string-append (apply /p args) /))
+  (match-let*
+   (;; empty list
+    [#f (common-path-prefix '())]
+    ;; single path at root
+    [,@/ (common-path-prefix (list (/p "foo")))]
+    ;; single path
+    [,/foo/ (/p/ "foo")]
+    [,@/foo/ (common-path-prefix (list /foo/))]
+    [,@/foo/ (common-path-prefix `(,(/p "foo" "bar.ss")))]
+    ;; only root in common
+    [,@/
+     (common-path-prefix
+      `(,(/p "foo" "one.ss")
+        ,(/p "bar" "two.ss")))]
+    ;; paths in same directory
+    [,/foo/bar/ (/p/ "foo" "bar")]
+    [,@/foo/bar/
+     (common-path-prefix
+      `(,(/p "foo" "bar" "one.ss")
+        ,(/p "foo" "bar" "two.ss")))]
+    ;; paths in sibling directories
+    [,@/foo/
+     (common-path-prefix
+      `(,(/p "foo" "bar" "one.ss")
+        ,(/p "foo" "baz" "two.ss")))]
+    ;; paths where common prefix is not at a directory boundary
+    [,/home/user/ (/p/ "home" "user")]
+    [,@/home/user/
+     (common-path-prefix
+      `(,(/p "home" "user" "project" "main.ss")
+        ,(/p "home" "user" "project-backup" "main.ss")))]
+    ;; more nested common prefix
+    [,/src/lib/erty/ (/p/ "src" "lib" "erty")]
+    [,@/src/lib/erty/
+     (common-path-prefix
+      `(,(/p "src" "lib" "erty" "io" "reader.ss")
+        ,(/p "src" "lib" "erty" "db" "query.ss")
+        ,(/p "src" "lib" "erty" "util.ss")))]
+    ;; relative paths
+    ["foo/" (common-path-prefix '("foo/bar" "foo/baz"))]
+    ;; mixed relative and absolute
+    [#f (common-path-prefix '("foo/bar" "/foo/bar"))]
+    [#f (common-path-prefix `("foo/bar" ,(/p "abc" "def")))]
+    ;; mixed separators (Windows treats / and \ as equivalent)
+    ;; the separator in the result comes from the first path
+    [,expected (and windows? "foo/")]
+    [,@expected (common-path-prefix '("foo/bar" "foo\\baz"))]
+    [,expected (and windows? "C:/")]
+    [,@expected (common-path-prefix '("C:/foo" "C:\\bar"))]
+    ;; edge cases
+    ;; empty string in list
+    [#f (common-path-prefix '("" "/foo/bar"))]
+    [#f (common-path-prefix '("/foo/bar" "/foo/ba" ""))]
+    ;; one path is root-only
+    [,@/ (common-path-prefix `(,(/p "foo") ,/))]
+    ;; no separator in paths
+    [#f (common-path-prefix '("foo.ss" "bar.ss"))]
+    [#f (common-path-prefix '("foo.ss"))]
+    ;; one path is prefix of another directory
+    [,@/ (common-path-prefix `(,(/p "foo") ,(/p "foo" "bar")))]
+    ;; just a single slash
+    [,@/ (common-path-prefix (list /))]
+    ;; dot and dotdot paths
+    ["./" (common-path-prefix '("./foo" "./bar"))]
+    ["../" (common-path-prefix '("../foo" "../bar"))]
+    ["../foo/" (common-path-prefix '("../foo/bar" "../foo/abc"))]
+    ;; multiple consecutive separators
+    [,expected (and (not windows?) "///")]
+    [,@expected (common-path-prefix '("///foo" "///bar"))]
+    ;; directory (trailing separator) vs file inside it
+    [,@/foo/ (common-path-prefix `(,(/p/ "foo") ,(/p "foo" "bar")))]
+    ;; identical directories
+    [,@/foo/bar/ (common-path-prefix `(,(/p/ "foo" "bar") ,(/p/ "foo" "bar")))]
+    ;; paths with spaces
+    [,/foo-bar/ (/p/ "foo bar")]
+    [,@/foo-bar/
+     (common-path-prefix
+      `(,(/p "foo bar" "one.ss")
+        ,(/p "foo bar" "two.ss")))]
+    ;; Windows UNC paths: need \\server\share\ minimum for valid prefix
+    ;; Same server, same share - valid common prefix
+    [,expected (and windows? "\\\\server\\share\\")]
+    [,@expected (common-path-prefix '("\\\\server\\share\\foo" "\\\\server\\share\\bar"))]
+    ;; Same server, different shares - no valid common prefix (\\server\ alone is not valid)
+    [#f (common-path-prefix '("\\\\server\\share" "\\\\server\\other"))]
+    ;; Different servers - no valid common prefix
+    [#f (common-path-prefix '("\\\\server\\share" "\\\\server2\\other"))]
+    ;; paths diverge at first char
+    [#f (common-path-prefix '("abc/def" "xyz/def"))]
+    ;; paths with common non-directory prefix
+    [#f (common-path-prefix '("foobar" "foobaz"))])
+   'ok))
 
 (hook-console-input)

--- a/src/swish/io.ss
+++ b/src/swish/io.ss
@@ -30,6 +30,7 @@
    close-osi-port
    close-path-watcher
    close-tcp-listener
+   common-path-prefix
    connect-tcp
    count-foreign-handles
    directory?
@@ -685,6 +686,50 @@
                (write-char (directory-separator) op))
              (display-string s op)
              (f more (ends-with-directory-separator? s))])))]))
+
+  (define (common-path-prefix paths)
+    (define (bogus-UNC? prefix/)
+      ;; Valid UNC directory prefix needs \\server\share\ (4+ separators).
+      (let ([len (string-length prefix/)])
+        (and (fx>= len 2)
+             (directory-separator? (string-ref prefix/ 0))
+             (directory-separator? (string-ref prefix/ 1))
+             (let loop ([i 2] [count 2])
+               (cond
+                [(fx>= count 4) #f]       ; found enough, not bogus
+                [(fx>= i len) #t]         ; ran out, bogus
+                [(directory-separator? (string-ref prefix/ i))
+                 (loop (fx+ i 1) (fx+ count 1))]
+                [else (loop (fx+ i 1) count)])))))
+    (define (sanitize prefix/)
+      (if (and windows? (bogus-UNC? prefix/))
+          #f
+          prefix/))
+    (define (directory-prefix s end)
+      (let loop ([i (fx- end 1)])
+        (cond
+         [(fx< i 0) #f]
+         [(directory-separator? (string-ref s i))
+          (sanitize (substring s 0 (fx+ i 1)))]
+         [else (loop (fx- i 1))])))
+    (define (char-match? a b)
+      (or (char=? a b)
+          (and windows? (directory-separator? a) (directory-separator? b))))
+    (match paths
+      [() #f]
+      [(,first-path . ,rest)
+       (define (common-prefix-upto s limit)
+         (let ([len (fxmin (string-length s) limit)])
+           (let scan ([i 0])
+             (if (or (fx= i len)
+                     (not (char-match? (string-ref first-path i) (string-ref s i))))
+                 i
+                 (scan (fx+ i 1))))))
+       (let loop ([rest rest] [prefix-len (string-length first-path)])
+         (match rest
+           [() (directory-prefix first-path prefix-len)]
+           [(,path . ,rest)
+            (loop rest (common-prefix-upto path prefix-len))]))]))
 
   (define make-directory
     (case-lambda

--- a/src/swish/profile.ss
+++ b/src/swish/profile.ss
@@ -369,25 +369,18 @@
     (let ([results (load-profiles)]
           [op (open-file-to-replace (make-directory-path output-fn))])
       (define common-prefix
-        (fold-left
-         (lambda (pfx entry)
-           (match entry
-             [(,source-path . #f) pfx] ;; file skipped
-             [(,source-path . ,_)      ;; absolute path if not skipped
-              (let ([dir (path-parent source-path)])
-                (let loop ([pfx (or pfx dir)])
-                  (if (starts-with? dir pfx)
-                      pfx
-                      (loop (path-parent pfx)))))]))
-         #f
-         results))
+        (common-path-prefix
+         (fold-left
+          (lambda (paths entry)
+            (match entry
+              [(,source-path . #f) paths] ;; file skipped
+              [(,source-path . ,_) (cons source-path paths)]))
+          '()
+          results)))
       (define strip-prefix
         (if (not common-prefix)
             values
-            (let* ([prefix-length (string-length common-prefix)]
-                   [n (if (ends-with? common-prefix (string (directory-separator)))
-                          prefix-length
-                          (+ prefix-length 1))])
+            (let ([n (string-length common-prefix)])
               (lambda (src)
                 (substring src n (string-length src))))))
       (fprintf op "<!DOCTYPE html>\n")


### PR DESCRIPTION
**Fixes**

When eliding common prefixes of file paths, the profile report can incorrectly treat `"/home/bob/project"` as a prefix of `"/home/bob/project-backup"` (string prefix does not imply valid path prefix).

**Proposed changes**

* Add `common-path-prefix` to `(swish io)` that operates as if on path components, but without the extra allocation of `path-parent`, et al.
* Use `common-path-prefix` when generating a profile report.