### PR TITLE
Check ,key in json:extend-object

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,9 @@ jobs:
         id: build-clone-main
         run: |
           git clone --filter=blob:none --branch main https://github.com/cisco/ChezScheme.git
-          echo "HASH_KEY=v3_$(cat ChezScheme/.git/refs/heads/main)" >> "${GITHUB_OUTPUT}"
+          MAIN_HASH="$(git -C ChezScheme rev-parse main^{commit})"
+          RELEASED_HASH="$(git -C ChezScheme rev-parse "${RELEASED}^{commit}")"
+          echo "HASH_KEY=v4_${RELEASED_HASH}_${MAIN_HASH}" >> "${GITHUB_OUTPUT}"
       - name: Establish Chez Scheme .git / boot file cache
         id: build-restore-bootfiles
         uses: actions/cache@v5
@@ -142,7 +144,7 @@ jobs:
             V="${RELEASED}"
           fi
           echo "chez=$V" >> "$GITHUB_OUTPUT"
-      - name: Build Chez Scheme ${{ steps.resolve.version.chez }}
+      - name: Build Chez Scheme ${{ env.RELEASED }}
         run: |
           M=${{ matrix.config.machine }}
           cd ChezScheme
@@ -155,7 +157,7 @@ jobs:
           else
             ./bin/zuo $M kernel
           fi
-      - name: Build Chez Scheme ${{ steps.resolve.version.chez }}
+      - name: Build Chez Scheme 'main'
         if: ${{ matrix.config.chez == 'main' }}
         run: |
           M=${{ matrix.config.machine }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@
 name: Test
 on: [push]
 env:
-  RELEASED: v10.3.0
+  RELEASED: v10.4.1
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/src/run-mats
+++ b/src/run-mats
@@ -22,22 +22,22 @@ esac
 
 LIBSEP="::"
 DIR="${PWD}"
-GITTOP="$(git rev-parse --show-toplevel)"
 case "$(uname -s)" in
   CYGWIN_NT-*)
     LIBSEP=";;"
     ;;
   MINGW64_NT-* | MSYS_NT-*)
     LIBSEP=";;"
-    GITTOP="$(cygpath -u "$GITTOP")"
     ;;
   *)
     DIR="$(realpath "${DIR}")"
     ;;
 esac
-if [ "$DIR" != "$GITTOP" ]; then
-  echo "${this} expected to be run from the repository root"
-  fail
+
+PREFIX="$(git rev-parse --show-prefix 2>/dev/null)" || fail
+if [ -n "$PREFIX" ]; then
+    echo "${this} expected to be run from the repository root"
+    fail
 fi
 
 if [ ! -d "${LIBDIR}" ]; then

--- a/src/swish/app.ms
+++ b/src/swish/app.ms
@@ -517,23 +517,23 @@
             (app:start)
             (printf "started\n")
             (flush-output-port)
-            (receive (after 1000) (exit 3)))
+            (test:receive (after 1000) (exit 3)))
          to-stdin)
         (flush-output-port to-stdin)
         (match-let*
          (["started"
-           (receive (after 1500 'bad-start)
+           (test:receive (after 1500 'bad-start)
              [(,@from-stdout . ,msg) msg])]
           [,! (osi_kill os-pid signum)]
           [,expected-exit-code 0]
           [,expected-signal 0]
           [ok
-           (receive (after 1500 'fail)
+           (test:receive (after 1500 'fail)
              [#(process-terminated ,@os-pid ,@expected-exit-code ,@expected-signal)
               'ok])])
          (match (match-regexps '()
                   (let f ()
-                    (receive (after 0 '())
+                    (test:receive (after 0 '())
                       [(,@from-stderr . ,msg) (cons msg (f))])))
            [() 'no-extraneous-output])
          'ok)))

--- a/src/swish/errors.ss
+++ b/src/swish/errors.ss
@@ -88,6 +88,7 @@
            context
            (and (not eof?) what)))]
       [#(json:invalid-datum ,what) (format "Invalid datum while writing JSON: ~s." what)]
+      [#(json:invalid-key ,what ,src) (format "Invalid key~a: ~s" (src->english src) what)]
       [#(listen-tcp-failed ,address ,port-number ,who ,errno) (format "Error ~d from ~a when listening on TCP port ~d: ~a." errno who port-number (errno->english errno))]
       [#(name-already-registered ,pid) (format "Name is already registered to ~s." pid)]
       [#(osi-error ,name ,who ,errno) (format "Error ~d from ~a during ~a: ~a." errno who name (errno->english errno))]

--- a/src/swish/json.ms
+++ b/src/swish/json.ms
@@ -1057,7 +1057,13 @@
   (assert-syntax-error (json:make-object ["str" 123]) "invalid key \"str\" in" match-form)
   (assert-syntax-error (json:extend-object x ["str" 123]) "invalid key \"str\" in" match-form)
   (match-let*
-   ([#(EXIT #(bad-arg json:write -1))
+   ([#(EXIT #(json:invalid-key "x" ,_))
+     (catch (json:make-object [,"x" 123]))]
+    [#(EXIT #(json:invalid-key "y" ,_))
+     (catch (json:extend-object (json:make-object) [,"y" 123]))]
+    ["Invalid key at offset 123 of bug.ss: \"B-flat\""
+     (exit-reason->english `#(json:invalid-key "B-flat" #(at 123 "bug.ss")))]
+    [#(EXIT #(bad-arg json:write -1))
      (catch (json:write (open-output-string) 12 -1))]
     [,ip (open-input-string "wrong")]
     [#(EXIT #(bad-arg json:write ,@ip))

--- a/src/swish/json.ss
+++ b/src/swish/json.ss
@@ -95,10 +95,15 @@
          ...
          ht)]))
 
+  (define (ensure-key x src)
+    (unless (symbol? x)
+      (throw `#(json:invalid-key ,x ,src)))
+    x)
+
   (define-syntax (parse-key x)
     (syntax-case x (unquote)
       [(_ id form) (identifier? #'id) #'(quote id)]
-      [(_ (unquote e) form) #'e]
+      [(_ (unquote e) form) #`(ensure-key e #,(find-source #'form))]
       [(_ key form) (syntax-error #'form (format "invalid key ~s in" (datum key)))]))
 
   (define (verify-json-object who x)

--- a/src/swish/swish-build.ms
+++ b/src/swish/swish-build.ms
@@ -205,11 +205,11 @@
   ;; run fat app via PATH search, not via relative or absolute path
   (test-os-process (fix-exe "bash") '()
     (string-append
-     "PATH=\"${PWD}/data/tmp/mat-output/:${PATH}\"\n"
+     (format "PATH=\"~a:${PATH}\"\n" (output-dir))
      "type -a fat1\n"
      "fat1\n"
      "exit\n")
-    '("^fat1 is .*/data/tmp/mat-output/fat1.*"
+    '("^fat1 is .*[\\\\/]data[\\\\/]tmp[\\\\/]mat-output[\\\\/]fat1.*"
       "^Hello, World!"))
   )
 

--- a/src/vs32.bat
+++ b/src/vs32.bat
@@ -4,6 +4,22 @@ if not "%Applications%" == "" goto win64
 set Applications=%ProgramFiles%
 :win64
 
+:: Visual Studio 2026 Enterprise
+set BATDIR=%ProgramW6432%\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build
+if exist "%BATDIR%\vcvarsall.bat" goto found
+
+:: Visual Studio 2026 Professional
+set BATDIR=%ProgramW6432%\Microsoft Visual Studio\18\Professional\VC\Auxiliary\Build
+if exist "%BATDIR%\vcvarsall.bat" goto found
+
+:: Visual Studio 2026 Community
+set BATDIR=%ProgramW6432%\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build
+if exist "%BATDIR%\vcvarsall.bat" goto found
+
+:: Visual Studio 2026 BuildTools
+set BATDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\18\BuildTools\VC\Auxiliary\Build
+if exist "%BATDIR%\vcvarsall.bat" goto found
+
 :: Visual Studio 2022 Enterprise
 set BATDIR=%ProgramW6432%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build
 if exist "%BATDIR%\vcvarsall.bat" goto found
@@ -48,7 +64,7 @@ if exist "%BATDIR%\vcvarsall.bat" goto found
 set BATDIR=%Applications%\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build
 if exist "%BATDIR%\vcvarsall.bat" goto found
 
-echo Visual Studio 2019 or 2017 must be installed.
+echo Visual Studio 2026, 2022, 2019 or 2017 must be installed.
 exit 1
 
 :found

--- a/src/vs64.bat
+++ b/src/vs64.bat
@@ -1,5 +1,21 @@
 @echo off
 
+:: Visual Studio 2026 Enterprise
+set BATDIR=%ProgramW6432%\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build
+if exist "%BATDIR%\vcvarsall.bat" goto found
+
+:: Visual Studio 2026 Professional
+set BATDIR=%ProgramW6432%\Microsoft Visual Studio\18\Professional\VC\Auxiliary\Build
+if exist "%BATDIR%\vcvarsall.bat" goto found
+
+:: Visual Studio 2026 Community
+set BATDIR=%ProgramW6432%\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build
+if exist "%BATDIR%\vcvarsall.bat" goto found
+
+:: Visual Studio 2026 BuildTools
+set BATDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\18\BuildTools\VC\Auxiliary\Build
+if exist "%BATDIR%\vcvarsall.bat" goto found
+
 :: Visual Studio 2022 Enterprise
 set BATDIR=%ProgramW6432%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build
 if exist "%BATDIR%\vcvarsall.bat" goto found
@@ -44,7 +60,7 @@ if exist "%BATDIR%\vcvarsall.bat" goto found
 set BATDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build
 if exist "%BATDIR%\vcvarsall.bat" goto found
 
-echo Visual Studio 2022, 2019, or 2017 must be installed.
+echo Visual Studio 2026, 2022, 2019, or 2017 must be installed.
 exit 1
 
 :found


### PR DESCRIPTION
This fixes an issue Chris discovered where `(json:make-object [,"foo" 3])` failed to detect that `"foo"` did not evaluate to a symbol.

The attempt at fixing Windows builds is guesswork. Early CI failures were at the point where we try to build Chez Scheme itself; updating the CI build to use the latest release helped, and we needed to make a few tweaks to adapt to changes in the Windows runner and provide yet more timing flexibility for the overloaded macOS runner.
